### PR TITLE
Turn on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ addons:
   apt:
     packages:
       - gcc-riscv64-linux-gnu
-      - qemu-system-misc
+      - qemu-system-misc=1:4.2-3ubuntu6
 install:
   - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
   - source $HOME/.cargo/env
   - rustup component add rust-src
 script:
  - cargo fmt --manifest-path=kernel-rs/Cargo.toml -- --check -l
- - make
+ - make qemu USERTEST=yes
+ - rm fs.img ; make qemu USERTEST=yes RUST_MODE=release

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ install:
   - source $HOME/.cargo/env
   - rustup component add rust-src
 script:
- - cargo fmt --manifest-path=kernel-rs/Cargo.toml -- --check -l
- - make qemu USERTEST=yes RUST_MODE=release
+  - cargo fmt --manifest-path=kernel-rs/Cargo.toml -- --check -l
+  - cargo clippy --manifest-path=kernel-rs/Cargo.toml
+  - make qemu USERTEST=yes RUST_MODE=release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+os: linux
+dist: focal
+addons:
+  apt:
+    packages:
+      - gcc-riscv64-linux-gnu
+      - qemu-system-misc
+install:
+  - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+  - source $HOME/.cargo/env
+  - rustup component add rust-src
+script:
+ - cargo fmt --manifest-path=kernel-rs/Cargo.toml -- --check -l
+ - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ install:
   - rustup component add rust-src
 script:
  - cargo fmt --manifest-path=kernel-rs/Cargo.toml -- --check -l
- - make qemu USERTEST=yes
- - rm fs.img ; make qemu USERTEST=yes RUST_MODE=release
+ - make qemu USERTEST=yes RUST_MODE=release

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax
 CFLAGS += -I.
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 
+ifeq ($(USERTEST),yes)
+CFLAGS += -DUSERTEST
+endif
+
 # Disable PIE when possible (for Ubuntu 16.10 toolchain)
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)
 CFLAGS += -fno-pie -no-pie

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -98,6 +98,9 @@ impl Console {
         }
     }
 
