### PR TITLE
[closes #164] Simplify syscall()

### DIFF
--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -99,9 +99,7 @@ pub unsafe fn syscall() {
     let mut p: *mut Proc = myproc();
     let num: i32 = (*(*p).tf).a7 as i32;
     if num > 0
-        && (num as usize)
-            < (::core::mem::size_of::<[Option<unsafe fn() -> usize>; 22]>())
-                .wrapping_div(::core::mem::size_of::<Option<unsafe fn() -> usize>>())
+        && (num as usize) < SYSCALLS.len()
         && SYSCALLS[num as usize].is_some()
     {
         (*(*p).tf).a0 = SYSCALLS[num as usize].expect("non-null function pointer")()


### PR DESCRIPTION
- closes #164 
- all usertests passed
- cargo +stable fmt
- "hart starting" messages came up well