### PR TITLE
[subissue of #204] Create ProcessPool & implement methods.

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -2,7 +2,7 @@ use crate::libc;
 use crate::{
     file::{Devsw, DEVSW},
     printf::PANICKED,
-    proc::{either_copyin, either_copyout, myproc, procdump, WaitChannel},
+    proc::{either_copyin, either_copyout, myproc, WaitChannel, PROCPOOL},
     spinlock::{RawSpinlock, Spinlock},
     uart::Uart,
     utils::spin_loop,
@@ -155,7 +155,7 @@ impl Console {
         match cin {
             // Print process list.
             m if m == ctrl('P') => {
-                procdump();
+                PROCPOOL.debug();
             }
 
             // Kill line.

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -2,7 +2,7 @@ use crate::libc;
 use crate::{
     file::{Devsw, DEVSW},
     printf::PANICKED,
-    proc::{either_copyin, either_copyout, myproc, WaitChannel, PROCPOOL},
+    proc::{either_copyin, either_copyout, myproc, WaitChannel, PROCSYS},
     spinlock::{RawSpinlock, Spinlock},
     uart::Uart,
     utils::spin_loop,
@@ -155,7 +155,7 @@ impl Console {
         match cin {
             // Print process list.
             m if m == ctrl('P') => {
-                PROCPOOL.debug();
+                PROCSYS.dump();
             }
 
             // Kill line.

--- a/kernel-rs/src/kernel_main.rs
+++ b/kernel-rs/src/kernel_main.rs
@@ -6,7 +6,7 @@ use crate::{
     plic::{plicinit, plicinithart},
     printf::printfinit,
     println,
-    proc::{cpuid, procinit, scheduler, userinit},
+    proc::{cpuid, init_process_system, scheduler, userinit},
     trap::{trapinit, trapinithart},
     virtio_disk::virtio_disk_init,
     vm::{kvminit, kvminithart},
@@ -35,7 +35,7 @@ pub unsafe fn kernel_main() {
         kvminithart();
 
         // process table
-        procinit();
+        init_process_system();
 
         // trap vectors
         trapinit();

--- a/kernel-rs/src/kernel_main.rs
+++ b/kernel-rs/src/kernel_main.rs
@@ -6,7 +6,7 @@ use crate::{
     plic::{plicinit, plicinithart},
     printf::printfinit,
     println,
-    proc::{cpuid, process_system_init, scheduler, userinit},
+    proc::{cpuid, scheduler, PROCSYS},
     trap::{trapinit, trapinithart},
     virtio_disk::virtio_disk_init,
     vm::{kvminit, kvminithart},
@@ -34,6 +34,9 @@ pub unsafe fn kernel_main() {
         // Turn on paging.
         kvminithart();
 
+        // Process system.
+        PROCSYS.init();
+
         // Trap vectors.
         trapinit();
 
@@ -56,7 +59,7 @@ pub unsafe fn kernel_main() {
         virtio_disk_init();
 
         // First user process.
-        userinit();
+        PROCSYS.user_proc_init();
         STARTED.store(true, Ordering::Release);
     } else {
         while !STARTED.load(Ordering::Acquire) {}

--- a/kernel-rs/src/kernel_main.rs
+++ b/kernel-rs/src/kernel_main.rs
@@ -34,7 +34,7 @@ pub unsafe fn kernel_main() {
         // Turn on paging.
         kvminithart();
 
-        // Process pool.
+        // Process system.
         init_process_pool();
 
         // Trap vectors.

--- a/kernel-rs/src/kernel_main.rs
+++ b/kernel-rs/src/kernel_main.rs
@@ -6,7 +6,7 @@ use crate::{
     plic::{plicinit, plicinithart},
     printf::printfinit,
     println,
-    proc::{cpuid, process_pool_init, scheduler, userinit},
+    proc::{cpuid, process_system_init, scheduler, userinit},
     trap::{trapinit, trapinithart},
     virtio_disk::virtio_disk_init,
     vm::{kvminit, kvminithart},
@@ -33,14 +33,6 @@ pub unsafe fn kernel_main() {
 
         // Turn on paging.
         kvminithart();
-
-<<<<<<< HEAD
-        // Process system.
-        init_process_pool();
-=======
-        // Process pool.
-        process_pool_init();
->>>>>>> init_process_pool to process_pool_init
 
         // Trap vectors.
         trapinit();

--- a/kernel-rs/src/kernel_main.rs
+++ b/kernel-rs/src/kernel_main.rs
@@ -6,7 +6,7 @@ use crate::{
     plic::{plicinit, plicinithart},
     printf::printfinit,
     println,
-    proc::{cpuid, init_process_system, scheduler, userinit},
+    proc::{cpuid, init_process_pool, scheduler, userinit},
     trap::{trapinit, trapinithart},
     virtio_disk::virtio_disk_init,
     vm::{kvminit, kvminithart},
@@ -25,40 +25,40 @@ pub unsafe fn kernel_main() {
         println!("rv6 kernel is booting");
         println!();
 
-        // physical page allocator
+        // Physical page allocator.
         kinit();
 
-        // create kernel page table
+        // Create kernel page table.
         kvminit();
 
-        // turn on paging
+        // Turn on paging.
         kvminithart();
 
-        // process table
-        init_process_system();
+        // Process pool.
+        init_process_pool();
 
-        // trap vectors
+        // Trap vectors.
         trapinit();
 
-        // install kernel trap vector
+        // Install kernel trap vector.
         trapinithart();
 
-        // set up interrupt controller
+        // Set up interrupt controller.
         plicinit();
 
-        // ask PLIC for device interrupts
+        // Ask PLIC for device interrupts.
         plicinithart();
 
-        // buffer cache
+        // Buffer cache.
         binit();
 
-        // inode cache
+        // Inode cache.
         iinit();
 
-        // emulated hard disk
+        // Emulated hard disk.
         virtio_disk_init();
 
-        // first user process
+        // First user process.
         userinit();
         STARTED.store(true, Ordering::Release);
     } else {
@@ -66,13 +66,13 @@ pub unsafe fn kernel_main() {
 
         println!("hart {} starting", cpuid());
 
-        // turn on paging
+        // Turn on paging.
         kvminithart();
 
-        // install kernel trap vector
+        // Install kernel trap vector.
         trapinithart();
 
-        // ask PLIC for device interrupts
+        // Ask PLIC for device interrupts.
         plicinithart();
     }
 

--- a/kernel-rs/src/kernel_main.rs
+++ b/kernel-rs/src/kernel_main.rs
@@ -6,7 +6,7 @@ use crate::{
     plic::{plicinit, plicinithart},
     printf::printfinit,
     println,
-    proc::{cpuid, init_process_pool, scheduler, userinit},
+    proc::{cpuid, process_pool_init, scheduler, userinit},
     trap::{trapinit, trapinithart},
     virtio_disk::virtio_disk_init,
     vm::{kvminit, kvminithart},
@@ -34,8 +34,13 @@ pub unsafe fn kernel_main() {
         // Turn on paging.
         kvminithart();
 
+<<<<<<< HEAD
         // Process system.
         init_process_pool();
+=======
+        // Process pool.
+        process_pool_init();
+>>>>>>> init_process_pool to process_pool_init
 
         // Trap vectors.
         trapinit();

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -553,8 +553,8 @@ pub static mut PROCSYS: ProcessSystem = ProcessSystem::zeroed();
 static mut INITPROC: *mut Proc = ptr::null_mut();
 
 #[no_mangle]
-pub unsafe fn process_pool_init() {
-    PROCPOOL.init();
+pub unsafe fn process_system_init() {
+    PROCSYS.init();
     kvminithart();
 }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -18,7 +18,6 @@ use crate::{
 };
 use core::cmp::Ordering;
 use core::ptr;
-use core::result::Result;
 use core::str;
 
 extern "C" {
@@ -418,9 +417,9 @@ impl Proc {
             *file = None;
         }
         begin_op();
-        (*(*self).cwd).put();
+        (*self.cwd).put();
         end_op();
-        (*self).cwd = ptr::null_mut();
+        self.cwd = ptr::null_mut();
     }
 }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -453,7 +453,7 @@ impl ProcessPool {
 
     /// Pass p's abandoned children to init.
     /// Caller must hold p->lock.
-    pub unsafe fn init_parent(&mut self, p: *mut Proc) {
+    unsafe fn init_parent(&mut self, p: *mut Proc) {
         for pp in self.process.iter_mut() {
             // This code uses pp->parent without holding pp->lock.
             // Acquiring the lock first could cause a deadlock
@@ -505,7 +505,7 @@ impl ProcessPool {
             p.lock.release();
         }
     }
-    pub fn run_processes(&mut self, c: *mut Cpu) {
+    fn run_processes(&mut self, c: *mut Cpu) {
         for p in self.process.iter_mut() {
             p.lock.acquire();
             if p.state == Procstate::RUNNABLE {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -424,8 +424,8 @@ impl ProcessSystem {
     /// Look in the process system for an UNUSED proc.
     /// If found, initialize state required to run in the kernel,
     /// and return with p->lock held.
-    /// If there are no free procs, return 0.
-    unsafe fn alloc(&mut self) -> *mut Proc {
+    /// If there are no free procs, return ptr::null_mut().
+    unsafe fn alloc_proc(&mut self) -> *mut Proc {
         for p in self.process.iter_mut() {
             p.lock.acquire();
             if p.state == Procstate::UNUSED {
@@ -664,7 +664,7 @@ static mut INITCODE: [u8; 51] = [
 
 /// Set up first user process.
 pub unsafe fn userinit() {
-    let mut p = PROCSYS.alloc();
+    let mut p = PROCPOOL.alloc_proc();
     INITPROC = p;
 
     // Allocate one user page and copy init's instructions
@@ -719,7 +719,7 @@ pub unsafe fn fork() -> i32 {
     let p = myproc();
 
     // Allocate process.
-    let mut np = PROCSYS.alloc();
+    let mut np = PROCPOOL.alloc_proc();
     if np.is_null() {
         return -1;
     }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -397,7 +397,7 @@ impl Proc {
 
 static mut CPUS: [Cpu; NCPU] = [Cpu::zeroed(); NCPU];
 
-/// System containing & managing whole processes.
+/// Process System type containing & managing whole processes.
 struct ProcessSystem {
     process: [Proc; NPROC],
 }
@@ -425,14 +425,17 @@ impl ProcessSystem {
             p.kstack = va;
         }
     }
+
+
 }
 
+/// Current Process System.
 static mut PROC: ProcessSystem = ProcessSystem::zeroed();
 
 static mut INITPROC: *mut Proc = ptr::null_mut();
 
 #[no_mangle]
-pub unsafe fn procinit() {
+pub unsafe fn init_process_system() {
     PROC.init();
     kvminithart();
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -385,11 +385,11 @@ impl Proc {
             name: [0; 16],
         }
     }
-    
+
     /// Allocate a page for the process's kernel stack.
     /// Map it high in memory, followed by an invalid
     /// guard page.
-    unsafe fn palloc(&mut self, i: usize) {    
+    unsafe fn palloc(&mut self, i: usize) {
         let pa = kalloc() as *mut u8;
         if pa.is_null() {
             panic!("kalloc");
@@ -553,8 +553,8 @@ pub static mut PROCSYS: ProcessSystem = ProcessSystem::zeroed();
 static mut INITPROC: *mut Proc = ptr::null_mut();
 
 #[no_mangle]
-pub unsafe fn init_process_pool() {
-    PROCSYS.init();
+pub unsafe fn process_pool_init() {
+    PROCPOOL.init();
     kvminithart();
 }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -550,7 +550,7 @@ pub static mut PROCPOOL: ProcessPool = ProcessPool::zeroed();
 static mut INITPROC: *mut Proc = ptr::null_mut();
 
 #[no_mangle]
-pub unsafe fn init_process_system() {
+pub unsafe fn init_process_pool() {
     PROCPOOL.init();
     kvminithart();
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -508,7 +508,7 @@ impl ProcessSystem {
             p.lock.release();
         }
     }
-    fn run_processes(&mut self, c: *mut Cpu) {
+    unsafe fn run_processes(&mut self, c: *mut Cpu) {
         for p in self.process.iter_mut() {
             p.lock.acquire();
             if p.state == Procstate::RUNNABLE {
@@ -516,14 +516,12 @@ impl ProcessSystem {
                 // to release its lock and then reacquire it
                 // before jumping back to us.
                 p.state = Procstate::RUNNING;
-                unsafe {
-                    (*c).proc = p;
-                    swtch(&mut (*c).scheduler, &mut p.context);
+                (*c).proc = p;
+                swtch(&mut (*c).scheduler, &mut p.context);
 
-                    // Process is done running for now.
-                    // It should have changed its p->state before coming back.
-                    (*c).proc = ptr::null_mut()
-                }
+                // Process is done running for now.
+                // It should have changed its p->state before coming back.
+                (*c).proc = ptr::null_mut()
             }
             p.lock.release();
         }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,6 +1,6 @@
 use crate::{
     ok_or,
-    proc::{fork, myproc, resizeproc, wait, PROCSYS},
+    proc::{myproc, resizeproc, PROCSYS},
     syscall::{argaddr, argint},
     trap::{TICKS, TICKSLOCK, TICKSWAITCHANNEL},
 };
@@ -17,12 +17,12 @@ pub unsafe fn sys_getpid() -> usize {
 }
 
 pub unsafe fn sys_fork() -> usize {
-    fork() as _
+    PROCSYS.fork() as _
 }
 
 pub unsafe fn sys_wait() -> usize {
     let p = ok_or!(argaddr(0), return usize::MAX);
-    wait(p) as _
+    PROCSYS.wait(p) as _
 }
 
 pub unsafe fn sys_sbrk() -> usize {

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,6 +1,6 @@
 use crate::{
     ok_or,
-    proc::{exit, fork, myproc, resizeproc, wait, PROCPOOL},
+    proc::{exit, fork, myproc, resizeproc, wait, PROCSYS},
     syscall::{argaddr, argint},
     trap::{TICKS, TICKSLOCK, TICKSWAITCHANNEL},
 };
@@ -51,7 +51,7 @@ pub unsafe fn sys_sleep() -> usize {
 
 pub unsafe fn sys_kill() -> usize {
     let pid = ok_or!(argint(0), return usize::MAX);
-    PROCPOOL.kill_process(pid) as usize
+    PROCSYS.kill(pid) as usize
 }
 
 /// return how many clock tick interrupts have occurred

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,13 +1,13 @@
 use crate::{
     ok_or,
-    proc::{exit, fork, myproc, resizeproc, wait, PROCSYS},
+    proc::{fork, myproc, resizeproc, wait, PROCSYS},
     syscall::{argaddr, argint},
     trap::{TICKS, TICKSLOCK, TICKSWAITCHANNEL},
 };
 
 pub unsafe fn sys_exit() -> usize {
     let n = ok_or!(argint(0), return usize::MAX);
-    exit(n);
+    PROCSYS.exit_current(n);
 
     panic!("sys_exit: not reached");
 }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,6 +1,6 @@
 use crate::{
     ok_or,
-    proc::{exit, fork, PROCPOOL, myproc, resizeproc, wait},
+    proc::{exit, fork, myproc, resizeproc, wait, PROCPOOL},
     syscall::{argaddr, argint},
     trap::{TICKS, TICKSLOCK, TICKSWAITCHANNEL},
 };

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,6 +1,6 @@
 use crate::{
     ok_or,
-    proc::{exit, fork, kill, myproc, resizeproc, wait},
+    proc::{exit, fork, PROCPOOL, myproc, resizeproc, wait},
     syscall::{argaddr, argint},
     trap::{TICKS, TICKSLOCK, TICKSWAITCHANNEL},
 };
@@ -51,7 +51,7 @@ pub unsafe fn sys_sleep() -> usize {
 
 pub unsafe fn sys_kill() -> usize {
     let pid = ok_or!(argint(0), return usize::MAX);
-    kill(pid) as usize
+    PROCPOOL.kill_process(pid) as usize
 }
 
 /// return how many clock tick interrupts have occurred

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -2,7 +2,7 @@ use crate::{
     memlayout::{TRAMPOLINE, TRAPFRAME, UART0_IRQ, VIRTIO0_IRQ},
     plic::{plic_claim, plic_complete},
     println,
-    proc::{cpuid, exit, myproc, proc_yield, Proc, Procstate, WaitChannel},
+    proc::{cpuid, myproc, proc_yield, Proc, Procstate, WaitChannel, PROCSYS},
     riscv::{
         intr_get, intr_off, intr_on, make_satp, r_satp, r_scause, r_sepc, r_sip, r_stval, r_tp,
         w_sepc, w_sip, w_stvec, Sstatus, PGSIZE,
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn usertrap() {
         // system call
 
         if (*p).killed {
-            exit(-1);
+            PROCSYS.exit_current(-1);
         }
 
         // sepc points to the ecall instruction,
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn usertrap() {
     }
 
     if (*p).killed {
-        exit(-1);
+        PROCSYS.exit_current(-1);
     }
 
     // give up the CPU if this is a timer interrupt.


### PR DESCRIPTION
- make / usertests / hart message / fmt
- 기존에 PROC으로 나타내던 Process들의 pool을 ProcessPool type으로 변경하고 global PROCPOOL을 선언.
- 해당하는 함수들을 ProcessPool의 method로 implement

@efenniht 
- wait의 경우 Proc을 refactoring 하면서 조금 더 생각해봐야 할 것 같습니다.

- 이어서 Proc, CpuPool, Cpu, Context 등에 대한 수정을 진행하도록 하겠습니다.