### PR TITLE
Clippy  : Uart::new -> Uart::init

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -54,7 +54,7 @@ impl Console {
     }
 
     pub unsafe fn init() {
-        Uart::new();
+        Uart::init();
 
         // Connect read and write system calls
         // to consoleread and consolewrite.

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -58,7 +58,7 @@ impl Uart {
         Uart(())
     }
 
-    pub unsafe fn new() {
+    pub unsafe fn init() {
         // Disable interrupts.
         IER.write(0x00);
 


### PR DESCRIPTION
![Imgur](https://imgur.com/wNIyi44.png)

위 그림과 같이 Clippy 오류가 발생하는 것을 해결했습니다.