### PR TITLE
[closes #78] Use spin_loop() in sys_exit() and remove typecast in sysproc.rs

### DIFF
--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,9 +1,9 @@
 use crate::{
     libc,
+    printf::panic,
     proc::{exit, fork, growproc, kill, myproc, sleep, wait},
     syscall::{argaddr, argint},
     trap::{ticks, tickslock},
-    utils::spin_loop,
 };
 
 pub unsafe fn sys_exit() -> u64 {
@@ -13,8 +13,7 @@ pub unsafe fn sys_exit() -> u64 {
     }
     exit(n);
 
-    // not reached
-    spin_loop()
+    panic(b"sys_exit: not reached\x00" as *const u8 as *const libc::c_char as *mut libc::c_char);
 }
 
 pub unsafe fn sys_getpid() -> u64 {


### PR DESCRIPTION
- closes #78
- all usertests passed
- cargo fmt
- **"hart starting" messages came up well**
- (현재 적용되지 않은 상태인) #54 에서 `sysproc.rs`를 수정한 내용을 적용
  - `sysproc.rs`에서 불필요한 typecast 제거
  - `sys_exit()`에서 `spin_loop()` 사용