### PR TITLE
[related to #148, #155] printf refactoring 제안

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -38,7 +38,7 @@ impl Console {
 
     /// send one character to the uart.
     // TODO: This function should receive `&mut self`. Need to consider printf.rs and #148.
-    pub unsafe fn putc(c: i32) {
+    pub fn putc(c: i32) {
         // from printf.rs
         if PANICKED.load(Ordering::Acquire) {
             spin_loop();

--- a/kernel-rs/src/printf.rs
+++ b/kernel-rs/src/printf.rs
@@ -9,7 +9,7 @@ struct Writer {}
 impl fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for c in s.bytes() {
-            unsafe {
+            {
                 Console::putc(c as _);
             }
         }


### PR DESCRIPTION
https://github.com/kaist-cp/rv6/issues/155 를 참고하여 작성했습니다.

- cargo +stable fmt
- cargo clippy
- make qemu / usertests / hart message

unsafe가 유의미하게 줄어든 것 같은데, xv6와 printf locking의 의도를 잘 살려서 좋게 추상화한 상태인지는 모르겠습니다.
Ordering 은 docs를 읽어보니 일단 SeqCst로 하면 별 문제가 없는 것 같아서(가장 안전할 것 같아서) 사용했는데, 확신은 없습니다.

#154 수정 권장 사항도 반영했습니다.

참고하여 개선한 더 좋은 코드가 나오면 좋을 것 같습니다.

혹시 이 pr을 merge 한다면 TODO로 남긴 부분 적절한 코멘트 추천해주시면 감사하겠습니다.
LOCKING 변수의 더 적절한 naming이 필요할 것 같기도 합니다.

+ Ordering을 macro 외의 다른 곳에서도 사용하자 rust-analyzer의 오류도 사라졌습니다 :)