### PR TITLE
[#50 - bio.rs, buf.rs, console.rs, elf.rs] Remove pub type and refactoring struct

### DIFF
--- a/kernel-rs/src/buf.rs
+++ b/kernel-rs/src/buf.rs
@@ -16,6 +16,6 @@ pub struct Buf {
     pub next: *mut Buf,
 
     /// disk queue
-    pub qnext: *mut Buf,
+    qnext: *mut Buf,
     pub data: [u8; 1024],
 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -8,18 +8,18 @@ use crate::{
 };
 
 #[derive(Copy, Clone)]
-pub struct Console {
-    pub lock: Spinlock,
-    pub buf: [libc::c_char; 128],
+struct Console {
+    lock: Spinlock,
+    buf: [libc::c_char; 128],
 
     /// Read index
-    pub r: u32,
+    r: u32,
 
     /// Write index
-    pub w: u32,
+    w: u32,
 
     /// Edit index
-    pub e: u32,
+    e: u32,
 }
 
 impl Console {
@@ -43,7 +43,7 @@ impl Console {
 ///   control-u -- kill line
 ///   control-d -- end of file
 ///   control-p -- print process list
-pub const BACKSPACE: i32 = 0x100;
+const BACKSPACE: i32 = 0x100;
 
 /// Control-x
 const fn ctrl(x: char) -> i32 {
@@ -66,12 +66,12 @@ pub unsafe fn consputc(mut c: i32) {
 }
 
 /// input
-pub const INPUT_BUF: usize = 128;
+const INPUT_BUF: usize = 128;
 
-pub static mut cons: Console = Console::zeroed();
+static mut cons: Console = Console::zeroed();
 
 /// user write()s to the console go here.
-pub unsafe fn consolewrite(mut user_src: i32, mut src: u64, mut n: i32) -> i32 {
+unsafe fn consolewrite(mut user_src: i32, mut src: u64, mut n: i32) -> i32 {
     cons.lock.acquire();
     for i in 0..n {
         let mut c: libc::c_char = 0;
@@ -94,7 +94,7 @@ pub unsafe fn consolewrite(mut user_src: i32, mut src: u64, mut n: i32) -> i32 {
 /// copy (up to) a whole input line to dst.
 /// user_dist indicates whether dst is a user
 /// or kernel address.
-pub unsafe fn consoleread(mut user_dst: i32, mut dst: u64, mut n: i32) -> i32 {
+unsafe fn consoleread(mut user_dst: i32, mut dst: u64, mut n: i32) -> i32 {
     let mut target: u32 = n as u32;
     cons.lock.acquire();
     while n > 0 as i32 {

--- a/kernel-rs/src/elf.rs
+++ b/kernel-rs/src/elf.rs
@@ -11,20 +11,20 @@ pub const ELF_MAGIC: u32 = 0x464c457f;
 #[repr(C)]
 pub struct ElfHdr {
     pub magic: u32,
-    pub elf: [u8; 12],
-    pub typ: u16,
-    pub machine: u16,
-    pub version: u32,
+    elf: [u8; 12],
+    typ: u16,
+    machine: u16,
+    version: u32,
     pub entry: u64,
     pub phoff: u64,
-    pub shoff: u64,
-    pub flags: u32,
-    pub ehsize: u16,
-    pub phentsize: u16,
+    shoff: u64,
+    flags: u32,
+    ehsize: u16,
+    phentsize: u16,
     pub phnum: u16,
-    pub shentsize: u16,
-    pub shnum: u16,
-    pub shstrndx: u16,
+    shentsize: u16,
+    shnum: u16,
+    shstrndx: u16,
 }
 
 /// Program section header
@@ -35,13 +35,13 @@ pub struct ElfHdr {
 #[repr(C)]
 pub struct ProgHdr {
     pub typ: u32,
-    pub flags: u32,
+    flags: u32,
     pub off: u64,
     pub vaddr: u64,
-    pub paddr: u64,
+    paddr: u64,
     pub filesz: u64,
     pub memsz: u64,
-    pub align: u64,
+    align: u64,
 }
 
 /// Values for Proghdr type

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -11,7 +11,7 @@
 
 use crate::libc;
 use crate::{
-    bio::{bread, brelse},
+    bio::bread,
     buf::Buf,
     file::Inode,
     log::{initlog, log_write},
@@ -193,7 +193,7 @@ impl Inode {
             ::core::mem::size_of::<[u32; 13]>(),
         );
         log_write(bp);
-        brelse(bp);
+        (*bp).release();
     }
 
     /// Increment reference count for ip.
@@ -270,7 +270,7 @@ unsafe fn readsb(mut dev: i32, mut sb_0: *mut Superblock) {
         sb_0 as *mut libc::c_void,
         ::core::mem::size_of::<Superblock>(),
     );
-    brelse(bp);
+    (*bp).release();
 }
 
 /// Init fs
@@ -288,7 +288,7 @@ unsafe fn bzero(mut dev: i32, mut bno: i32) {
     bp = bread(dev as u32, bno as u32);
     ptr::write_bytes((*bp).data.as_mut_ptr(), 0, BSIZE as usize);
     log_write(bp);
-    brelse(bp);
+    (*bp).release();
 }
 
 /// Blocks.
@@ -307,13 +307,13 @@ unsafe fn balloc(mut dev: u32) -> u32 {
                 (*bp).data[(bi / 8 as i32) as usize] =
                     ((*bp).data[(bi / 8 as i32) as usize] as i32 | m) as u8; // Mark block in use.
                 log_write(bp);
-                brelse(bp);
+                (*bp).release();
                 bzero(dev as i32, b + bi);
                 return (b + bi) as u32;
             }
             bi += 1
         }
-        brelse(bp);
+        (*bp).release();
         b += BPB
     }
     panic(b"balloc: out of blocks\x00" as *const u8 as *const libc::c_char as *mut libc::c_char);
@@ -332,7 +332,7 @@ unsafe fn bfree(mut dev: i32, mut b: u32) {
     }
     (*bp).data[(bi / 8 as i32) as usize] = ((*bp).data[(bi / 8 as i32) as usize] as i32 & !m) as u8;
     log_write(bp);
-    brelse(bp);
+    (*bp).release();
 }
 
 pub static mut icache: Icache = Icache::zeroed();
@@ -363,10 +363,10 @@ pub unsafe fn ialloc(mut dev: u32, mut typ: i16) -> *mut Inode {
 
             // mark it allocated on the disk
             log_write(bp);
-            brelse(bp);
+            (*bp).release();
             return iget(dev, inum as u32);
         }
-        brelse(bp);
+        (*bp).release();
     }
     panic(b"ialloc: no inodes\x00" as *const u8 as *const libc::c_char as *mut libc::c_char);
 }
@@ -432,7 +432,7 @@ pub unsafe fn ilock(mut ip: *mut Inode) {
             (*ip).addrs.as_mut_ptr() as *mut libc::c_void,
             ::core::mem::size_of::<[u32; 13]>(),
         );
-        brelse(bp);
+        (*bp).release();
         (*ip).valid = 1 as i32;
         if (*ip).typ as i32 == 0 as i32 {
             panic(b"ilock: no type\x00" as *const u8 as *const libc::c_char as *mut libc::c_char);
@@ -517,7 +517,7 @@ unsafe fn bmap(mut ip: *mut Inode, mut bn: u32) -> u32 {
             *a.offset(bn as isize) = addr;
             log_write(bp);
         }
-        brelse(bp);
+        (*bp).release();
         return addr;
     }
     panic(b"bmap: out of range\x00" as *const u8 as *const libc::c_char as *mut libc::c_char);
@@ -553,7 +553,7 @@ unsafe fn itrunc(mut ip: *mut Inode) {
                 bfree((*ip).dev as i32, *a.offset(j as isize));
             }
         }
-        brelse(bp);
+        (*bp).release();
         bfree((*ip).dev as i32, (*ip).addrs[NDIRECT as usize]);
         (*ip).addrs[NDIRECT as usize] = 0 as i32 as u32
     }
@@ -606,10 +606,10 @@ pub unsafe fn readi(
             m as u64,
         ) == -(1 as i32)
         {
-            brelse(bp);
+            (*bp).release();
             break;
         } else {
-            brelse(bp);
+            (*bp).release();
             tot = (tot as u32).wrapping_add(m) as u32 as u32;
             off = (off as u32).wrapping_add(m) as u32 as u32;
             dst = (dst as u64).wrapping_add(m as u64) as u64 as u64
@@ -653,11 +653,11 @@ pub unsafe fn writei(
             m as u64,
         ) == -(1 as i32)
         {
-            brelse(bp);
+            (*bp).release();
             break;
         } else {
             log_write(bp);
-            brelse(bp);
+            (*bp).release();
             tot = (tot as u32).wrapping_add(m) as u32 as u32;
             off = (off as u32).wrapping_add(m) as u32 as u32;
             src = (src as u64).wrapping_add(m as u64) as u64 as u64

--- a/kernel-rs/src/log.rs
+++ b/kernel-rs/src/log.rs
@@ -1,6 +1,6 @@
 use crate::libc;
 use crate::{
-    bio::{bpin, bread, brelse, bunpin, bwrite},
+    bio::bread,
     buf::Buf,
     fs::{Superblock, BSIZE},
     param::{LOGSIZE, MAXOPBLOCKS},
@@ -106,10 +106,10 @@ unsafe fn install_trans() {
         );
 
         // write dst to disk
-        bwrite(dbuf);
-        bunpin(dbuf);
-        brelse(lbuf);
-        brelse(dbuf);
+        (*dbuf).write();
+        (*dbuf).unpin();
+        (*lbuf).release();
+        (*dbuf).release();
         // tail += 1
     }
 }
@@ -122,7 +122,7 @@ unsafe fn read_head() {
     for i in 0..log.lh.n {
         log.lh.block[i as usize] = (*lh).block[i as usize];
     }
-    brelse(buf);
+    (*buf).release();
 }
 
 /// Write in-memory log header to disk.
@@ -135,8 +135,8 @@ unsafe fn write_head() {
     for i in 0..log.lh.n {
         (*hb).block[i as usize] = log.lh.block[i as usize];
     }
-    bwrite(buf);
-    brelse(buf);
+    (*buf).write();
+    (*buf).release();
 }
 
 unsafe fn recover_from_log() {
@@ -213,9 +213,9 @@ unsafe fn write_log() {
         );
 
         // write the log
-        bwrite(to);
-        brelse(from);
-        brelse(to);
+        (*to).write();
+        (*from).release();
+        (*to).release();
     }
 }
 
@@ -240,11 +240,11 @@ unsafe fn commit() {
 /// Record the block number and pin in the cache by increasing refcnt.
 /// commit()/write_log() will do the disk write.
 ///
-/// log_write() replaces bwrite(); a typical use is:
+/// log_write() replaces write(); a typical use is:
 ///   bp = bread(...)
 ///   modify bp->data[]
 ///   log_write(bp)
-///   brelse(bp)
+///   (*bp).release()
 pub unsafe fn log_write(mut b: *mut Buf) {
     let mut i: i32 = 0;
     if log.lh.n >= LOGSIZE || log.lh.n >= log.size - 1 as i32 {
@@ -270,7 +270,7 @@ pub unsafe fn log_write(mut b: *mut Buf) {
 
     // Add new block to log?
     if i == log.lh.n {
-        bpin(b);
+        (*b).pin();
         log.lh.n += 1
     }
     log.lock.release();


### PR DESCRIPTION
- all usertest passed
- cargo fmt
- "hart starting" messages came up well
- #50 - bio.rs : `Bcache`, buf.rs : `Buf`, console.rs : `Console`, elf.rs : `elfhdr`, `proghdr`
  - 불필요한 pub 제거
  - 함수들 impl로 만들며, 이름 변경
    - `Buf` 관련 함수는 이름에서 `b` 뺌.
    - 예외 : `brelse()`는 `release()`로 변경