### PR TITLE
[closes #31] Change MAXOPBLOCKS and NBUF to i32, and remove libc::c_int in uart.rs

### DIFF
--- a/kernel-rs/src/param.rs
+++ b/kernel-rs/src/param.rs
@@ -1,4 +1,3 @@
-use crate::libc;
 /// maximum number of processes
 pub const NPROC: i32 = 64;
 /// open files per process
@@ -15,10 +14,10 @@ pub const ROOTDEV: i32 = 1;
 pub const MAXARG: i32 = 32;
 /// max # of blocks any FS op writes
 /// Will be handled in #31
-pub const MAXOPBLOCKS: libc::c_int = 10 as libc::c_int;
+pub const MAXOPBLOCKS: i32 = 10;
 /// max data blocks in on-disk log
 pub const LOGSIZE: i32 = MAXOPBLOCKS * 3;
 /// size of disk block cache
-pub const NBUF: libc::c_int = MAXOPBLOCKS * 3 as libc::c_int;
+pub const NBUF: i32 = MAXOPBLOCKS * 3;
 /// maximum file path name
 pub const MAXPATH: i32 = 128;

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -1,5 +1,4 @@
 use crate::console::consoleintr;
-use crate::libc;
 use crate::memlayout::UART0;
 use core::ptr;
 /// low-level driver routines for 16550a UART.
@@ -21,20 +20,20 @@ use core::ptr;
 #[no_mangle]
 pub unsafe extern "C" fn uartinit() {
     // disable interrupts.
-    ptr::write_volatile((UART0 + 1 as i64) as *mut u8, 0 as libc::c_int as u8);
+    ptr::write_volatile((UART0 + 1 as i64) as *mut u8, 0);
     // special mode to set baud rate.
-    ptr::write_volatile((UART0 + 3 as i64) as *mut u8, 0x80 as libc::c_int as u8);
+    ptr::write_volatile((UART0 + 3 as i64) as *mut u8, 0x80);
     // LSB for baud rate of 38.4K.
-    ptr::write_volatile((UART0 + 0 as i64) as *mut u8, 0x3 as libc::c_int as u8);
+    ptr::write_volatile((UART0 + 0 as i64) as *mut u8, 0x3);
     // MSB for baud rate of 38.4K.
-    ptr::write_volatile((UART0 + 1 as i64) as *mut u8, 0 as libc::c_int as u8);
+    ptr::write_volatile((UART0 + 1 as i64) as *mut u8, 0);
     // leave set-baud mode,
     // and set word length to 8 bits, no parity.
-    ptr::write_volatile((UART0 + 3 as i64) as *mut u8, 0x3 as libc::c_int as u8);
+    ptr::write_volatile((UART0 + 3 as i64) as *mut u8, 0x3);
     // reset and enable FIFOs.
-    ptr::write_volatile((UART0 + 2 as i64) as *mut u8, 0x7 as libc::c_int as u8);
+    ptr::write_volatile((UART0 + 2 as i64) as *mut u8, 0x7);
     // enable receive interrupts.
-    ptr::write_volatile((UART0 + 1 as i64) as *mut u8, 0x1 as libc::c_int as u8);
+    ptr::write_volatile((UART0 + 1 as i64) as *mut u8, 0x1);
 }
 /// write one output character to the UART.
 #[no_mangle]


### PR DESCRIPTION
- cargo fmt
- all usertests passed
- `libc::c_int` 삭제하기
  - #31 에서 논의된 대로 `param.rs`의 `MAXOPBLOCKS, NBUF`를 `i32`로 변경
  - 아래의 예시와 같이 `uart.rs`의 `typecast to libc::c_int`를 삭제
```
ptr::write_volatile((UART0 + 1 as i64) as *mut u8, 0 as libc::c_int as u8); (수정 이전)
```
```
ptr::write_volatile((UART0 + 1 as i64) as *mut u8, 0); (수정 이후)
```
- 이제 남은 `libc::*`는 `libc::c_void`, `libc::c_char`, `libc::c_uint`이며, `libc::c_uint`는 #25 의 subissue 2를 해결하면 모두 없어질 것 같습니다.
 