### PR TITLE
Refactor vm.rs - pagetable struct

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -89,7 +89,7 @@ impl Console {
                 user_src,
                 src.wrapping_add(i as usize),
                 1usize,
-            ) == -1
+            ).is_err()
             {
                 break;
             }
@@ -135,7 +135,7 @@ impl Console {
                     dst,
                     &mut cbuf as *mut u8 as *mut libc::CVoid,
                     1usize,
-                ) == -1
+                ).is_err()
                 {
                     break;
                 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -89,7 +89,8 @@ impl Console {
                 user_src,
                 src.wrapping_add(i as usize),
                 1usize,
-            ).is_err()
+            )
+            .is_err()
             {
                 break;
             }
@@ -135,7 +136,8 @@ impl Console {
                     dst,
                     &mut cbuf as *mut u8 as *mut libc::CVoid,
                     1usize,
-                ).is_err()
+                )
+                .is_err()
                 {
                     break;
                 }

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -79,7 +79,7 @@ pub unsafe fn exec(path: *mut u8, argv: *mut *mut u8) -> i32 {
                 return -1;
             }
             let sz_op = uvmalloc(pt, *sz, ph.vaddr.wrapping_add(ph.memsz));
-            if sz_op.is_none() {
+            if sz_op.is_err() {
                 return -1;
             }
             *sz = sz_op.unwrap();
@@ -103,7 +103,7 @@ pub unsafe fn exec(path: *mut u8, argv: *mut *mut u8) -> i32 {
     *sz = sz.wrapping_add(PGSIZE).wrapping_sub(1) & !PGSIZE.wrapping_sub(1);
     let sz_op = uvmalloc(pt, *sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)));
 
