### PR TITLE
Follow up #198

### DIFF
--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -401,8 +401,6 @@ static mut PROC: [Proc; NPROC] = [Proc::zeroed(); NPROC];
 
 static mut INITPROC: *mut Proc = ptr::null_mut();
 
-static mut NEXTPID: Spinlock<i32> = Spinlock::new("nextpid", 1);
-
 #[no_mangle]
 pub unsafe fn procinit() {
     for (i, p) in PROC.iter_mut().enumerate() {
@@ -448,7 +446,9 @@ pub unsafe fn myproc() -> *mut Proc {
     p
 }
 
-unsafe fn allocpid() -> i32 {
+fn allocpid() -> i32 {
+    static NEXTPID: Spinlock<i32> = Spinlock::new("nextpid", 1);
+
     let mut pid = NEXTPID.lock();
     let ret = *pid;
     *pid += 1;


### PR DESCRIPTION
Move `NEXTPID` into `allocpid` as immutable static, and mark it safe.