### PR TITLE
[closes #131] Use "end" from kernel.ld and include .bss* to bss

### DIFF
--- a/kernel-rs/src/kalloc.rs
+++ b/kernel-rs/src/kalloc.rs
@@ -10,9 +10,12 @@ use crate::{
 };
 use core::ptr;
 
-/// first address after kernel.
-/// defined by kernel.ld.
-pub static mut END: [u8; 0] = [0; 0];
+extern "C" {
+    // first address after kernel.
+    // defined by kernel.ld.
+    #[no_mangle]
+    static mut end: [u8; 0];
+}
 
 #[derive(Copy, Clone)]
 struct Run {
@@ -45,7 +48,7 @@ pub unsafe fn kinit() {
     drop(protection);
 
     freerange(
-        END.as_mut_ptr() as *mut libc::CVoid,
+        end.as_mut_ptr() as *mut libc::CVoid,
         PHYSTOP as *mut libc::CVoid,
     );
 }
@@ -64,7 +67,7 @@ pub unsafe fn freerange(pa_start: *mut libc::CVoid, pa_end: *mut libc::CVoid) {
 /// initializing the allocator; see kinit above.)
 pub unsafe fn kfree(pa: *mut libc::CVoid) {
     if (pa as usize).wrapping_rem(PGSIZE as usize) != 0
-        || (pa as *mut u8) < END.as_mut_ptr()
+        || (pa as *mut u8) < end.as_mut_ptr()
         || pa as usize >= PHYSTOP as usize
     {
         panic(b"kfree\x00" as *const u8 as *mut u8);

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -25,7 +25,7 @@ SECTIONS
     *(.data)
   }
   .bss : {
-    *(.bss)
+    *(.bss*)
     *(.sbss*)
      PROVIDE(end = .);
   }


### PR DESCRIPTION
### 요약 : `END` 대신 `kernel.ld`의 `end`를 사용하고, `end`가 .bss의 끝 주소를 가지게 하였습니다.

- closes #131  
- cargo +stable fmt
- all usertests passed
- "hart starting" messages came up well
- `END` 대신 `end`
  - 기존의 `kalloc.rs`에서 정의한 `END`는 `kernel.ld`에서 정의한 .bss의 끝 주소를 갖는 `end`와 별개이기 때문에, `extern "C"`를 이용해 `kernel.ld`의 `end`를 사용했습니다.
- `.bss*`를 `.bss`에 포함
  - `static mut`으로 정의된 변수들이 `end`보다 더 작은 값을 갖게 하여, 쓰레기 값으로 덮이지 않게 하였습니다.
- `make qemu`는 잘 동작하지만, `make qemu-gdb`시 아래의 에러가 발생합니다. 별도의 이슈에서 다루겠습니다.
![image](https://user-images.githubusercontent.com/20202266/90085652-75681180-dd53-11ea-965e-1b1a705fae60.png)
