### PR TITLE
(WIP) improve error handling

### DIFF
--- a/kernel-rs/src/etrace.rs
+++ b/kernel-rs/src/etrace.rs
@@ -1,0 +1,176 @@
+/// Creates a new error
+///
+/// Use `new_err!(kind)` to create an error with an automatically created description or use
+/// `new_err!(kind, description)` to provide an explicit description
+#[macro_export]
+macro_rules! new_err {
+    ($kind:expr, $description:expr) => {
+        $crate::Error::with_kind_desc($kind, $description, file!(), line!())
+    };
+    ($kind:expr) => {
+        $crate::Error::with_kind($kind, file!(), line!())
+    };
+}
+
+/// Creates a new error containing the underlaying error
+///
+/// Use `new_err_with(error)` to create an error with the same kind and an automatic description
+/// or use
+/// `new_err_with(kind, error)` to provide a new error-kind or use
+/// `new_err_with(kind, description, error)` to provide a new error-kind with an explicit
+/// description
+#[macro_export]
+macro_rules! new_err_with {
+    ($kind:expr, $description:expr, $suberr:expr) => {
+        $crate::Error::propagate_with_kind_desc(
+            $kind,
+            $description,
+            $suberr.into(),
+            file!(),
+            line!(),
+        )
+    };
+    ($kind:expr, $suberr:expr) => {
+        $crate::Error::propagate_with_kind($kind, $suberr.into(), file!(), line!())
+    };
+    ($suberr:expr) => {
+        $crate::Error::propagate($suberr.into(), file!(), line!())
+    };
+}
+
+/// Creates a new error by converting `kind` __into__ the matching `Error<T>` (using a `From`-trait)
+/// and returns it (`return Err(Error<T>)`)
+///
+/// Use `new_err_from!(kind)` to create an error with an automatically created description or use
+/// `new_err_from!(kind, description)` to provide an explicit description
+#[macro_export]
+macro_rules! new_err_from {
+    ($kind:expr, $description:expr) => {
+        new_err!($kind.into(), $description)
+    };
+    ($kind:expr) => {
+        new_err!($kind.into())
+    };
+}
+
+/// Creates a new error and returns it (`return Err(created_error)`)
+///
+/// Use `throw_err!(kind)` to create an error with an automatically created description or use
+/// `throw_err!(kind, description)` to provide an explicit description
+#[macro_export]
+macro_rules! throw_err {
+    ($kind:expr, $description:expr) => {
+        return Err(new_err!($kind, $description));
+    };
+    ($kind:expr) => {
+        return Err(new_err!($kind));
+    };
+}
+
+/// Creates a new error with a sub-error and returns it (`return Err(created_error)`)
+///
+/// Use `rethrow_err!(error)` to create an error with the same kind or use
+/// `rethrow_err!(kind, error)` to provide a new error-kind or use
+/// `rethrow_err!(kind, description, error)` to provide a new error-kind with an explicit
+/// description
+#[macro_export]
+macro_rules! rethrow_err {
+    ($kind:expr, $description:expr, $suberr:expr) => {
+        return Err(new_err_with!($kind, $description, $suberr));
+    };
+    ($kind:expr, $suberr:expr) => {
+        return Err(new_err_with!($kind, $suberr));
+    };
+    ($suberr:expr) => {
+        return Err(new_err_with!($suberr));
+    };
+}
+
+/// Runs an expression and returns either the unwrapped result or creates a new error with the
+/// returned error as sub-error and returns the new error (`return Err(Error<T>)`)
+///
+/// Use `try_err!(expression)` to adopt the underlying error-kind and description or use
+/// `try_err!(expression, kind)` to create an error with an automatically created description
+/// or use
+/// `try_err!(expression, kind, description)` to provide an explicit description
+#[macro_export]
+macro_rules! try_err {
+    ($code:expr, $kind:expr, $description:expr) => {
+        match $code {
+            Ok(result) => result,
+            Err(error) => rethrow_err!($kind, $description, error),
+        }
+    };
+    ($code:expr, $kind:expr) => {
+        match $code {
+            Ok(result) => result,
+            Err(error) => rethrow_err!($kind, error),
+        }
+    };
+    ($code:expr) => {
+        match $code {
+            Ok(result) => result,
+            Err(error) => rethrow_err!(error),
+        }
+    };
+}
+
+/// Runs an expression and returns either the unwrapped result or converts the error __into__ the
+/// matching `Error<T>` (using a `From`-trait) and returns it (`return Err(Error<T>)`)
+///
+/// Use `try_err_from!(expression)` to create an error with an automatically created description or
+/// use `try_err_from!(expression, description)` to provide an explicit description
+#[macro_export]
+macro_rules! try_err_from {
+    ($code:expr, $description:expr) => {
+        match $code {
+            Ok(result) => result,
+            Err(error) => throw_err!(error.into(), $description),
+        }
+    };
+    ($code:expr) => {
+        match $code {
+            Ok(result) => result,
+            Err(error) => throw_err!(error.into()),
+        }
+    };
+}
+
+/// Runs `$code` and returns either the unwrapped result or binds the error to `$err` and executes
+/// `$or` (or can then access the error using the identifier passed as `$err`)
+///
+/// Example:
+/// ```
+/// // This code either prints the error and exits (if error) or prints the result (if ok)
+/// let unwrapped = ok_or!(result, example_error_identifier, {
+/// 	eprintln!("Fatal error: \"{}\"", example_error_identifier);
+/// 	std::process::exit(1);
+/// });
+/// println!("Result: \"{}\"", unwrapped);
+/// ```
+#[macro_export]
+macro_rules! ok_or {
+    ($code:expr, $err:ident, $or:expr) => {
+        match $code {
+            Ok(result) => result,
+            Err($err) => $or,
+        }
+    };
+    ($code:expr, $or:expr) => {
+        match $code {
+            Ok(result) => result,
+            Err(_) => $or,
+        }
+    };
+}
+
+/// Runs an expression and returns either the unwrapped result or executes `$or`
+#[macro_export]
+macro_rules! some_or {
+    ($code:expr, $or:expr) => {
+        match $code {
+            Some(result) => result,
+            None => $or,
+        }
+    };
+}

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -26,6 +26,7 @@ mod bio;
 mod buf;
 mod console;
 mod elf;
