### PR TITLE
Revert "Revert "[closes #48] booting error in riscv.rs when useing pub const fn""

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -7,7 +7,7 @@ use crate::{
     param::MAXARG,
     printf::panic,
     proc::{myproc, proc_0, proc_freepagetable, proc_pagetable},
-    riscv::{pagetable_t, PGSIZE},
+    riscv::{pagetable_t, pgroundup, PGSIZE},
     string::{safestrcpy, strlen},
     vm::{copyout, uvmalloc, uvmclear, walkaddr},
 };
@@ -135,8 +135,7 @@ pub unsafe fn exec(mut path: *mut libc::c_char, mut argv: *mut *mut libc::c_char
                     oldsz = (*p).sz;
                     // Allocate two pages at the next page boundary.
                     // Use the second as the user stack.
-                    sz = sz.wrapping_add(PGSIZE as u64).wrapping_sub(1 as i32 as u64)
-                        & !(PGSIZE - 1 as i32) as u64;
+                    sz = pgroundup(sz);
                     sz = uvmalloc(pagetable, sz, sz.wrapping_add((2 as i32 * PGSIZE) as u64));
                     if sz != 0 as i32 as u64 {
                         uvmclear(pagetable, sz.wrapping_sub((2 as i32 * PGSIZE) as u64));

--- a/kernel-rs/src/kalloc.rs
+++ b/kernel-rs/src/kalloc.rs
@@ -2,7 +2,7 @@ use crate::libc;
 use crate::{
     memlayout::PHYSTOP,
     printf::{panic, printf},
-    riscv::PGSIZE,
+    riscv::{pgroundup, PGSIZE},
     spinlock::{acquire, initlock, release, Spinlock},
 };
 use core::ptr;
@@ -47,10 +47,7 @@ pub unsafe fn kinit() {
 /// and pipe buffers. Allocates whole 4096-byte pages.
 pub unsafe fn freerange(mut pa_start: *mut libc::c_void, mut pa_end: *mut libc::c_void) {
     let mut p: *mut libc::c_char = ptr::null_mut();
-    p = ((pa_start as u64)
-        .wrapping_add(PGSIZE as u64)
-        .wrapping_sub(1 as i32 as u64)
-        & !(PGSIZE - 1 as i32) as u64) as *mut libc::c_char;
+    p = pgroundup(pa_start as u64) as *mut libc::c_char;
     while p.offset(PGSIZE as isize) <= pa_end as *mut libc::c_char {
         kfree(p as *mut libc::c_void);
         p = p.offset(PGSIZE as isize)

--- a/kernel-rs/src/riscv.rs
+++ b/kernel-rs/src/riscv.rs
@@ -274,11 +274,6 @@ pub const fn pgroundup(sz: u64) -> u64 {
 pub const fn pgrounddown(a: u64) -> u64 {
     a & !(PGSIZE - 1 as i32) as u64
 }
-/*
-TODO: used directly in oter function e.g., uvmalloc in vm.rs
-#define PGROUNDUP(sz)  (((sz)+PGSIZE-1) & ~(PGSIZE-1))
-#define PGROUNDDOWN(a) (((a)) & ~(PGSIZE-1))
-*/
 /// valid
 pub const PTE_V: i64 = (1 as i64) << 0 as i32;
 pub const PTE_R: i64 = (1 as i64) << 1 as i32;
@@ -296,15 +291,6 @@ pub const fn pte2pa(pte: pte_t) -> u64 {
 pub const fn pte_flags(pte: pte_t) -> u64 {
     pte & 0x3ff as i32 as u64
 }
-/*
-TODO: used directly in other file e.g., vm.rs
-
-#define PA2PTE(pa) ((((u64)pa) >> 12) << 10)
-
-#define PTE2PA(pte) (((pte) >> 10) << 12)
-
-#define PTE_FLAGS(pte) ((pte) & 0x3FF)
-*/
 /// extract the three 9-bit page table indices from a virtual address.
 /// 9 bits
 pub const PXMASK: i32 = 0x1ff as i32;
@@ -313,15 +299,9 @@ fn pxshift(level: i32) -> i32 {
     PGSHIFT + 9 * level
 }
 
-pub fn px(level: i32, va: u64) -> u64 {
-    (va >> pxshift(level) as u64) & PXMASK as u64
+pub fn px(level: i32, va: u64) -> isize {
+    ((va >> pxshift(level) as u64) & PXMASK as u64) as isize
 }
-/*
-TODO: unused
-#define PXSHIFT(level)  (PGSHIFT+(9*(level)))
-TODO: used directly in vm.rs
-#define PX(level, va) ((((u64) (va)) >> PXSHIFT(level)) & PXMASK)
-*/
 
 /// one beyond the highest possible virtual address.
 /// MAXVA is actually one bit less than the max allowed by


### PR DESCRIPTION
Reverts kaist-cp/rv6#61

- #60 을 저희가 리뷰하고 머지하면 #54 #57 #58 은 revert가 필요가 없어서 revert를 취소하기 위한 PR을 드립니다.