### PR TITLE
DRAFT : SpinLock structure 

### DIFF
--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -122,7 +122,7 @@ impl<T> Spinlock<T> {
         let mut lock = RawSpinlock::zeroed();
         lock.initlock(name);
         Self {
-            lock: lock,
+            lock,
             data: UnsafeCell::new(data),
         }
     }
@@ -191,8 +191,6 @@ pub unsafe fn pop_off() {
         intr_on();
     };
 }
-
-
 
 /// Mutual exclusion lock.
 pub struct OldSpinlock {
@@ -291,4 +289,3 @@ impl OldSpinlock {
         r
     }
 }
-


### PR DESCRIPTION
`Spinlock` struct 안에 data가 있기 때문에, spinlock이 code region말고 data를 보호합니다.

1. cs492 repo의 lock(https://github.com/kaist-cp/cs492-concur/blob/master/lock/src/lock.rs )처럼 `lock`과 `unlock`을 impl하는 RawLock struct가 있고,

- 아래 함수와 같이 `RawLock` struct와 `data`를 inner로 가지는 `SpinLock`을 만들어야 하는지
```rust
pub struct Lock<L: RawLock, T> {
    lock: L,
    data: UnsafeCell<T>,
}
```

<1> 이 맞다면, 

2. `acquire`, `release`는 `SpinLock`에 impl하고, `RawLock`에는 `LockGuard`를 return 하는 `lock`함수를 `impl` 하는 것이 맞는지
```rust
pub fn Lock<T>::lock(&self) -> SpinLockGuard<T> { 
    self.lock.lock();
    SpinLockGuard { lock: self }
}
```
궁금합니다.


---

1, 2 가 아니라면
현재 구조에서 `RawLock` -> `SpinLock` 으로 수정 후
```rust
struct Icache {
    lock: Spinlock,
    inode: [Inode; NINODE as usize],
}
```
와 같은 구조를

```rust
struct Icache {
    inode: Spinlock<[Inode; NINODE as usize]>,
}
```
위와 같이 수정하면 되는지 궁금합니다.
