### PR TITLE
[closes #81] cargo clippy 오류 해결 : Change type of Buf.disk : i32 -> AtomicI32

### DIFF
--- a/kernel-rs/src/buf.rs
+++ b/kernel-rs/src/buf.rs
@@ -1,11 +1,12 @@
 use crate::sleeplock::Sleeplock;
+use core::sync::atomic::AtomicI32;
 
 pub struct Buf {
     /// has data been read from disk?
     pub valid: i32,
 
     /// does disk "own" buf?
-    pub disk: i32,
+    pub disk: AtomicI32,
     pub dev: u32,
     pub blockno: u32,
     pub lock: Sleeplock,


### PR DESCRIPTION
### struct Buf의 disk 필드를 i32에서 AtomicI32로 바꿀 것을 제안합니다. -> cargo clippy 오류 해결

- Buf의 disk 필드를 AtomicBool로 바꿔도 올바른 것인지는 buf.rs와 밀접하게 관련된 파일을 리팩토링할때 고려해보겠습니다. (struct Buf 자체의 크기를 바꿔도 되는지)
- closes #81 
- cargo clippy
- all usertests passed
- cargo +stable fmt
- "hart starting" messages came up well