### PR TITLE
[closes #25] Change C2RustUnnamed of type to u32

### DIFF
--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -16,7 +16,7 @@ pub const CONSOLE: isize = 1;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct File {
-    pub typ: C2RustUnnamed,
+    pub typ: u32,
     pub ref_0: i32,
     pub readable: libc::c_char,
     pub writable: libc::c_char,
@@ -42,11 +42,10 @@ pub struct inode {
     pub size: u32,
     pub addrs: [u32; 13],
 }
-pub type C2RustUnnamed = libc::c_uint;
-pub const FD_DEVICE: C2RustUnnamed = 3;
-pub const FD_INODE: C2RustUnnamed = 2;
-pub const FD_PIPE: C2RustUnnamed = 1;
-pub const FD_NONE: C2RustUnnamed = 0;
+pub const FD_DEVICE: u32 = 3;
+pub const FD_INODE: u32 = 2;
+pub const FD_PIPE: u32 = 1;
+pub const FD_NONE: u32 = 0;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Ftable {

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -13,11 +13,10 @@ use crate::{
     string::{strncmp, strncpy},
 };
 use core::ptr;
-pub type C2RustUnnamed = libc::c_uint;
-pub const FD_DEVICE: C2RustUnnamed = 3;
-pub const FD_INODE: C2RustUnnamed = 2;
-pub const FD_PIPE: C2RustUnnamed = 1;
-pub const FD_NONE: C2RustUnnamed = 0;
+pub const FD_DEVICE: u32 = 3;
+pub const FD_INODE: u32 = 2;
+pub const FD_PIPE: u32 = 1;
+pub const FD_NONE: u32 = 0;
 
 /// block size
 /// Disk layout:

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -21,11 +21,10 @@ use crate::{
     vm::copyout,
 };
 use core::ptr;
-pub type C2RustUnnamed = libc::c_uint;
-pub const FD_DEVICE: C2RustUnnamed = 3;
-pub const FD_INODE: C2RustUnnamed = 2;
-pub const FD_PIPE: C2RustUnnamed = 1;
-pub const FD_NONE: C2RustUnnamed = 0;
+pub const FD_DEVICE: u32 = 3;
+pub const FD_INODE: u32 = 2;
+pub const FD_PIPE: u32 = 1;
+pub const FD_NONE: u32 = 0;
 
 /// File-system system calls.
 /// Mostly argument checking, since we don't trust


### PR DESCRIPTION
- Closes #25 
- cargo fmt
- all usertests passed
- #25 의 아래 [코멘트](https://github.com/kaist-cp/rv6/issues/25#issuecomment-664814171)대로 `C2RustUnnamed`를 `u32`로 수정
  - 이제 `libc::*`는 `libc::c_char`와 `libc::c_void` 밖에 없습니다.
> 코드를 살펴보니 해당 Issue는 struct와 type의 두 종류가 있습니다.
> 
> 1. struct의 경우 앞서  시원님이 말씀하셨던 bio.rs가 예시입니다. ([#25 (comment)](https://github.com/kaist-cp/rv6/issues/25#issue-665929899))
>    어떤 변수를 정의하기 위해서 사용되는 struct이기 때문에 변수명의 첫글자를 대문자로 변경해서 struct 이름을 지정하면 좋을 것 같습니다.
>    (예를 들어 위 예시에서는 `bcache`를 정의하기 위한 struct이므로 `C2RustUnnamed` -> `Bcache`)
> 2. type의 경우 아래와 같은 예시입니다.
>    https://github.com/kaist-cp/rv6/blob/6ae222d8f5d648d85eeb16a7c4efae6898eea993/kernel-rs/src/fs.rs#L29-L33
>    
>    이 부분은 type수정이 모두 완료된 이후에 진행하거나 `C2RustUnnamed`정의를 지우고 `u32`로 수정하여 적용하면 될 것 같습니다.