-    if sz_op.is_none() {
+    if sz_op.is_err() {
         return -1;
     }
 

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -8,7 +8,7 @@ use crate::{
     riscv::PGSIZE,
     string::{safestrcpy, strlen},
     vm::PageTable,
-    vm::{uvmalloc, uvmclear, walkaddr},
+    vm::{uvmalloc, uvmclear},
 };
 
 pub unsafe fn exec(path: *mut u8, argv: *mut *mut u8) -> i32 {
@@ -211,7 +211,7 @@ unsafe fn loadseg(
     }
 
     for i in num_iter::range_step(0, sz, PGSIZE as _) {
-        let pa = walkaddr(pagetable, va.wrapping_add(i as usize));
+        let pa = pagetable.walkaddr(va.wrapping_add(i as usize));
         if pa == 0 {
             panic!("loadseg: address should exist");
         }

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -210,10 +210,9 @@ unsafe fn loadseg(
     }
 
     for i in num_iter::range_step(0, sz, PGSIZE as _) {
-        let pa = pagetable.walkaddr(va.wrapping_add(i as usize));
-        if pa == 0 {
-            panic!("loadseg: address should exist");
-        }
+        let pa = pagetable
+            .walkaddr(va.wrapping_add(i as usize))
+            .expect("loadseg: address should exist");
 
         let n = if sz.wrapping_sub(i) < PGSIZE as u32 {
             sz.wrapping_sub(i)

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -133,7 +133,8 @@ pub unsafe fn exec(path: *mut u8, argv: *mut *mut u8) -> i32 {
             sp,
             *argv.add(argc),
             (strlen(*argv.add(argc)) + 1) as usize,
-        ) < 0
+        )
+        .is_err()
         {
             return -1;
         }
@@ -156,7 +157,8 @@ pub unsafe fn exec(path: *mut u8, argv: *mut *mut u8) -> i32 {
             ustack.as_mut_ptr() as *mut u8,
             argc.wrapping_add(1)
                 .wrapping_mul(::core::mem::size_of::<usize>()),
-        ) >= 0
+        )
+        .is_ok()
     {
         let (pt, sz) = scopeguard::ScopeGuard::into_inner(ptable_guard);
         // arguments to user main(argc, argv)

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -177,7 +177,7 @@ pub unsafe fn exec(path: *mut u8, argv: *mut *mut u8) -> i32 {
         );
 
         // Commit to the user image.
-        let mut oldpagetable = core::mem::replace(&mut (*p).pagetable, pt);
+        let mut oldpagetable = core::mem::replace((*p).pagetable.assume_init_mut(), pt);
         (*p).sz = sz;
 
         // initial program counter = main

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -5,196 +5,193 @@ use crate::{
     log::{begin_op, end_op},
     param::MAXARG,
     proc::{myproc, proc_freepagetable, proc_pagetable, Proc},
-    riscv::{PagetableT, PGSIZE},
+    riscv::PGSIZE,
     string::{safestrcpy, strlen},
+    vm::PageTable,
     vm::{copyout, uvmalloc, uvmclear, walkaddr},
 };
-use core::ptr;
 
 pub unsafe fn exec(path: *mut u8, argv: *mut *mut u8) -> i32 {
-    let mut sz: usize = 0;
+    let sz: usize = 0;
     let mut ustack: [usize; MAXARG + 1] = [0; MAXARG + 1];
     let mut elf: ElfHdr = Default::default();
     let mut ph: ProgHdr = Default::default();
-    let mut pagetable: PagetableT = 0 as PagetableT;
     let mut p: *mut Proc = myproc();
 
     begin_op();
-    let mut ip: *mut Inode = namei(path);
+    let ip: *mut Inode = namei(path);
     if ip.is_null() {
         end_op();
         return -1;
     }
     (*ip).lock();
 
-    let _op = scopeguard::guard((pagetable, sz, ip), |(pagetable, sz, ip)| {
-        if !pagetable.is_null() {
-            proc_freepagetable(pagetable, sz);
-        }
-        if !ip.is_null() {
-            (*ip).unlockput();
-            end_op();
-        }
+    let mut ip = scopeguard::guard(ip, |ip| {
+        (*ip).unlockput();
+        end_op();
     });
 
     // Check ELF header
-    if (*ip).read(
+    if !((**ip).read(
         0,
         &mut elf as *mut ElfHdr as usize,
         0,
         ::core::mem::size_of::<ElfHdr>() as u32,
     ) as usize
         == ::core::mem::size_of::<ElfHdr>()
-        && elf.magic == ELF_MAGIC
+        && elf.magic == ELF_MAGIC)
     {
-        pagetable = proc_pagetable(p);
-        if !pagetable.is_null() {
-            // Load program into memory.
-            sz = 0;
-            for i in 0..elf.phnum as usize {
-                let off = elf
-                    .phoff
-                    .wrapping_add(i * ::core::mem::size_of::<ProgHdr>());
+        return -1;
+    }
 
-                if (*ip).read(
-                    0,
-                    &mut ph as *mut ProgHdr as usize,
-                    off as u32,
-                    ::core::mem::size_of::<ProgHdr>() as u32,
-                ) as usize
-                    != ::core::mem::size_of::<ProgHdr>()
-                {
-                    return -1;
-                }
-                if ph.typ == ELF_PROG_LOAD {
-                    if ph.memsz < ph.filesz {
-                        return -1;
-                    }
-                    if ph.vaddr.wrapping_add(ph.memsz) < ph.vaddr {
-                        return -1;
-                    }
-                    sz = uvmalloc(pagetable, sz, ph.vaddr.wrapping_add(ph.memsz));
-                    if sz == 0 {
-                        return -1;
-                    }
-                    if ph.vaddr.wrapping_rem(PGSIZE) != 0 {
-                        return -1;
-                    }
-                    if loadseg(pagetable, ph.vaddr, ip, ph.off as u32, ph.filesz as u32).is_err() {
-                        return -1;
-                    }
-                }
+    let pt = proc_pagetable(p);
+    if pt.is_null() {
+        return -1;
+    }
+
+    let mut ptable_guard = scopeguard::guard((pt, sz), |(mut pt, sz)| {
+        proc_freepagetable(&mut pt, sz);
+    });
+
+    let (pt, sz) = &mut *ptable_guard;
+    // Load program into memory.
+    *sz = 0;
+    for i in 0..elf.phnum as usize {
+        let off = elf
+            .phoff
+            .wrapping_add(i * ::core::mem::size_of::<ProgHdr>());
+
+        if (**ip).read(
+            0,
+            &mut ph as *mut ProgHdr as usize,
+            off as u32,
+            ::core::mem::size_of::<ProgHdr>() as u32,
+        ) as usize
+            != ::core::mem::size_of::<ProgHdr>()
+        {
+            return -1;
+        }
+        if ph.typ == ELF_PROG_LOAD {
+            if ph.memsz < ph.filesz {
+                return -1;
             }
-            (*ip).unlockput();
-            core::mem::forget(_op);
-            end_op();
-            ip = ptr::null_mut();
-
-            p = myproc();
-            let oldsz: usize = (*p).sz;
-
-            // Allocate two pages at the next page boundary.
-            // Use the second as the user stack.
-            sz = sz.wrapping_add(PGSIZE).wrapping_sub(1) & !PGSIZE.wrapping_sub(1);
-            sz = uvmalloc(pagetable, sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)));
-            let _op = scopeguard::guard((pagetable, sz, ip), |(pagetable, sz, ip)| {
-                if !pagetable.is_null() {
-                    proc_freepagetable(pagetable, sz);
-                }
-                if !ip.is_null() {
-                    (*ip).unlockput();
-                    end_op();
-                }
-            });
-            if sz != 0 {
-                uvmclear(pagetable, sz.wrapping_sub(2usize.wrapping_mul(PGSIZE)));
-                let mut sp: usize = sz;
-                let stackbase: usize = sp.wrapping_sub(PGSIZE);
-
-                // Push argument strings, prepare rest of stack in ustack.
-                let mut argc: usize = 0;
-                loop {
-                    if (*argv.add(argc)).is_null() {
-                        break;
-                    }
-                    if argc >= MAXARG {
-                        return -1;
-                    }
-                    sp = sp.wrapping_sub((strlen(*argv.add(argc)) + 1) as usize);
-
-                    // riscv sp must be 16-byte aligned
-                    sp = sp.wrapping_sub(sp.wrapping_rem(16));
-                    if sp < stackbase {
-                        return -1;
-                    }
-                    if copyout(
-                        pagetable,
-                        sp,
-                        *argv.add(argc),
-                        (strlen(*argv.add(argc)) + 1) as usize,
-                    ) < 0
-                    {
-                        return -1;
-                    }
-                    ustack[argc] = sp;
-                    argc = argc.wrapping_add(1)
-                }
-                ustack[argc] = 0;
-
-                // push the array of argv[] pointers.
-                sp = sp.wrapping_sub(
-                    argc.wrapping_add(1)
-                        .wrapping_mul(::core::mem::size_of::<usize>()),
-                );
-                sp = sp.wrapping_sub(sp.wrapping_rem(16));
-
-                if sp >= stackbase
-                    && copyout(
-                        pagetable,
-                        sp,
-                        ustack.as_mut_ptr() as *mut u8,
-                        argc.wrapping_add(1)
-                            .wrapping_mul(::core::mem::size_of::<usize>()),
-                    ) >= 0
-                {
-                    core::mem::forget(_op);
-                    // arguments to user main(argc, argv)
-                    // argc is returned via the system call return
-                    // value, which goes in a0.
-                    (*(*p).tf).a1 = sp;
-
-                    // Save program name for debugging.
-                    let mut s: *mut u8 = path;
-                    let mut last: *mut u8 = s;
-                    while *s != 0 {
-                        if *s as i32 == '/' as i32 {
-                            last = s.offset(1)
-                        }
-                        s = s.offset(1)
-                    }
-                    safestrcpy(
-                        (*p).name.as_mut_ptr(),
-                        last,
-                        ::core::mem::size_of::<[u8; 16]>() as i32,
-                    );
-
-                    // Commit to the user image.
-                    let oldpagetable: PagetableT = (*p).pagetable;
-                    (*p).pagetable = pagetable;
-                    (*p).sz = sz;
-
-                    // initial program counter = main
-                    (*(*p).tf).epc = elf.entry;
-
-                    // initial stack pointer
-                    (*(*p).tf).sp = sp;
-                    proc_freepagetable(oldpagetable, oldsz);
-
-                    // this ends up in a0, the first argument to main(argc, argv)
-                    return argc as i32;
-                }
+            if ph.vaddr.wrapping_add(ph.memsz) < ph.vaddr {
+                return -1;
+            }
+            let sz_op = uvmalloc(pt, *sz, ph.vaddr.wrapping_add(ph.memsz));
+            if sz_op.is_none() {
+                return -1;
+            }
+            *sz = sz_op.unwrap();
+            if ph.vaddr.wrapping_rem(PGSIZE) != 0 {
+                return -1;
+            }
+            if loadseg(pt, ph.vaddr, *ip, ph.off as u32, ph.filesz as u32).is_err() {
+                return -1;
             }
         }
+    }
+    (**ip).unlockput();
+    core::mem::forget(ip);
+    end_op();
+
+    p = myproc();
+    let oldsz: usize = (*p).sz;
+
+    // Allocate two pages at the next page boundary.
+    // Use the second as the user stack.
+    *sz = sz.wrapping_add(PGSIZE).wrapping_sub(1) & !PGSIZE.wrapping_sub(1);
+    let sz_op = uvmalloc(pt, *sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)));
+
+    if sz_op.is_none() {
+        return -1;
+    }
+
+    *sz = sz_op.unwrap();
+    uvmclear(pt, sz.wrapping_sub(2usize.wrapping_mul(PGSIZE)));
+    let mut sp: usize = *sz;
+    let stackbase: usize = sp.wrapping_sub(PGSIZE);
+
+    // Push argument strings, prepare rest of stack in ustack.
+    let mut argc: usize = 0;
+    loop {
+        if (*argv.add(argc)).is_null() {
+            break;
+        }
+        if argc >= MAXARG {
+            return -1;
+        }
+        sp = sp.wrapping_sub((strlen(*argv.add(argc)) + 1) as usize);
+
+        // riscv sp must be 16-byte aligned
+        sp = sp.wrapping_sub(sp.wrapping_rem(16));
+        if sp < stackbase {
+            return -1;
+        }
+        if copyout(
+            pt,
+            sp,
+            *argv.add(argc),
+            (strlen(*argv.add(argc)) + 1) as usize,
+        ) < 0
+        {
+            return -1;
+        }
+        ustack[argc] = sp;
+        argc = argc.wrapping_add(1)
+    }
+    ustack[argc] = 0;
+
+    // push the array of argv[] pointers.
+    sp = sp.wrapping_sub(
+        argc.wrapping_add(1)
+            .wrapping_mul(::core::mem::size_of::<usize>()),
+    );
+    sp = sp.wrapping_sub(sp.wrapping_rem(16));
+
+    if sp >= stackbase
+        && copyout(
+            pt,
+            sp,
+            ustack.as_mut_ptr() as *mut u8,
+            argc.wrapping_add(1)
+                .wrapping_mul(::core::mem::size_of::<usize>()),
+        ) >= 0
+    {
+        let (pt, sz) = scopeguard::ScopeGuard::into_inner(ptable_guard);
+        // arguments to user main(argc, argv)
+        // argc is returned via the system call return
+        // value, which goes in a0.
+        (*(*p).tf).a1 = sp;
+
+        // Save program name for debugging.
+        let mut s: *mut u8 = path;
+        let mut last: *mut u8 = s;
+        while *s != 0 {
+            if *s as i32 == '/' as i32 {
+                last = s.offset(1)
+            }
+            s = s.offset(1)
+        }
+        safestrcpy(
+            (*p).name.as_mut_ptr(),
+            last,
+            ::core::mem::size_of::<[u8; 16]>() as i32,
+        );
+
+        // Commit to the user image.
+        let mut oldpagetable = core::mem::replace(&mut (*p).pagetable, pt);
+        (*p).sz = sz;
+
+        // initial program counter = main
+        (*(*p).tf).epc = elf.entry;
+
+        // initial stack pointer
+        (*(*p).tf).sp = sp;
+        proc_freepagetable(&mut oldpagetable, oldsz);
+
+        // this ends up in a0, the first argument to main(argc, argv)
+        return argc as i32;
     }
     -1
 }
@@ -205,7 +202,7 @@ pub unsafe fn exec(path: *mut u8, argv: *mut *mut u8) -> i32 {
 ///
 /// Returns `Ok(())` on success, `Err(())` on failure.
 unsafe fn loadseg(
-    pagetable: PagetableT,
+    pagetable: &mut PageTable,
     va: usize,
     ip: *mut Inode,
     offset: u32,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -107,7 +107,9 @@ impl File {
                 (*ip).lock();
                 stati(ip, &mut st);
                 (*ip).unlock();
-                if (*p).pagetable.copyout(
+                if (*p)
+                    .pagetable
+                    .assume_init_mut().copyout(
                     addr,
                     &mut st as *mut Stat as *mut u8,
                     ::core::mem::size_of::<Stat>() as usize,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -109,7 +109,7 @@ impl File {
                 stati(ip, &mut st);
                 (*ip).unlock();
                 if copyout(
-                    (*p).pagetable,
+                    &mut (*p).pagetable,
                     addr,
                     &mut st as *mut Stat as *mut u8,
                     ::core::mem::size_of::<Stat>() as usize,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -113,7 +113,7 @@ impl File {
                     addr,
                     &mut st as *mut Stat as *mut u8,
                     ::core::mem::size_of::<Stat>() as usize,
-                ) < 0
+                ).is_err()
                 {
                     Err(())
                 } else {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -109,11 +109,13 @@ impl File {
                 (*ip).unlock();
                 if (*p)
                     .pagetable
-                    .assume_init_mut().copyout(
-                    addr,
-                    &mut st as *mut Stat as *mut u8,
-                    ::core::mem::size_of::<Stat>() as usize,
-                ).is_err()
+                    .assume_init_mut()
+                    .copyout(
+                        addr,
+                        &mut st as *mut Stat as *mut u8,
+                        ::core::mem::size_of::<Stat>() as usize,
+                    )
+                    .is_err()
                 {
                     Err(())
                 } else {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -9,7 +9,6 @@ use crate::{
     sleeplock::Sleeplock,
     spinlock::Spinlock,
     stat::Stat,
-    vm::copyout,
 };
 use core::cmp;
 use core::convert::TryFrom;
@@ -108,8 +107,7 @@ impl File {
                 (*ip).lock();
                 stati(ip, &mut st);
                 (*ip).unlock();
-                if copyout(
-                    &mut (*p).pagetable,
+                if (*p).pagetable.copyout(
                     addr,
                     &mut st as *mut Stat as *mut u8,
                     ::core::mem::size_of::<Stat>() as usize,

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -364,7 +364,8 @@ impl Inode {
                     .offset(off.wrapping_rem(BSIZE as u32) as isize)
                     as *mut libc::CVoid,
                 m as usize,
-            ).is_err()
+            )
+            .is_err()
             {
                 brelease(&mut *bp);
                 break;
@@ -406,7 +407,8 @@ impl Inode {
                 user_src,
                 src,
                 m as usize,
-            ).is_err()
+            )
+            .is_err()
             {
                 brelease(&mut *bp);
                 break;

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -364,7 +364,7 @@ impl Inode {
                     .offset(off.wrapping_rem(BSIZE as u32) as isize)
                     as *mut libc::CVoid,
                 m as usize,
-            ) == -1
+            ).is_err()
             {
                 brelease(&mut *bp);
                 break;
@@ -406,7 +406,7 @@ impl Inode {
                 user_src,
                 src,
                 m as usize,
-            ) == -1
+            ).is_err()
             {
                 brelease(&mut *bp);
                 break;

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -173,7 +173,12 @@ impl PipeInner {
                 }
                 return Ok(i);
             }
-            if copyin((*proc).pagetable, &mut ch, addr.wrapping_add(i), 1usize) == -1 {
+            if copyin(
+                &mut (*proc).pagetable,
+                &mut ch,
+                addr.wrapping_add(i),
+                1usize,
+            ) == -1 {
                 break;
             }
             self.data[self.nwrite as usize % PIPESIZE] = ch;
@@ -200,7 +205,7 @@ impl PipeInner {
             }
             let mut ch = self.data[self.nread as usize % PIPESIZE];
             self.nread = self.nread.wrapping_add(1);
-            if copyout((*proc).pagetable, addr.wrapping_add(i), &mut ch, 1usize) == -1 {
+            if copyout(&mut (*proc).pagetable, addr.wrapping_add(i), &mut ch, 1usize) == -1 {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -178,7 +178,9 @@ impl PipeInner {
                 &mut ch,
                 addr.wrapping_add(i),
                 1usize,
-            ) == -1 {
+            )
+            .is_err()
+            {
                 break;
             }
             self.data[self.nwrite as usize % PIPESIZE] = ch;

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -4,7 +4,6 @@ use crate::{
     kalloc::{kalloc, kfree},
     proc::{myproc, WaitChannel},
     spinlock::Spinlock,
-    vm::{copyin, copyout},
 };
 use core::{ops::Deref, ptr};
 
@@ -173,8 +172,7 @@ impl PipeInner {
                 }
                 return Ok(i);
             }
-            if copyin(
-                &mut (*proc).pagetable,
+            if (*proc).pagetable.copyin(
                 &mut ch,
                 addr.wrapping_add(i),
                 1usize,
@@ -207,7 +205,7 @@ impl PipeInner {
             }
             let mut ch = self.data[self.nread as usize % PIPESIZE];
             self.nread = self.nread.wrapping_add(1);
-            if copyout(&mut (*proc).pagetable, addr.wrapping_add(i), &mut ch, 1usize).is_err() {
+            if (*proc).pagetable.copyout(addr.wrapping_add(i), &mut ch, 1usize).is_err() {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -207,7 +207,7 @@ impl PipeInner {
             }
             let mut ch = self.data[self.nread as usize % PIPESIZE];
             self.nread = self.nread.wrapping_add(1);
-            if copyout(&mut (*proc).pagetable, addr.wrapping_add(i), &mut ch, 1usize) == -1 {
+            if copyout(&mut (*proc).pagetable, addr.wrapping_add(i), &mut ch, 1usize).is_err() {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -174,12 +174,9 @@ impl PipeInner {
             }
             if (*proc)
                 .pagetable
-                .assume_init_mut().copyin(
-                &mut ch,
-                addr.wrapping_add(i),
-                1usize,
-            )
-            .is_err()
+                .assume_init_mut()
+                .copyin(&mut ch, addr.wrapping_add(i), 1usize)
+                .is_err()
             {
                 break;
             }
@@ -209,8 +206,10 @@ impl PipeInner {
             self.nread = self.nread.wrapping_add(1);
             if (*proc)
                 .pagetable
-                .assume_init_mut().copyout(addr.wrapping_add(i), &mut ch, 1usize)
-                .is_err() {
+                .assume_init_mut()
+                .copyout(addr.wrapping_add(i), &mut ch, 1usize)
+                .is_err()
+            {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -172,7 +172,9 @@ impl PipeInner {
                 }
                 return Ok(i);
             }
-            if (*proc).pagetable.copyin(
+            if (*proc)
+                .pagetable
+                .assume_init_mut().copyin(
                 &mut ch,
                 addr.wrapping_add(i),
                 1usize,
@@ -205,7 +207,10 @@ impl PipeInner {
             }
             let mut ch = self.data[self.nread as usize % PIPESIZE];
             self.nread = self.nread.wrapping_add(1);
-            if (*proc).pagetable.copyout(addr.wrapping_add(i), &mut ch, 1usize).is_err() {
+            if (*proc)
+                .pagetable
+                .assume_init_mut().copyout(addr.wrapping_add(i), &mut ch, 1usize)
+                .is_err() {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -970,7 +970,7 @@ pub unsafe fn either_copyout(user_dst: i32, dst: usize, src: *mut libc::CVoid, l
 pub unsafe fn either_copyin(dst: *mut libc::CVoid, user_src: i32, src: usize, len: usize) -> i32 {
     let p = myproc();
     if user_src != 0 {
-        copyin(&mut (*p).pagetable, dst as *mut u8, src, len)
+        copyin(&mut (*p).pagetable, dst as *mut u8, src, len).map_or(-1, |_v| 0)
     } else {
         ptr::copy(src as *mut u8 as *const libc::CVoid, dst, len);
         0

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -574,7 +574,7 @@ impl ProcessSystem {
         let mut np = ok_or!(self.alloc(), return -1);
 
         // Copy user memory from parent to child.
-        if uvmcopy(&mut (*p).pagetable, &mut (*np).pagetable, (*p).sz) < 0 {
+        if uvmcopy(&mut (*p).pagetable, &mut (*np).pagetable, (*p).sz).is_err() {
             freeproc(np);
             (*np).lock.release();
             return -1;

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -16,7 +16,7 @@ use crate::{
         uvmunmap,
     },
 };
-use crate::{libc, vm::mappages_temp, vm::PageTable};
+use crate::{libc, vm::mappages, vm::PageTable};
 use core::cmp::Ordering;
 use core::ptr;
 use core::str;
@@ -805,7 +805,7 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> PageTable {
     // at the highest user virtual address.
     // Only the supervisor uses it, on the way
     // to/from user space, so not PTE_U.
-    mappages_temp(
+    mappages(
         &mut pagetable,
         TRAMPOLINE,
         PGSIZE,
@@ -814,7 +814,7 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> PageTable {
     );
 
     // Map the trapframe just below TRAMPOLINE, for trampoline.S.
-    mappages_temp(
+    mappages(
         &mut pagetable,
         TRAPFRAME,
         PGSIZE,

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -940,30 +940,30 @@ unsafe fn forkret() {
 
 /// Copy to either a user address, or kernel address,
 /// depending on usr_dst.
-/// Returns 0 on success, -1 on error.
-pub unsafe fn either_copyout(user_dst: i32, dst: usize, src: *mut libc::CVoid, len: usize) -> i32 {
+/// Returns Ok(()) on success, Err(()) on error.
+pub unsafe fn either_copyout(user_dst: i32, dst: usize, src: *mut libc::CVoid, len: usize) -> Result<(),()> {
     let p = myproc();
     if user_dst != 0 {
         (*p).pagetable
             .copyout(dst, src as *mut u8, len)
-            .map_or(-1, |_v| 0)
+            .map_or(Err(()), |_v| Ok(()))
     } else {
         ptr::copy(src, dst as *mut u8 as *mut libc::CVoid, len);
-        0
+        Ok(())
     }
 }
 
 /// Copy from either a user address, or kernel address,
 /// depending on usr_src.
-/// Returns 0 on success, -1 on error.
-pub unsafe fn either_copyin(dst: *mut libc::CVoid, user_src: i32, src: usize, len: usize) -> i32 {
+/// Returns Ok(()) on success, Err(()) on error.
+pub unsafe fn either_copyin(dst: *mut libc::CVoid, user_src: i32, src: usize, len: usize) -> Result<(), ()> {
     let p = myproc();
     if user_src != 0 {
         (*p).pagetable
             .copyin(dst as *mut u8, src, len)
-            .map_or(-1, |_v| 0)
+            .map_or(Err(()), |_v| Ok(()))
     } else {
         ptr::copy(src as *mut u8 as *const libc::CVoid, dst, len);
-        0
+        Ok(())
     }
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -634,7 +634,7 @@ impl ProcessSystem {
                                 addr,
                                 &mut np.xstate as *mut i32 as *mut u8,
                                 ::core::mem::size_of::<i32>(),
-                            ) < 0
+                            ).is_err()
                         {
                             np.lock.release();
                             (*p).lock.release();
@@ -957,7 +957,7 @@ unsafe fn forkret() {
 pub unsafe fn either_copyout(user_dst: i32, dst: usize, src: *mut libc::CVoid, len: usize) -> i32 {
     let p = myproc();
     if user_dst != 0 {
-        copyout(&mut (*p).pagetable, dst, src as *mut u8, len)
+        copyout(&mut (*p).pagetable, dst, src as *mut u8, len).map_or(-1, |_v| 0)
     } else {
         ptr::copy(src, dst as *mut u8 as *mut libc::CVoid, len);
         0

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -13,7 +13,7 @@ use crate::{
     trap::usertrapret,
     vm::{kvminithart, kvmmap, uvmalloc, uvmcopy, uvmdealloc, uvmfree, uvminit, uvmunmap},
 };
-use crate::{libc, vm::mappages, vm::PageTable};
+use crate::{libc, vm::PageTable};
 use core::cmp::Ordering;
 use core::ptr;
 use core::str;
@@ -801,8 +801,7 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> PageTable {
     // at the highest user virtual address.
     // Only the supervisor uses it, on the way
     // to/from user space, so not PTE_U.
-    mappages(
-        &mut pagetable,
+    pagetable.mappages(
         TRAMPOLINE,
         PGSIZE,
         trampoline.as_mut_ptr() as usize,
@@ -810,8 +809,7 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> PageTable {
     );
 
     // Map the trapframe just below TRAMPOLINE, for trampoline.S.
-    mappages(
-        &mut pagetable,
+    pagetable.mappages(
         TRAPFRAME,
         PGSIZE,
         (*p).tf as usize,

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -852,7 +852,7 @@ pub unsafe fn resizeproc(n: i32) -> i32 {
         Ordering::Equal => sz,
         Ordering::Greater => {
             let sz = uvmalloc(&mut (*p).pagetable, sz, sz.wrapping_add(n as usize));
-            if sz.is_none() {
+            if sz.is_err() {
                 return -1;
             }
             sz.unwrap()

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -809,7 +809,6 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> PageTable {
 
     // Map the trapframe just below TRAMPOLINE, for trampoline.S.
     pagetable.mappages(TRAPFRAME, PGSIZE, (*p).tf as usize, PTE_R | PTE_W);
-
     pagetable
 }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -568,7 +568,12 @@ impl ProcessSystem {
         let mut np = ok_or!(self.alloc(), return -1);
 
         // Copy user memory from parent to child.
-        if (*p).pagetable.assume_init_mut().uvmcopy((*np).pagetable.assume_init_mut(), (*p).sz).is_err() {
+        if (*p)
+            .pagetable
+            .assume_init_mut()
+            .uvmcopy((*np).pagetable.assume_init_mut(), (*p).sz)
+            .is_err()
+        {
             freeproc(np);
             (*np).lock.release();
             return -1;
@@ -623,11 +628,15 @@ impl ProcessSystem {
                     if np.state == Procstate::ZOMBIE {
                         let pid = np.pid;
                         if addr != 0
-                            && (*p).pagetable.assume_init_mut().copyout(
-                                addr,
-                                &mut np.xstate as *mut i32 as *mut u8,
-                                ::core::mem::size_of::<i32>(),
-                            ).is_err()
+                            && (*p)
+                                .pagetable
+                                .assume_init_mut()
+                                .copyout(
+                                    addr,
+                                    &mut np.xstate as *mut i32 as *mut u8,
+                                    ::core::mem::size_of::<i32>(),
+                                )
+                                .is_err()
                         {
                             np.lock.release();
                             (*p).lock.release();
@@ -844,10 +853,7 @@ pub unsafe fn resizeproc(n: i32) -> i32 {
                 .pagetable
                 .assume_init_mut()
                 .uvmalloc(sz, sz.wrapping_add(n as usize));
-            if sz.is_err() {
-                return -1;
-            }
-            sz.unwrap()
+            ok_or!(sz, return -1)
         }
         Ordering::Less => (*p)
             .pagetable

--- a/kernel-rs/src/riscv.rs
+++ b/kernel-rs/src/riscv.rs
@@ -1,3 +1,6 @@
+use crate::vm::PageTableEntry;
+use core::mem;
+
 /// Which hart (core) is this?
 #[inline]
 pub unsafe fn r_mhartid() -> usize {
@@ -403,3 +406,4 @@ pub type PdeT = usize;
 
 /// 512 PTEs
 pub type PagetableT = *mut usize;
+pub const PTESIZE: usize = PGSIZE / mem::size_of::<PageTableEntry>();

--- a/kernel-rs/src/riscv.rs
+++ b/kernel-rs/src/riscv.rs
@@ -1,6 +1,3 @@
-use crate::vm::PageTableEntry;
-use core::mem;
-
 /// Which hart (core) is this?
 #[inline]
 pub unsafe fn r_mhartid() -> usize {
@@ -406,4 +403,3 @@ pub type PdeT = usize;
 
 /// 512 PTEs
 pub type PagetableT = *mut usize;
-pub const PTESIZE: usize = PGSIZE / mem::size_of::<PageTableEntry>();

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -15,7 +15,8 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
     }
     if (*p)
         .pagetable
-        .assume_init_mut().copyin(ip as *mut u8, addr, ::core::mem::size_of::<usize>())
+        .assume_init_mut()
+        .copyin(ip as *mut u8, addr, ::core::mem::size_of::<usize>())
         .is_err()
     {
         return -1;

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -15,7 +15,7 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
     }
     if (*p)
         .pagetable
-        .copyin(ip as *mut u8, addr, ::core::mem::size_of::<usize>())
+        .assume_init_mut().copyin(ip as *mut u8, addr, ::core::mem::size_of::<usize>())
         .is_err()
     {
         return -1;
@@ -27,7 +27,7 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
 /// Returns length of string, not including nul, or -1 for error.
 pub unsafe fn fetchstr(addr: usize, buf: *mut u8, max: usize) -> i32 {
     let p: *mut Proc = myproc();
-    let err = (*p).pagetable.copyinstr(buf, addr, max);
+    let err = (*p).pagetable.assume_init_mut().copyinstr(buf, addr, max);
     if err.is_err() {
         return -1;
     }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -19,7 +19,8 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
         ip as *mut u8,
         addr,
         ::core::mem::size_of::<usize>(),
-    ) != 0
+    )
+    .is_err()
     {
         return -1;
     }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -4,7 +4,6 @@ use crate::{
     string::strlen,
     sysfile::*,
     sysproc::*,
-    vm::{copyin, copyinstr},
 };
 use core::str;
 
@@ -14,8 +13,7 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
     if addr >= (*p).sz || addr.wrapping_add(::core::mem::size_of::<usize>()) > (*p).sz {
         return -1;
     }
-    if copyin(
-        &mut (*p).pagetable,
+    if (*p).pagetable.copyin(
         ip as *mut u8,
         addr,
         ::core::mem::size_of::<usize>(),
@@ -31,7 +29,7 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
 /// Returns length of string, not including nul, or -1 for error.
 pub unsafe fn fetchstr(addr: usize, buf: *mut u8, max: usize) -> i32 {
     let p: *mut Proc = myproc();
-    let err = copyinstr(&mut (*p).pagetable, buf, addr, max);
+    let err = (*p).pagetable.copyinstr(buf, addr, max);
     if err.is_err() {
         return -1;
     }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -13,12 +13,10 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
     if addr >= (*p).sz || addr.wrapping_add(::core::mem::size_of::<usize>()) > (*p).sz {
         return -1;
     }
-    if (*p).pagetable.copyin(
-        ip as *mut u8,
-        addr,
-        ::core::mem::size_of::<usize>(),
-    )
-    .is_err()
+    if (*p)
+        .pagetable
+        .copyin(ip as *mut u8, addr, ::core::mem::size_of::<usize>())
+        .is_err()
     {
         return -1;
     }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -15,7 +15,7 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
         return -1;
     }
     if copyin(
-        (*p).pagetable,
+        &mut (*p).pagetable,
         ip as *mut u8,
         addr,
         ::core::mem::size_of::<usize>(),
@@ -30,7 +30,7 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
 /// Returns length of string, not including nul, or -1 for error.
 pub unsafe fn fetchstr(addr: usize, buf: *mut u8, max: usize) -> i32 {
     let p: *mut Proc = myproc();
-    let err: i32 = copyinstr((*p).pagetable, buf, addr, max);
+    let err: i32 = copyinstr(&mut (*p).pagetable, buf, addr, max);
     if err < 0 {
         return err;
     }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -30,9 +30,9 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
 /// Returns length of string, not including nul, or -1 for error.
 pub unsafe fn fetchstr(addr: usize, buf: *mut u8, max: usize) -> i32 {
     let p: *mut Proc = myproc();
-    let err: i32 = copyinstr(&mut (*p).pagetable, buf, addr, max);
-    if err < 0 {
-        return err;
+    let err = copyinstr(&mut (*p).pagetable, buf, addr, max);
+    if err.is_err() {
+        return -1;
     }
     strlen(buf)
 }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -446,13 +446,15 @@ pub unsafe fn sys_pipe() -> usize {
         fdarray,
         &mut fd0 as *mut i32 as *mut u8,
         mem::size_of::<i32>(),
-    ) < 0
+    )
+    .is_err()
         || copyout(
             &mut (*p).pagetable,
             fdarray.wrapping_add(mem::size_of::<i32>()),
             &mut fd1 as *mut i32 as *mut u8,
             mem::size_of::<i32>(),
-        ) < 0
+        )
+        .is_err()
     {
         (*p).open_files[fd0 as usize] = None;
         (*p).open_files[fd1 as usize] = None;

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -18,7 +18,6 @@ use crate::{
     some_or,
     stat::{T_DEVICE, T_DIR, T_FILE},
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
-    vm::copyout,
 };
 
 use core::mem;
@@ -441,20 +440,22 @@ pub unsafe fn sys_pipe() -> usize {
         return usize::MAX;
     });
 
-    if copyout(
-        &mut (*p).pagetable,
-        fdarray,
-        &mut fd0 as *mut i32 as *mut u8,
-        mem::size_of::<i32>(),
-    )
-    .is_err()
-        || copyout(
-            &mut (*p).pagetable,
-            fdarray.wrapping_add(mem::size_of::<i32>()),
-            &mut fd1 as *mut i32 as *mut u8,
+    if (*p)
+        .pagetable
+        .copyout(
+            fdarray,
+            &mut fd0 as *mut i32 as *mut u8,
             mem::size_of::<i32>(),
         )
         .is_err()
+        || (*p)
+            .pagetable
+            .copyout(
+                fdarray.wrapping_add(mem::size_of::<i32>()),
+                &mut fd1 as *mut i32 as *mut u8,
+                mem::size_of::<i32>(),
+            )
+            .is_err()
     {
         (*p).open_files[fd0 as usize] = None;
         (*p).open_files[fd1 as usize] = None;

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -442,7 +442,7 @@ pub unsafe fn sys_pipe() -> usize {
 
     if (*p)
         .pagetable
-        .copyout(
+        .assume_init_mut().copyout(
             fdarray,
             &mut fd0 as *mut i32 as *mut u8,
             mem::size_of::<i32>(),
@@ -450,7 +450,7 @@ pub unsafe fn sys_pipe() -> usize {
         .is_err()
         || (*p)
             .pagetable
-            .copyout(
+            .assume_init_mut().copyout(
                 fdarray.wrapping_add(mem::size_of::<i32>()),
                 &mut fd1 as *mut i32 as *mut u8,
                 mem::size_of::<i32>(),

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -442,13 +442,13 @@ pub unsafe fn sys_pipe() -> usize {
     });
 
     if copyout(
-        (*p).pagetable,
+        &mut (*p).pagetable,
         fdarray,
         &mut fd0 as *mut i32 as *mut u8,
         mem::size_of::<i32>(),
     ) < 0
         || copyout(
-            (*p).pagetable,
+            &mut (*p).pagetable,
             fdarray.wrapping_add(mem::size_of::<i32>()),
             &mut fd1 as *mut i32 as *mut u8,
             mem::size_of::<i32>(),

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -442,7 +442,8 @@ pub unsafe fn sys_pipe() -> usize {
 
     if (*p)
         .pagetable
-        .assume_init_mut().copyout(
+        .assume_init_mut()
+        .copyout(
             fdarray,
             &mut fd0 as *mut i32 as *mut u8,
             mem::size_of::<i32>(),
@@ -450,7 +451,8 @@ pub unsafe fn sys_pipe() -> usize {
         .is_err()
         || (*p)
             .pagetable
-            .assume_init_mut().copyout(
+            .assume_init_mut()
+            .copyout(
                 fdarray.wrapping_add(mem::size_of::<i32>()),
                 &mut fd1 as *mut i32 as *mut u8,
                 mem::size_of::<i32>(),

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -148,7 +148,7 @@ pub unsafe fn usertrapret() {
     w_sepc((*(*p).tf).epc);
 
     // tell trampoline.S the user page table to switch to.
-    let satp: usize = make_satp((*p).pagetable.assume_init_mut().ptr as usize);
+    let satp: usize = make_satp((*p).pagetable.assume_init_mut().as_raw() as usize);
 
     // jump to trampoline.S at the top of memory, which
     // switches to the user page table, restores user registers,

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -148,7 +148,7 @@ pub unsafe fn usertrapret() {
     w_sepc((*(*p).tf).epc);
 
     // tell trampoline.S the user page table to switch to.
-    let satp: usize = make_satp((*p).pagetable.ptr as usize);
+    let satp: usize = make_satp((*p).pagetable.assume_init_mut().ptr as usize);
 
     // jump to trampoline.S at the top of memory, which
     // switches to the user page table, restores user registers,

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -148,7 +148,7 @@ pub unsafe fn usertrapret() {
     w_sepc((*(*p).tf).epc);
 
     // tell trampoline.S the user page table to switch to.
-    let satp: usize = make_satp((*p).pagetable as usize);
+    let satp: usize = make_satp((*p).pagetable.ptr as usize);
 
     // jump to trampoline.S at the top of memory, which
     // switches to the user page table, restores user registers,

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -213,7 +213,10 @@ impl RawPageTable {
     /// Mark a PTE invalid for user access.
     /// Used by exec for the user stack guard page.
     pub unsafe fn uvmclear(&mut self, va: usize) {
-        PageTable::from_raw(self).walk(va, 0).expect("uvmclear").clear_flag(PTE_U as usize);
+        PageTable::from_raw(self)
+            .walk(va, 0)
+            .expect("uvmclear")
+            .clear_flag(PTE_U as usize);
     }
 
     /// Copy from user to kernel.
@@ -333,11 +336,7 @@ impl PageTable {
     ///   21..39 -- 9 bits of level-1 index.
     ///   12..20 -- 9 bits of level-0 index.
     ///    0..12 -- 12 bits of byte offset within the page.
-    unsafe fn walk(
-        &mut self,
-        va: usize,
-        alloc: i32,
-    ) -> Option<&mut PageTableEntry> {
+    unsafe fn walk(&mut self, va: usize, alloc: i32) -> Option<&mut PageTableEntry> {
         let mut pagetable = &mut *self.as_raw();
         if va >= MAXVA {
             panic!("walk");
@@ -570,7 +569,9 @@ pub unsafe fn kvmmap(va: usize, pa: usize, sz: usize, perm: i32) {
 /// Assumes va is page aligned.
 pub unsafe fn kvmpa(va: usize) -> usize {
     let off: usize = va.wrapping_rem(PGSIZE);
-    let pte = KERNEL_PAGETABLE.assume_init_mut().walk(va, 0)
+    let pte = KERNEL_PAGETABLE
+        .assume_init_mut()
+        .walk(va, 0)
         .filter(|pte| pte.check_flag(PTE_V))
         .expect("kvmpa");
     let pa = pte.as_page() as *const _ as usize;

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -288,7 +288,6 @@ impl RawPageTable {
             }
             new = scopeguard::ScopeGuard::into_inner(new_ptable);
         }
-
         Ok(())
     }
 

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -118,6 +118,7 @@ impl RawPageTable {
     /// Copy from kernel to user.
     /// Copy len bytes from src to virtual address dstva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
+    // TODO: Refactor src to type &[u8]
     pub unsafe fn copyout(
         &mut self,
         mut dstva: usize,

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -33,11 +33,11 @@ impl PageTableEntry {
         self.inner & flag != 0
     }
 
-    fn set_valid(&mut self, flag: usize) {
+    fn set_flag(&mut self, flag: usize) {
         self.inner |= flag;
     }
 
-    fn set_invalid(&mut self, flag: usize) {
+    fn clear_flag(&mut self, flag: usize) {
         self.inner &= !flag;
     }
 
@@ -287,7 +287,7 @@ impl RawPageTable {
         if pte_op.is_none() {
             panic!("uvmclear");
         }
-        pte_op.unwrap().set_invalid(PTE_U as usize)
+        pte_op.unwrap().clear_flag(PTE_U as usize)
     }
 
     /// Copy from kernel to user.
@@ -536,7 +536,7 @@ unsafe fn walk(
 
             ptr::write_bytes(k as *mut libc::CVoid, 0, PGSIZE);
             pte.set_inner(pa2pte(k as usize));
-            pte.set_valid(PTE_V);
+            pte.set_flag(PTE_V);
             pagetable = pte.as_table_mut();
         }
     }

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -26,16 +26,6 @@ pub struct PageTableEntry {
 }
 
 impl PageTableEntry {
-    /// Creates a page table entry from the inner representation.
-    ///
-    /// # Safety
-    ///
-    /// Improper use of this function may lead to memory problems. For example, a double-free may
-    /// occur if the function is called twice on the same raw pointer.
-    unsafe fn from_raw(inner: PteT) -> Self {
-        Self { inner }
-    }
-
     fn check_flag(&self, flag: usize) -> bool {
         self.inner & flag != 0
     }
@@ -62,10 +52,6 @@ impl PageTableEntry {
 
     fn as_page(&self) -> &Page {
         unsafe { &*(pte2pa(self.inner) as *const Page) }
-    }
-
-    unsafe fn as_table(&self) -> &RawPageTable {
-        &*(pte2pa(self.inner) as *const RawPageTable)
     }
 
     unsafe fn as_table_mut(&mut self) -> &mut RawPageTable {

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -198,7 +198,6 @@ pub unsafe fn kvminithart() {
     sfence_vma();
 }
 
-// TODO: replace fn walk to this function after change all pagetables to struct.
 /// Return the address of the PTE in page table pagetable
 /// that corresponds to virtual address va. If alloc!=0,
 /// create any required page-table pages.
@@ -284,7 +283,6 @@ pub unsafe fn kvmpa(va: usize) -> usize {
     pa.wrapping_add(off)
 }
 
-// TODO: replace fn walk to this function after change all pagetables to struct.
 /// Create PTEs for virtual addresses starting at va that refer to
 /// physical addresses starting at pa. va and size might not
 /// be page-aligned. Returns true on success, false if walk() couldn't
@@ -426,9 +424,7 @@ unsafe fn freewalk(pagetable: &mut RawPageTable) {
         let pte = &mut pagetable[i];
         if pte.check_flag(PTE_V) && !pte.check_flag((PTE_R | PTE_W | PTE_X) as usize) {
             // This PTE points to a lower-level page table.
-            // let child = pte.get_pa();
             freewalk(pte.as_table_mut());
-            // *pagetable.offset(i) = 0
             pte.set_inner(0);
         } else if pte.check_flag(PTE_V) {
             panic!("freewalk: leaf");
@@ -464,7 +460,7 @@ pub unsafe fn uvmcopy(old: &mut RawPageTable, mut new: &mut RawPageTable, sz: us
             uvmunmap(ptable, 0, i, 1);
         });
         let pa = pte.get_pa();
-        let flags = pte.get_flags() as u32; //pte_flags(*pte) as u32;
+        let flags = pte.get_flags() as u32;
         let mem = kalloc() as *mut u8;
         if mem.is_null() {
             return -1;

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -83,7 +83,7 @@ impl DerefMut for RawPageTable {
 impl RawPageTable {
     /// Look up a virtual address, return the physical address,
     /// or 0 if not mapped.
-    /// Can only be used to look up user pages.
+    /// TODO: Use type parameter at PageTable to show this function "Can only be used to look up user pages."
     pub unsafe fn walkaddr(&mut self, va: usize) -> Option<usize> {
         if va >= MAXVA {
             return None;

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -92,112 +92,6 @@ impl DerefMut for RawPageTable {
 }
 
 impl RawPageTable {
-    /// Copy from kernel to user.
-    /// Copy len bytes from src to virtual address dstva in a given page table.
-    /// Return Ok(()) on success, Err(()) on error.
-    pub unsafe fn copyout(
-        &mut self,
-        mut dstva: usize,
-        mut src: *mut u8,
-        mut len: usize,
-    ) -> Result<(), ()> {
-        while len > 0 {
-            let va0 = pgrounddown(dstva);
-            let pa0 = self.walkaddr(va0);
-            if pa0 == 0 {
-                return Err(());
-            }
-            let mut n = PGSIZE.wrapping_sub(dstva.wrapping_sub(va0));
-            if n > len {
-                n = len
-            }
-            ptr::copy(
-                src as *const libc::CVoid,
-                pa0.wrapping_add(dstva.wrapping_sub(va0)) as *mut libc::CVoid,
-                n,
-            );
-            len = len.wrapping_sub(n);
-            src = src.add(n);
-            dstva = va0.wrapping_add(PGSIZE);
-        }
-        Ok(())
-    }
-
-    /// Copy from user to kernel.
-    /// Copy len bytes to dst from virtual address srcva in a given page table.
-    /// Return Ok(()) on success, Err(()) on error.
-    pub unsafe fn copyin(
-        &mut self,
-        mut dst: *mut u8,
-        mut srcva: usize,
-        mut len: usize,
-    ) -> Result<(), ()> {
-        while len > 0 {
-            let va0 = pgrounddown(srcva);
-            let pa0 = self.walkaddr(va0);
-            if pa0 == 0 {
-                return Err(());
-            }
-            let mut n = PGSIZE.wrapping_sub(srcva.wrapping_sub(va0));
-            if n > len {
-                n = len
-            }
-            ptr::copy(
-                pa0.wrapping_add(srcva.wrapping_sub(va0)) as *mut libc::CVoid,
-                dst as *mut libc::CVoid,
-                n,
-            );
-            len = len.wrapping_sub(n);
-            dst = dst.add(n);
-            srcva = va0.wrapping_add(PGSIZE)
-        }
-        Ok(())
-    }
-
-    /// Copy a null-terminated string from user to kernel.
-    /// Copy bytes to dst from virtual address srcva in a given page table,
-    /// until a '\0', or max.
-    /// Return OK(()) on success, Err(()) on error.
-    pub unsafe fn copyinstr(
-        &mut self,
-        mut dst: *mut u8,
-        mut srcva: usize,
-        mut max: usize,
-    ) -> Result<(), ()> {
-        let mut got_null: i32 = 0;
-        while got_null == 0 && max > 0 {
-            let va0 = pgrounddown(srcva);
-            let pa0 = self.walkaddr(va0);
-            if pa0 == 0 {
-                return Err(());
-            }
-            let mut n = PGSIZE.wrapping_sub(srcva.wrapping_sub(va0));
-            if n > max {
-                n = max
-            }
-            let mut p: *mut u8 = pa0.wrapping_add(srcva.wrapping_sub(va0)) as *mut u8;
-            while n > 0 {
-                if *p as i32 == '\u{0}' as i32 {
-                    *dst = '\u{0}' as i32 as u8;
-                    got_null = 1;
-                    break;
-                } else {
-                    *dst = *p;
-                    n = n.wrapping_sub(1);
-                    max = max.wrapping_sub(1);
-                    p = p.offset(1);
-                    dst = dst.offset(1)
-                }
-            }
-            srcva = va0.wrapping_add(PGSIZE)
-        }
-        if got_null != 0 {
-            Ok(())
-        } else {
-            Err(())
-        }
-    }
-
     /// Look up a virtual address, return the physical address,
     /// or 0 if not mapped.
     /// Can only be used to look up user pages.
@@ -433,6 +327,111 @@ impl RawPageTable {
         pte_op.unwrap().set_invalid(PTE_U as usize)
     }
 
+    /// Copy from kernel to user.
+    /// Copy len bytes from src to virtual address dstva in a given page table.
+    /// Return Ok(()) on success, Err(()) on error.
+    pub unsafe fn copyout(
+        &mut self,
+        mut dstva: usize,
+        mut src: *mut u8,
+        mut len: usize,
+    ) -> Result<(), ()> {
+        while len > 0 {
+            let va0 = pgrounddown(dstva);
+            let pa0 = self.walkaddr(va0);
+            if pa0 == 0 {
+                return Err(());
+            }
+            let mut n = PGSIZE.wrapping_sub(dstva.wrapping_sub(va0));
+            if n > len {
+                n = len
+            }
+            ptr::copy(
+                src as *const libc::CVoid,
+                pa0.wrapping_add(dstva.wrapping_sub(va0)) as *mut libc::CVoid,
+                n,
+            );
+            len = len.wrapping_sub(n);
+            src = src.add(n);
+            dstva = va0.wrapping_add(PGSIZE);
+        }
+        Ok(())
+    }
+
+    /// Copy from user to kernel.
+    /// Copy len bytes to dst from virtual address srcva in a given page table.
+    /// Return Ok(()) on success, Err(()) on error.
+    pub unsafe fn copyin(
+        &mut self,
+        mut dst: *mut u8,
+        mut srcva: usize,
+        mut len: usize,
+    ) -> Result<(), ()> {
+        while len > 0 {
+            let va0 = pgrounddown(srcva);
+            let pa0 = self.walkaddr(va0);
+            if pa0 == 0 {
+                return Err(());
+            }
+            let mut n = PGSIZE.wrapping_sub(srcva.wrapping_sub(va0));
+            if n > len {
+                n = len
+            }
+            ptr::copy(
+                pa0.wrapping_add(srcva.wrapping_sub(va0)) as *mut libc::CVoid,
+                dst as *mut libc::CVoid,
+                n,
+            );
+            len = len.wrapping_sub(n);
+            dst = dst.add(n);
+            srcva = va0.wrapping_add(PGSIZE)
+        }
+        Ok(())
+    }
+
+    /// Copy a null-terminated string from user to kernel.
+    /// Copy bytes to dst from virtual address srcva in a given page table,
+    /// until a '\0', or max.
+    /// Return OK(()) on success, Err(()) on error.
+    pub unsafe fn copyinstr(
+        &mut self,
+        mut dst: *mut u8,
+        mut srcva: usize,
+        mut max: usize,
+    ) -> Result<(), ()> {
+        let mut got_null: i32 = 0;
+        while got_null == 0 && max > 0 {
+            let va0 = pgrounddown(srcva);
+            let pa0 = self.walkaddr(va0);
+            if pa0 == 0 {
+                return Err(());
+            }
+            let mut n = PGSIZE.wrapping_sub(srcva.wrapping_sub(va0));
+            if n > max {
+                n = max
+            }
+            let mut p: *mut u8 = pa0.wrapping_add(srcva.wrapping_sub(va0)) as *mut u8;
+            while n > 0 {
+                if *p as i32 == '\u{0}' as i32 {
+                    *dst = '\u{0}' as i32 as u8;
+                    got_null = 1;
+                    break;
+                } else {
+                    *dst = *p;
+                    n = n.wrapping_sub(1);
+                    max = max.wrapping_sub(1);
+                    p = p.offset(1);
+                    dst = dst.offset(1)
+                }
+            }
+            srcva = va0.wrapping_add(PGSIZE)
+        }
+        if got_null != 0 {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
 }
 
 pub struct PageTable {
@@ -583,7 +582,6 @@ unsafe fn walk(
     }
     Some(&mut pagetable[px(0, va)])
 }
-
 
 /// Add a mapping to the kernel page table.
 /// Only used when booting.

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -555,19 +555,19 @@ pub unsafe fn copyin(
 /// Copy a null-terminated string from user to kernel.
 /// Copy bytes to dst from virtual address srcva in a given page table,
 /// until a '\0', or max.
-/// Return 0 on success, -1 on error.
+/// Return OK(()) on success, Err(()) on error.
 pub unsafe fn copyinstr(
     pagetable: &mut RawPageTable,
     mut dst: *mut u8,
     mut srcva: usize,
     mut max: usize,
-) -> i32 {
+) -> Result<(), ()> {
     let mut got_null: i32 = 0;
     while got_null == 0 && max > 0 {
         let va0 = pgrounddown(srcva);
         let pa0 = walkaddr(pagetable, va0);
         if pa0 == 0 {
-            return -1;
+            return Err(());
         }
         let mut n = PGSIZE.wrapping_sub(srcva.wrapping_sub(va0));
         if n > max {
@@ -590,8 +590,8 @@ pub unsafe fn copyinstr(
         srcva = va0.wrapping_add(PGSIZE)
     }
     if got_null != 0 {
-        0
+        Ok(())
     } else {
-        -1
+        Err(())
     }
 }

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -523,18 +523,18 @@ pub unsafe fn copyout(
 
 /// Copy from user to kernel.
 /// Copy len bytes to dst from virtual address srcva in a given page table.
-/// Return 0 on success, -1 on error.
+/// Return Ok(()) on success, Err(()) on error.
 pub unsafe fn copyin(
     pagetable: &mut RawPageTable,
     mut dst: *mut u8,
     mut srcva: usize,
     mut len: usize,
-) -> i32 {
+) -> Result<(), ()> {
     while len > 0 {
         let va0 = pgrounddown(srcva);
         let pa0 = walkaddr(pagetable, va0);
         if pa0 == 0 {
-            return -1;
+            return Err(());
         }
         let mut n = PGSIZE.wrapping_sub(srcva.wrapping_sub(va0));
         if n > len {
@@ -549,7 +549,7 @@ pub unsafe fn copyin(
         dst = dst.add(n);
         srcva = va0.wrapping_add(PGSIZE)
     }
-    0
+    Ok(())
 }
 
 /// Copy a null-terminated string from user to kernel.

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -62,13 +62,13 @@ impl PageTableEntry {
     }
 }
 
-const PTSIZE: usize = PGSIZE / mem::size_of::<PageTableEntry>();
+const PTE_PER_PT: usize = PGSIZE / mem::size_of::<PageTableEntry>();
 pub struct RawPageTable {
-    inner: [PageTableEntry; PTSIZE],
+    inner: [PageTableEntry; PTE_PER_PT],
 }
 
 impl Deref for RawPageTable {
-    type Target = [PageTableEntry; PTSIZE];
+    type Target = [PageTableEntry; PTE_PER_PT];
     fn deref(&self) -> &Self::Target {
         &self.inner
     }

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -144,7 +144,7 @@ impl RawPageTable {
     }
 }
 
-// TODO: separate these methods for uvm type/struct
+// TODO: separate these methods for uvm type/struct (Use type to show this)
 impl RawPageTable {
     /// Remove mappings from a page table. The mappings in
     /// the given range must exist. Optionally free the
@@ -313,7 +313,7 @@ impl PageTable {
     }
 }
 
-// TODO: separate these function for va structure later
+// TODO: separate these function for va structure later (Use type to show this)
 impl PageTable {
     /// Create PTEs for virtual addresses starting at va that refer to
     /// physical addresses starting at pa. va and size might not

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -4,7 +4,7 @@ use crate::{
     println,
     riscv::{
         make_satp, pa2pte, pgrounddown, pgroundup, pte2pa, pte_flags, px, sfence_vma, w_satp,
-        PagetableT, PdeT, PteT, MAXVA, PGSIZE, PTESIZE, PTE_R, PTE_U, PTE_V, PTE_W, PTE_X,
+        PagetableT, PdeT, PteT, MAXVA, PGSIZE, PTE_R, PTE_U, PTE_V, PTE_W, PTE_X,
     },
     some_or,
 };
@@ -73,12 +73,13 @@ impl PageTableEntry {
     }
 }
 
+const PTSIZE: usize = PGSIZE / mem::size_of::<PageTableEntry>();
 pub struct RawPageTable {
-    inner: [PageTableEntry; PTESIZE],
+    inner: [PageTableEntry; PTSIZE],
 }
 
 impl Deref for RawPageTable {
-    type Target = [PageTableEntry; PTESIZE];
+    type Target = [PageTableEntry; PTSIZE];
     fn deref(&self) -> &Self::Target {
         &self.inner
     }

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -451,6 +451,7 @@ pub static mut KERNEL_PAGETABLE: MaybeUninit<PageTable> = MaybeUninit::uninit();
 /// turn on paging. Called early, in supervisor mode.
 /// The page allocator is already initialized.
 pub unsafe fn kvminit() {
+    // TODO: make MemoryManager which initiate and own KERNEL_PAGETABLE
     KERNEL_PAGETABLE.write(PageTable::new());
 
     // uart registers

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -492,18 +492,18 @@ pub unsafe fn uvmclear(pagetable: &mut RawPageTable, va: usize) {
 
 /// Copy from kernel to user.
 /// Copy len bytes from src to virtual address dstva in a given page table.
-/// Return 0 on success, -1 on error.
+/// Return Ok(()) on success, Err(()) on error.
 pub unsafe fn copyout(
     pagetable: &mut RawPageTable,
     mut dstva: usize,
     mut src: *mut u8,
     mut len: usize,
-) -> i32 {
+) -> Result<(), ()> {
     while len > 0 {
         let va0 = pgrounddown(dstva);
         let pa0 = walkaddr(pagetable, va0);
         if pa0 == 0 {
-            return -1;
+            return Err(());
         }
         let mut n = PGSIZE.wrapping_sub(dstva.wrapping_sub(va0));
         if n > len {
@@ -518,7 +518,7 @@ pub unsafe fn copyout(
         src = src.add(n);
         dstva = va0.wrapping_add(PGSIZE);
     }
-    0
+    Ok(())
 }
 
 /// Copy from user to kernel.


### PR DESCRIPTION
- all usertest passed
- cargo fmt done
---
- subissue of #195
- vm.rs의 포인터로 되어 있는 `KERNEL_PAGETABLE`을 `PageTableEntry`, `RawPageTable`, `PageTable` struct의 구조로 재구성하였습니다.
---
1. 현재 temp로 되어 있는 `walk_temp`와 같은 함수들을 'walk'대신 사용할 수 있도록 다른 파일에도 수정된 struct 적용
2. 가능한 함수들을 각 struct의 method로 수정
한 후에 merge 가능한 pr로 돌리겠습니다.