### PR TITLE
Refactor kalloc (related to #156)

### DIFF
--- a/kernel-rs/src/kalloc.rs
+++ b/kernel-rs/src/kalloc.rs
@@ -63,13 +63,15 @@ pub unsafe fn kfree(pa: *mut libc::CVoid) {
 /// Returns a pointer that the kernel can use.
 /// Returns 0 if the memory cannot be allocated.
 pub unsafe fn kalloc() -> *mut libc::CVoid {
-    let mut freelist = KMEM.lock();
-    if freelist.is_null() {
-        return ptr::null_mut();
-    }
-    let next = (**freelist).next;
-    let ret = mem::replace(&mut *freelist, next) as _;
-    
+    let ret = {
+        let mut freelist = KMEM.lock();
+        if freelist.is_null() {
+            return ptr::null_mut();
+        }
+        let next = (**freelist).next;
+        mem::replace(&mut *freelist, next) as _
+    };
+
     // fill with junk
     ptr::write_bytes(ret, 5, PGSIZE);
     ret


### PR DESCRIPTION
#156 에 더해서, 이런 식으로 바꾸는 게 좀 더 idiomatic 할 것 같습니다:
 - `Run` 은 `Copy` 와 `Clone` 이 필요하지 않으므로 떼어낼 수 있습니다.
    + 참고로 `*mut T` 와 같은 raw pointer 는 [`Copy`를 구현합니다.](https://doc.rust-lang.org/stable/std/primitive.pointer.html#impl-Copy-1)
 - `deref()` 그리고 `deref_mut()` 은 Rust가 자동으로 타입을 보고 붙여줍니다. 이걸 [Deref coercion](https://doc.rust-lang.org/nightly/nomicon/coercions.html) 이라고 합니다.
 - `kfree` 의 시멘틱은 할당할 수 있는 페이지가 없으면 null pointer를 리턴하는 것이므로 이 경우에는 early return 을 하는 것이 좋습니다.
   + lockguard 는 함수가 리턴할 때 drop 되므로 `drop(freelist)` 가 없어도 됩니다.