+mod etrace;
 mod exec;
 mod fcntl;
 mod file;

--- a/kernel-rs/src/start.rs
+++ b/kernel-rs/src/start.rs
@@ -63,14 +63,13 @@ pub unsafe fn start() {
 /// which turns them into software interrupts for devintr() in trap.c.
 unsafe fn timerinit() {
     // each CPU has a separate source of timer interrupts.
-    let id: i32 = r_mhartid() as i32;
+    let id = r_mhartid();
 
     // ask the CLINT for a timer interrupt.
 
     // cycles; about 1/10th second in qemu.
     let interval: usize = 1000000;
-    *(clint_mtimecmp(id as usize) as *mut usize) =
-        (*(CLINT_MTIME as *mut usize)).wrapping_add(interval);
+    *(clint_mtimecmp(id) as *mut usize) = (*(CLINT_MTIME as *mut usize)).wrapping_add(interval);
 
     // prepare information in scratch[] for timervec.
     // scratch[0..3] : space for timervec to save registers.

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -38,42 +38,36 @@ pub unsafe fn fetchstr(addr: usize, buf: *mut u8, max: i32) -> i32 {
 }
 
 unsafe fn argraw(n: i32) -> usize {
-    let p: *mut Proc = myproc();
+    let p = myproc();
     match n {
-        0 => return (*(*p).tf).a0,
-        1 => return (*(*p).tf).a1,
-        2 => return (*(*p).tf).a2,
-        3 => return (*(*p).tf).a3,
-        4 => return (*(*p).tf).a4,
-        5 => return (*(*p).tf).a5,
-        _ => {}
+        0 => (*(*p).tf).a0,
+        1 => (*(*p).tf).a1,
+        2 => (*(*p).tf).a2,
+        3 => (*(*p).tf).a3,
+        4 => (*(*p).tf).a4,
+        5 => (*(*p).tf).a5,
+        _ => panic!("argraw"),
     }
-    panic!("argraw");
 }
 
 /// Fetch the nth 32-bit system call argument.
-pub unsafe fn argint(n: i32, ip: *mut i32) -> i32 {
-    *ip = argraw(n) as i32;
-    0
+pub unsafe fn argint(n: i32) -> Result<i32, ()> {
+    Ok(argraw(n) as i32)
 }
 
 /// Retrieve an argument as a pointer.
 /// Doesn't check for legality, since
 /// copyin/copyout will do that.
-pub unsafe fn argaddr(n: i32, ip: *mut usize) -> i32 {
-    *ip = argraw(n);
-    0
+pub unsafe fn argaddr(n: i32) -> Result<usize, ()> {
+    Ok(argraw(n))
 }
 
 /// Fetch the nth word-sized system call argument as a null-terminated string.
 /// Copies into buf, at most max.
 /// Returns string length if OK (including nul), -1 if error.
-pub unsafe fn argstr(n: i32, buf: *mut u8, max: i32) -> i32 {
-    let mut addr: usize = 0;
-    if argaddr(n, &mut addr) < 0 {
-        return -1;
-    }
-    fetchstr(addr, buf, max)
+pub unsafe fn argstr(n: i32, buf: *mut u8, max: i32) -> Result<i32, ()> {
+    let addr = argaddr(n)?;
+    Ok(fetchstr(addr, buf, max))
 }
 
 static mut SYSCALLS: [Option<unsafe fn() -> usize>; 22] = [

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -10,6 +10,7 @@ use crate::{
     fs::{Dirent, DIRSIZ},
     kalloc::{kalloc, kfree},
     log::{begin_op, end_op},
+    ok_or,
     param::{MAXARG, MAXPATH, NDEV, NOFILE},
     pipe::Pipe,
     proc::{myproc, Proc},
@@ -42,32 +43,22 @@ impl File {
 
 /// Fetch the nth word-sized system call argument as a file descriptor
 /// and return both the descriptor and the corresponding struct file.
-unsafe fn argfd(n: i32, pfd: *mut i32, pf: *mut *mut File) -> i32 {
-    let mut fd: i32 = 0;
-    let mut f: *mut File = ptr::null_mut();
-    if argint(n, &mut fd) < 0 {
-        return -1;
+unsafe fn argfd(n: i32) -> Result<(i32, *mut File), ()> {
+    let fd = argint(n)?;
+    if fd < 0 || fd >= NOFILE as i32 {
+        return Err(());
     }
-    if fd < 0 || fd >= NOFILE as i32 || {
-        f = (*myproc()).ofile[fd as usize];
-        f.is_null()
-    } {
-        return -1;
+
+    let f = (*myproc()).ofile[fd as usize];
+    if f.is_null() {
+        return Err(());
     }
-    if !pfd.is_null() {
-        *pfd = fd
-    }
-    if !pf.is_null() {
-        *pf = f
-    }
-    0
+
+    Ok((fd, f))
 }
 
 pub unsafe fn sys_dup() -> usize {
-    let mut f: *mut File = ptr::null_mut();
-    if argfd(0, ptr::null_mut(), &mut f) < 0 {
-        return usize::MAX;
-    }
+    let (_, f) = ok_or!(argfd(0), return usize::MAX);
     let fd: i32 = (*f).fdalloc();
     if fd < 0 {
         return usize::MAX;
@@ -77,31 +68,21 @@ pub unsafe fn sys_dup() -> usize {
 }
 
 pub unsafe fn sys_read() -> usize {
-    let mut f: *mut File = ptr::null_mut();
-    let mut n: i32 = 0;
-    let mut p: usize = 0;
-    if argfd(0, ptr::null_mut(), &mut f) < 0 || argint(2, &mut n) < 0 || argaddr(1, &mut p) < 0 {
-        return usize::MAX;
-    }
+    let (_, f) = ok_or!(argfd(0), return usize::MAX);
+    let n = ok_or!(argint(2), return usize::MAX);
+    let p = ok_or!(argaddr(1), return usize::MAX);
     (*f).read(p, n) as usize
 }
 
 pub unsafe fn sys_write() -> usize {
-    let mut f: *mut File = ptr::null_mut();
-    let mut n: i32 = 0;
-    let mut p: usize = 0;
-    if argfd(0, ptr::null_mut(), &mut f) < 0 || argint(2, &mut n) < 0 || argaddr(1, &mut p) < 0 {
-        return usize::MAX;
-    }
+    let (_, f) = ok_or!(argfd(0), return usize::MAX);
+    let n = ok_or!(argint(2), return usize::MAX);
+    let p = ok_or!(argaddr(1), return usize::MAX);
     (*f).write(p, n) as usize
 }
 
 pub unsafe fn sys_close() -> usize {
-    let mut fd: i32 = 0;
-    let mut f: *mut File = ptr::null_mut();
-    if argfd(0, &mut fd, &mut f) < 0 {
-        return usize::MAX;
-    }
+    let (fd, f) = ok_or!(argfd(0), return usize::MAX);
     let fresh0 = &mut (*myproc()).ofile[fd as usize];
     *fresh0 = ptr::null_mut();
     (*f).close();
@@ -109,13 +90,9 @@ pub unsafe fn sys_close() -> usize {
 }
 
 pub unsafe fn sys_fstat() -> usize {
-    let mut f: *mut File = ptr::null_mut();
-
+    let (_, f) = ok_or!(argfd(0), return usize::MAX);
     // user pointer to struct stat
-    let mut st: usize = 0;
-    if argfd(0, ptr::null_mut(), &mut f) < 0 || argaddr(1, &mut st) < 0 {
-        return usize::MAX;
-    }
+    let st = ok_or!(argaddr(1), return usize::MAX);
     (*f).stat(st) as usize
 }
 
@@ -124,11 +101,14 @@ pub unsafe fn sys_link() -> usize {
     let mut name: [u8; DIRSIZ] = [0; DIRSIZ];
     let mut new: [u8; MAXPATH as usize] = [0; MAXPATH];
     let mut old: [u8; MAXPATH as usize] = [0; MAXPATH];
-    if argstr(0, old.as_mut_ptr(), MAXPATH as i32) < 0
-        || argstr(1, new.as_mut_ptr(), MAXPATH as i32) < 0
-    {
-        return usize::MAX;
-    }
+    let _ = ok_or!(
+        argstr(0, old.as_mut_ptr(), MAXPATH as i32),
+        return usize::MAX
+    );
+    let _ = ok_or!(
+        argstr(1, new.as_mut_ptr(), MAXPATH as i32),
+        return usize::MAX
+    );
     begin_op();
     let mut ip: *mut Inode = namei(old.as_mut_ptr());
     if ip.is_null() {
@@ -192,9 +172,10 @@ pub unsafe fn sys_unlink() -> usize {
     let mut name: [u8; DIRSIZ] = [0; DIRSIZ];
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
     let mut off: u32 = 0;
-    if argstr(0, path.as_mut_ptr(), MAXPATH as i32) < 0 {
-        return usize::MAX;
-    }
+    let _ = ok_or!(
+        argstr(0, path.as_mut_ptr(), MAXPATH as i32),
+        return usize::MAX
+    );
     begin_op();
     let mut dp: *mut Inode = nameiparent(path.as_mut_ptr(), name.as_mut_ptr());
     if dp.is_null() {
@@ -295,12 +276,12 @@ unsafe fn create(path: *mut u8, typ: i16, major: i16, minor: i16) -> *mut Inode 
 pub unsafe fn sys_open() -> usize {
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
     let mut fd: i32 = 0;
-    let mut omode: i32 = 0;
     let ip: *mut Inode;
-    let n: i32 = argstr(0, path.as_mut_ptr(), MAXPATH as i32);
-    if n < 0 || argint(1, &mut omode) < 0 {
-        return usize::MAX;
-    }
+    let _ = ok_or!(
+        argstr(0, path.as_mut_ptr(), MAXPATH as i32),
+        return usize::MAX
+    );
+    let omode = ok_or!(argint(1), return usize::MAX);
     begin_op();
     let omode = FcntlFlags::from_bits_truncate(omode);
     if omode.contains(FcntlFlags::O_CREATE) {
@@ -358,7 +339,7 @@ pub unsafe fn sys_mkdir() -> usize {
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
     let mut ip: *mut Inode = ptr::null_mut();
     begin_op();
-    if argstr(0, path.as_mut_ptr(), MAXPATH as i32) < 0 || {
+    if argstr(0, path.as_mut_ptr(), MAXPATH as i32).is_err() || {
         ip = create(path.as_mut_ptr(), T_DIR as i16, 0, 0);
         ip.is_null()
     } {
@@ -371,29 +352,27 @@ pub unsafe fn sys_mkdir() -> usize {
 }
 
 pub unsafe fn sys_mknod() -> usize {
-    let mut ip: *mut Inode = ptr::null_mut();
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
-    let mut major: i32 = 0;
-    let mut minor: i32 = 0;
     begin_op();
-    if argstr(0, path.as_mut_ptr(), MAXPATH as i32) < 0
-        || argint(1, &mut major) < 0
-        || argint(2, &mut minor) < 0
-        || {
-            ip = create(
-                path.as_mut_ptr(),
-                T_DEVICE as i16,
-                major as i16,
-                minor as i16,
-            );
-            ip.is_null()
-        }
-    {
+    let _end_op = scopeguard::guard((), |_| {
         end_op();
+    });
+    let _ = ok_or!(
+        argstr(0, path.as_mut_ptr(), MAXPATH as i32),
+        return usize::MAX
+    );
+    let major = ok_or!(argint(1), return usize::MAX);
+    let minor = ok_or!(argint(2), return usize::MAX);
+    let ip = create(
+        path.as_mut_ptr(),
+        T_DEVICE as i16,
+        major as i16,
+        minor as i16,
+    );
+    if ip.is_null() {
         return usize::MAX;
     }
     (*ip).unlockput();
-    end_op();
     0
 }
 
@@ -402,7 +381,7 @@ pub unsafe fn sys_chdir() -> usize {
     let mut ip: *mut Inode = ptr::null_mut();
     let mut p: *mut Proc = myproc();
     begin_op();
-    if argstr(0, path.as_mut_ptr(), MAXPATH as i32) < 0 || {
+    if argstr(0, path.as_mut_ptr(), MAXPATH as i32).is_err() || {
         ip = namei(path.as_mut_ptr());
         ip.is_null()
     } {
@@ -427,11 +406,12 @@ pub unsafe fn sys_exec() -> usize {
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
     let mut argv: [*mut u8; MAXARG] = [ptr::null_mut(); MAXARG];
     let mut i: i32 = 0;
-    let mut uargv: usize = 0;
     let mut uarg: usize = 0;
-    if argstr(0, path.as_mut_ptr(), MAXPATH as i32) < 0 || argaddr(1, &mut uargv) < 0 {
-        return usize::MAX;
-    }
+    let _ = ok_or!(
+        argstr(0, path.as_mut_ptr(), MAXPATH as i32),
+        return usize::MAX
+    );
+    let uargv = ok_or!(argaddr(1), return usize::MAX);
     ptr::write_bytes(argv.as_mut_ptr(), 0, 1);
     loop {
         if i as usize
@@ -495,16 +475,12 @@ pub unsafe fn sys_exec() -> usize {
 }
 
 pub unsafe fn sys_pipe() -> usize {
-    // user pointer to array of two integers
-    let mut fdarray: usize = 0;
-
     let mut rf: *mut File = ptr::null_mut();
     let mut wf: *mut File = ptr::null_mut();
     let mut fd1: i32 = 0;
     let mut p: *mut Proc = myproc();
-    if argaddr(0, &mut fdarray) < 0 {
-        return usize::MAX;
-    }
+    // user pointer to array of two integers
+    let fdarray = ok_or!(argaddr(0), return usize::MAX);
     if Pipe::alloc(&mut rf, &mut wf) < 0 {
         return usize::MAX;
     }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,15 +1,12 @@
 use crate::{
-    libc,
+    libc, ok_or,
     proc::{exit, fork, growproc, kill, myproc, sleep, wait},
     syscall::{argaddr, argint},
     trap::{TICKS, TICKSLOCK},
 };
 
 pub unsafe fn sys_exit() -> usize {
-    let mut n: i32 = 0;
-    if argint(0, &mut n) < 0 {
-        return usize::MAX;
-    }
+    let n = ok_or!(argint(0), return usize::MAX);
     exit(n);
 
     panic!("sys_exit: not reached");
@@ -24,18 +21,12 @@ pub unsafe fn sys_fork() -> usize {
 }
 
 pub unsafe fn sys_wait() -> usize {
-    let mut p: usize = 0;
-    if argaddr(0, &mut p) < 0 {
-        return usize::MAX;
-    }
+    let p = ok_or!(argaddr(0), return usize::MAX);
     wait(p) as _
 }
 
 pub unsafe fn sys_sbrk() -> usize {
-    let mut n: i32 = 0;
-    if argint(0, &mut n) < 0 {
-        return usize::MAX;
-    }
+    let n = ok_or!(argint(0), return usize::MAX);
     let addr: i32 = (*myproc()).sz as i32;
     if growproc(n) < 0 {
         return usize::MAX;
@@ -44,10 +35,7 @@ pub unsafe fn sys_sbrk() -> usize {
 }
 
 pub unsafe fn sys_sleep() -> usize {
-    let mut n: i32 = 0;
-    if argint(0, &mut n) < 0 {
-        return usize::MAX;
-    }
+    let n = ok_or!(argint(0), return usize::MAX);
     TICKSLOCK.acquire();
     let ticks0 = TICKS;
     while TICKS.wrapping_sub(ticks0) < n as u32 {
@@ -62,10 +50,7 @@ pub unsafe fn sys_sleep() -> usize {
 }
 
 pub unsafe fn sys_kill() -> usize {
-    let mut pid: i32 = 0;
-    if argint(0, &mut pid) < 0 {
-        return usize::MAX;
-    }
+    let pid = ok_or!(argint(0), return usize::MAX);
     kill(pid) as usize
 }
 


### PR DESCRIPTION
이 PR을 적용시 다음과 같은 이상한 에러가 납니다:

```
$ make qemu 
cargo xbuild --manifest-path kernel-rs/Cargo.toml --target kernel-rs/riscv64gc-unknown-none-elfhf.json --release
   Compiling core v0.0.0 (/kaist-cp-home/jeehoon.kang/.rustup/toolchains/nightly-2020-06-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore)
   Compiling compiler_builtins v0.1.32
   Compiling rustc-std-workspace-core v1.99.0 (/kaist-cp-home/jeehoon.kang/.rustup/toolchains/nightly-2020-06-12-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/tools/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/tmp/cargo-xbuild.McU5pMRsTKs6)
    Finished release [optimized + debuginfo] target(s) in 9.65s
   Compiling autocfg v1.0.0
   Compiling bitflags v1.2.1
   Compiling scopeguard v1.1.0
   Compiling num-traits v0.2.12
   Compiling num-integer v0.1.43
   Compiling num-iter v0.1.41
   Compiling rv6-kernel v0.1.0 (/kaist-cp-home/jeehoon.kang/Works/rv6/kernel-rs)
error: fixup value out of range

error: aborting due to previous error

error: could not compile `rv6-kernel`.

To learn more, run the command again with --verbose.
make: *** [Makefile:98: kernel-rs/target/riscv64gc-unknown-none-elfhf/release/librv6_kernel.a] Error 101
```

검색해보니 LLVM 버그를 밟은 것 같네요 Aㅏ... https://github.com/rust-lang/rust/pull/74813
rust-lang/rust에서 해결해줄때까지 기다리겠습니다.