### PR TITLE
[closes #112] Add code for gdb into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ RUST_TARGET = riscv64gc-unknown-none-elfhf
 # XBUILD_MODE is needed because cargo xbuild doesn't have "--debug" option.
 # https://github.com/kaist-cp/rv6/pull/118
 ifeq (qemu-gdb, $(firstword $(MAKECMDGOALS)))
-RUST_MODE = debug
-XBUILD_MODE :=
+	RUST_MODE = debug
+	XBUILD_MODE :=
 else
-RUST_MODE = release
-XBUILD_MODE := --$(RUST_MODE)
+	RUST_MODE = release
+	XBUILD_MODE := --$(RUST_MODE)
 endif
 
 # OBJS = \


### PR DESCRIPTION
### 요약 : `make qemu`와 `make qemu-gdb` 둘 다 정상적으로 작동하도록 `Makefile`을 수정하였습니다.

- closes #112 
- all usertests passed
- "hart starting" messages came up well
- Makefile 수정
  - `make qemu-gdb` 외에는 모두 기존의 Makefile과 같음
  - `make qemu-gdb`를 통해 **Rust 코드**를 디버깅하려면 #112  [코멘트](https://github.com/kaist-cp/rv6/issues/112#issuecomment-671700606)의 **breakpoint 걸기**에 나온 것처럼 `Makefile`을 수정해야 했으며, 그 경우 부팅이 되지 않았습니다.
  - 그래서 `make qemu-gdb`를 `Makefile`이 따로 처리하도록 수정하였습니다. 이 PR이 머지되면 `Makefile`을 수정하지 않아도 `make qemu`와 `make qemu-gdb` 둘 다 정상 동작합니다.
- Rust nightly 2020-06-12에서는 **cargo fmt**가 사용이 되지 않아 **cargo stable fmt**를 사용했으며, cargo fmt가 되지 않는 것은 이슈 생성하겠습니다.