### PR TITLE
[#closes 127] Compile in release mode with debug symbol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ U = user
 KR = kernel-rs
 
 RUST_TARGET = riscv64gc-unknown-none-elfhf
-RUST_MODE = debug
+RUST_MODE = release
 
 # OBJS = \
 #   $K/entry.o \
@@ -95,7 +95,7 @@ $U/initcode: $U/initcode.S
 	$(OBJDUMP) -S $U/initcode.o > $U/initcode.asm
 
 $(KR)/target/$(RUST_TARGET)/$(RUST_MODE)/librv6_kernel.a: $(shell find $(KR) -type f)
-	cargo xbuild --manifest-path kernel-rs/Cargo.toml --target kernel-rs/$(RUST_TARGET).json
+	cargo xbuild --manifest-path kernel-rs/Cargo.toml --target kernel-rs/$(RUST_TARGET).json --$(RUST_MODE)
 
 tags: $(OBJS) _init
 	etags *.S *.c

--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -13,11 +13,11 @@ test = []
 
 [profile.dev]
 panic = "abort"
-lto = true
 
 [profile.release]
 panic = "abort"
 lto = true
+debug = true
 
 [dependencies]
 bitflags = "1.2.1"


### PR DESCRIPTION
### 요약 : `cargo xbuild`가 항상 debug 모드로 컴파일하도록 하였습니다.

- **`make qemu`, `make qemu-gdb` 둘 다 부팅 성공 + 둘 다 all usertests passed**
- closes #127   
- cargo +stable fmt
- "hart starting" messages came up well