+    // TODO: This should be removed after `WaitChannel::sleep` gets refactored to take
+    // `SpinLockGuard`.
+    #[allow(clippy::while_immutable_condition)]
     unsafe fn read(
         &mut self,
         user_dst: i32,

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -43,6 +43,7 @@ mod param;
 mod pipe;
 mod plic;
 mod pool;
+mod poweroff;
 mod printf;
 mod proc;
 mod riscv;

--- a/kernel-rs/src/memlayout.rs
+++ b/kernel-rs/src/memlayout.rs
@@ -17,6 +17,9 @@
 //! PHYSTOP -- end RAM used by the kernel
 use crate::riscv::{MAXVA, PGSIZE};
 
+/// SiFive Test Finisher. (virt device only)
+pub const FINISHER: usize = 0x100000;
+
 /// qemu puts UART registers here in physical memory.
 pub const UART0: usize = 0x10000000;
 pub const UART0_IRQ: usize = 10;

--- a/kernel-rs/src/poweroff.rs
+++ b/kernel-rs/src/poweroff.rs
@@ -1,5 +1,5 @@
-use core::ptr;
 use crate::memlayout;
+use core::ptr;
 
 /// Shutdowns this machine, discarding all unsaved data.
 ///

--- a/kernel-rs/src/poweroff.rs
+++ b/kernel-rs/src/poweroff.rs
@@ -1,0 +1,20 @@
+use core::ptr;
+use crate::memlayout;
+
+/// Shutdowns this machine, discarding all unsaved data.
+///
+/// This function uses SiFive Test Finalizer, which provides power management for QEMU virt device.
+pub fn machine_poweroff(exitcode: u16) -> ! {
+    const BASE_CODE: u64 = 0x3333;
+    let code = ((exitcode as u64) << 16) | BASE_CODE;
+    // SAFETY:
+    // - FINISHER is identically mapped from physical address.
+    // - FINISHER is for MMIO. Though this is not specified as document, see the implementation:
+    // https://github.com/qemu/qemu/blob/stable-5.0/hw/riscv/virt.c#L60 and,
+    // https://github.com/qemu/qemu/blob/stable-5.0/hw/riscv/sifive_test.c#L34
+    unsafe {
+        ptr::write_volatile(memlayout::FINISHER as *mut u64, code);
+    }
+
+    unreachable!("Power off failed");
+}

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -33,6 +33,9 @@ impl<T> SleeplockWIP<T> {
         self.data.into_inner()
     }
 
+    // TODO: This should be removed after `WaitChannel::sleep` gets refactored to take
+    // `SpinLockGuard`.
+    #[allow(clippy::while_immutable_condition)]
     pub unsafe fn lock(&self) -> SleepLockGuard<'_, T> {
         let mut guard = self.spinlock.lock();
         while *guard != -1 {

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -68,7 +68,7 @@ pub unsafe fn argstr(n: usize, buf: *mut u8, max: usize) -> Result<i32, ()> {
     Ok(fetchstr(addr, buf, max))
 }
 
-static mut SYSCALLS: [Option<unsafe fn() -> usize>; 22] = [
+static mut SYSCALLS: [Option<unsafe fn() -> usize>; 23] = [
     None,
     Some(sys_fork as unsafe fn() -> usize),
     Some(sys_exit as unsafe fn() -> usize),
@@ -91,6 +91,7 @@ static mut SYSCALLS: [Option<unsafe fn() -> usize>; 22] = [
     Some(sys_link as unsafe fn() -> usize),
     Some(sys_mkdir as unsafe fn() -> usize),
     Some(sys_close as unsafe fn() -> usize),
+    Some(sys_poweroff as unsafe fn() -> usize),
 ];
 
 pub unsafe fn syscall() {

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -3,6 +3,7 @@ use crate::{
     proc::{myproc, resizeproc, PROCSYS},
     syscall::{argaddr, argint},
     trap::{TICKS, TICKSLOCK, TICKSWAITCHANNEL},
+    poweroff,
 };
 
 pub unsafe fn sys_exit() -> usize {
@@ -61,4 +62,9 @@ pub unsafe fn sys_uptime() -> usize {
     let xticks: u32 = TICKS;
     TICKSLOCK.release();
     xticks as usize
+}
+
+pub unsafe fn sys_poweroff() -> usize {
+    let exitcode = ok_or!(argint(0), return usize::MAX);
+    poweroff::machine_poweroff(exitcode as _);
 }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,9 +1,8 @@
 use crate::{
-    ok_or,
+    ok_or, poweroff,
     proc::{myproc, resizeproc, PROCSYS},
     syscall::{argaddr, argint},
     trap::{TICKS, TICKSLOCK, TICKSWAITCHANNEL},
-    poweroff,
 };
 
 pub unsafe fn sys_exit() -> usize {

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -302,6 +302,8 @@ pub unsafe fn virtio_disk_init() {
     // plic.c and trap.c arrange for interrupts from VIRTIO0_IRQ.
 }
 
+// TODO: This should be removed after `WaitChannel::sleep` gets refactored to take `SpinLockGuard`.
+#[allow(clippy::while_immutable_condition)]
 pub unsafe fn virtio_disk_rw(b: *mut Buf, write: bool) {
     let sector: usize = (*b).blockno.wrapping_mul((BSIZE / 512) as u32) as _;
 

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -2,7 +2,7 @@ use mem::MaybeUninit;
 
 use crate::{
     kalloc::{kalloc, kfree},
-    memlayout::{CLINT, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, UART0, VIRTIO0},
+    memlayout::{CLINT, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, UART0, VIRTIO0},
     println,
     riscv::{
         make_satp, pa2pte, pgrounddown, pgroundup, pte2pa, pte_flags, px, sfence_vma, w_satp, PteT,
@@ -504,6 +504,9 @@ pub static mut KERNEL_PAGETABLE: MaybeUninit<PageTable> = MaybeUninit::uninit();
 pub unsafe fn kvminit() {
     // TODO: make MemoryManager which initiate and own KERNEL_PAGETABLE
     KERNEL_PAGETABLE.write(PageTable::new());
+
+    // SiFive Test Finisher MMIO
+    kvmmap(FINISHER, FINISHER, PGSIZE, PTE_R | PTE_W);
 
     // uart registers
     kvmmap(UART0, UART0, PGSIZE, PTE_R | PTE_W);

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_poweroff    22

--- a/user/init.c
+++ b/user/init.c
@@ -5,12 +5,16 @@
 #include "user/user.h"
 #include "kernel/fcntl.h"
 
+#ifdef USERTEST
+char *argv[] = { "usertests", 0 };
+#else
 char *argv[] = { "sh", 0 };
+#endif
 
 int
 main(void)
 {
-  int pid, wpid;
+  int pid, wpid, xstate;
 
   if(open("console", O_RDWR) < 0){
     mknod("console", 1, 1);
@@ -20,19 +24,22 @@ main(void)
   dup(0);  // stderr
 
   for(;;){
-    printf("init: starting sh\n");
+    printf("init: starting %s\n", argv[0]);
     pid = fork();
     if(pid < 0){
       printf("init: fork failed\n");
       exit(1);
     }
     if(pid == 0){
-      exec("sh", argv);
-      printf("init: exec sh failed\n");
+      exec(argv[0], argv);
+      printf("init: exec %s failed\n", argv[0]);
       exit(1);
     }
-    while((wpid=wait(0)) >= 0 && wpid != pid){
+    while((wpid=wait(&xstate)) >= 0 && wpid != pid){
       //printf("zombie!\n");
     }
+#ifdef USERTEST
+    poweroff(xstate);
+#endif
   }
 }

--- a/user/user.h
+++ b/user/user.h
@@ -23,6 +23,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int poweroff(int) __attribute__((noreturn));
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -2193,5 +2193,5 @@ main(int argc, char *argv[])
     printf("ALL TESTS PASSED\n");
   else
     printf("SOME TESTS FAILED\n");
-  exit(1);   // not reached.
+  exit(fail);
 }

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("poweroff");


### PR DESCRIPTION
Closes #17 

Travis CI 를 이용하여 PR 이 머지되기 전에 자동으로 1) formatting 이 되었는 지, 2) clippy 오류가 없는 지, 3) usertests가 성공적으로 작동하는 지 테스트합니다. 이를 위해:
 - 현재 테스트 환경 (QEMU virt device) 에서 poweroff 를 하는 함수와 시스템 콜을 추가했습니다.
 - `init` 이 `sh` 를 실행할 지 `usertests` 를 실행할 지 컴파일 타임에 결정할 수 있게 만들었습니다.
 - `init` 이 `usertests` 를 실행하는 경우 테스트가 종료하는 대로 poweroff를 하여 timeout 이 나지 않고 성공하도록 합니다.

Travis CI free-tier 는 cpu가 느려서, debug profile로 테스트하는 경우 timeout 이 납니다. 그래서 release profile 로 테스트하도록 설정했습니다.

이 PR 을 머지하시고 @jeehoonkang 교수님께서 Travis 를 연동해 주시면 이후 PR 에서 사용할 수 있습니다.