### PR TITLE
Use SleeplockWIP<Inode> (related to #218)

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -33,15 +33,15 @@ pub unsafe fn exec(path: &Path, argv: *mut *mut u8) -> Result<usize, ()> {
     });
 
     // Check ELF header
-    if !({
-        let x = ip_inodeguard.read(
+    if !(ip_inodeguard
+        .read(
             0,
             &mut elf as *mut ElfHdr as usize,
             0,
             ::core::mem::size_of::<ElfHdr>() as u32,
-        );
-        x.is_err() || x.unwrap() == ::core::mem::size_of::<ElfHdr>()
-    } && elf.magic == ELF_MAGIC)
+        )
+        .map_or(true, |v| v == ::core::mem::size_of::<ElfHdr>())
+        && elf.magic == ELF_MAGIC)
     {
         return Err(());
     }
@@ -63,15 +63,15 @@ pub unsafe fn exec(path: &Path, argv: *mut *mut u8) -> Result<usize, ()> {
             .phoff
             .wrapping_add(i * ::core::mem::size_of::<ProgHdr>());
 
-        if {
-            let x = ip_inodeguard.read(
+        if ip_inodeguard
+            .read(
                 0,
                 &mut ph as *mut ProgHdr as usize,
                 off as u32,
                 ::core::mem::size_of::<ProgHdr>() as u32,
-            );
-            x.is_err() || x.unwrap() != ::core::mem::size_of::<ProgHdr>()
-        } {
+            )
+            .map_or(true, |v| v != ::core::mem::size_of::<ProgHdr>())
+        {
             return Err(());
         }
         if ph.typ == ELF_PROG_LOAD {
@@ -226,10 +226,10 @@ impl InodeGuard<'_> {
                 PGSIZE as u32
             };
 
-            if {
-                let x = self.read(0, pa, offset.wrapping_add(i), n);
-                x.is_err() || x.unwrap() as u32 != n
-            } {
+            if self
+                .read(0, pa, offset.wrapping_add(i), n)
+                .map_or(true, |v| v as u32 != n)
+            {
                 return Err(());
             }
         }

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -25,7 +25,7 @@ pub unsafe fn exec(path: &Path, argv: *mut *mut u8) -> Result<usize, ()> {
         end_op();
         return Err(());
     });
-    let ip = (*ip).lock(ip);
+    let ip = (*ip).lock();
     let mut ip = scopeguard::guard(ip, |ip| {
         ip.unlockput();
         end_op();

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -25,10 +25,7 @@ pub unsafe fn exec(path: &Path, argv: *mut *mut u8) -> Result<usize, ()> {
         end_op();
         return Err(());
     });
-    let ip = InodeGuard {
-        guard: (*ip).lock(),
-        ptr: ip,
-    };
+    let ip = (*ip).lock(ip);
     let mut ip = scopeguard::guard(ip, |ip| {
         ip.unlockput();
         end_op();

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -139,13 +139,10 @@ impl File {
     /// addr is a user virtual address, pointing to a struct stat.
     pub unsafe fn stat(&mut self, addr: usize) -> Result<(), ()> {
         let p: *mut Proc = myproc();
-        let mut st: Stat = Default::default();
 
         match self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
-                let ip = (*ip).lock();
-                ip.stati(&mut st);
-                drop(ip);
+                let mut st = (*ip).lock().stat();
                 if (*p)
                     .pagetable
                     .assume_init_mut()

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use core::cmp;
 use core::convert::TryFrom;
+use core::ops::{Deref, DerefMut};
 
 pub struct File {
     pub typ: FileType,
@@ -26,6 +27,20 @@ pub struct InodeGuard<'a> {
     pub guard: SleepLockGuard<'a, InodeInner>,
     pub ptr: *mut Inode,
 }
+
+impl Deref for InodeGuard<'_> {
+    type Target = InodeInner;
+    fn deref(&self) -> &Self::Target {
+        &*self.guard
+    }
+}
+
+impl DerefMut for InodeGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.guard
+    }
+}
+
 pub struct InodeInner {
     /// copy of disk inode
     pub typ: i16,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -150,9 +150,9 @@ impl File {
                     ptr: *ip,
                 };
                 let ret = ip.read(1, addr, *off, n as u32);
-                ret.map(|v| {
+                if let Ok(v) = ret {
                     *off = off.wrapping_add(v as u32);
-                })?;
+                }
                 ip.unlock();
                 ret
             }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -48,7 +48,7 @@ pub struct Inode {
     pub ref_0: i32,
 
     /// inode has been read from disk?
-    pub valid: i32,
+    pub valid: bool,
 
     // pub inner: InodeInner,
     pub inner: SleeplockWIP<InodeInner>,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -197,15 +197,15 @@ impl File {
                         *off,
                         bytes_to_write as u32,
                     );
-                    if r > 0 {
-                        *off = off.wrapping_add(r as u32);
+                    if r.is_ok() {
+                        *off = off.wrapping_add(r.unwrap() as u32);
                     }
                     ip_inodeguard.unlock();
                     end_op();
-                    if r < 0 {
+                    if r.is_err() {
                         return Err(());
                     }
-                    if r != bytes_to_write {
+                    if r.unwrap() != bytes_to_write as usize {
                         panic!("short File::write");
                     }
                 }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -22,17 +22,7 @@ pub struct File {
 // TODO: will be infered as we wrap *mut Pipe and *mut Inode.
 unsafe impl Send for File {}
 
-/// in-memory copy of an inode
-pub struct Inode {
-    /// Device number
-    pub dev: u32,
-
-    /// Inode number
-    pub inum: u32,
-
-    /// Reference count
-    pub ref_0: i32,
-
+pub struct InodeInner {
     /// protects everything below here
     pub lock: Sleeplock,
 
@@ -46,6 +36,20 @@ pub struct Inode {
     pub nlink: i16,
     pub size: u32,
     pub addrs: [u32; 13],
+}
+
+/// in-memory copy of an inode
+pub struct Inode {
+    /// Device number
+    pub dev: u32,
+
+    /// Inode number
+    pub inum: u32,
+
+    /// Reference count
+    pub ref_0: i32,
+
+    pub inner: InodeInner,
 }
 
 pub enum FileType {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -200,12 +200,13 @@ impl File {
                         .map(|v| {
                             *off = off.wrapping_add(v as u32);
                             v
-                        })?;
+                        });
                     ip.unlock();
                     end_op();
-                    if bytes_written != bytes_to_write as usize {
-                        panic!("short File::write");
-                    }
+                    assert!(
+                        bytes_written? == bytes_to_write as usize,
+                        "short File::write"
+                    );
                 }
                 Ok(n as usize)
             }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -146,7 +146,7 @@ impl File {
 
         match self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
-                let ip = (*ip).lock(ip);
+                let ip = (*ip).lock();
                 ip.stati(&mut st);
                 drop(ip);
                 if (*p)
@@ -179,7 +179,7 @@ impl File {
         match &mut self.typ {
             FileType::Pipe { pipe } => pipe.read(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
-                let mut ip = (**ip).lock(*ip);
+                let mut ip = (**ip).lock();
                 let ret = ip.read(1, addr, *off, n as u32);
                 if let Ok(v) = ret {
                     *off = off.wrapping_add(v as u32);
@@ -216,7 +216,7 @@ impl File {
                 for bytes_written in (0..n).step_by(max) {
                     let bytes_to_write = cmp::min(n - bytes_written, max as i32);
                     begin_op();
-                    let mut ip = (**ip).lock(*ip);
+                    let mut ip = (**ip).lock();
 
                     let bytes_written = ip
                         .write(

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -151,11 +151,11 @@ impl File {
                     ptr: *ip,
                 };
                 let r = ip_inodeguard.read(1, addr, *off, n as u32);
-                if r > 0 {
-                    *off = off.wrapping_add(r as u32);
+                if r.is_ok() {
+                    *off = off.wrapping_add(r.unwrap() as u32);
                 }
                 ip_inodeguard.unlock();
-                Ok(r as usize)
+                r
             }
             FileType::Device { major, .. } => DEVSW
                 .get(*major as usize)

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -62,6 +62,8 @@ impl Drop for InodeGuard<'_> {
 }
 
 pub struct InodeInner {
+    /// inode has been read from disk?
+    pub valid: bool,
     /// copy of disk inode
     pub typ: i16,
     pub major: u16,
@@ -81,9 +83,6 @@ pub struct Inode {
 
     /// Reference count
     pub ref_0: i32,
-
-    /// inode has been read from disk?
-    pub valid: bool,
 
     pub inner: SleeplockWIP<InodeInner>,
 }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -27,8 +27,7 @@ unsafe impl Send for File {}
 ///
 /// # Invariant
 ///
-/// `guard` should contain Some(_) when InodeGuard is used.
-/// The fields in InodeInner are meaningful only when `guard` contains Some(_). (not None)
+/// When SleeplockWIP<InodeInner> is held, InodeInner's valid is always true.
 pub struct InodeGuard<'a> {
     guard: SleepLockGuard<'a, InodeInner>,
     pub ptr: &'a Inode,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -31,11 +31,11 @@ unsafe impl Send for File {}
 /// and inode's valid is always true.
 pub struct InodeGuard<'a> {
     guard: SleepLockGuard<'a, InodeInner>,
-    pub ptr: *mut Inode,
+    pub ptr: &'a Inode,
 }
 
 impl<'a> InodeGuard<'a> {
-    pub const fn new(guard: SleepLockGuard<'a, InodeInner>, ptr: *mut Inode) -> Self {
+    pub const fn new(guard: SleepLockGuard<'a, InodeInner>, ptr: &'a Inode) -> Self {
         Self { guard, ptr }
     }
 }
@@ -57,9 +57,7 @@ impl DerefMut for InodeGuard<'_> {
 impl Drop for InodeGuard<'_> {
     fn drop(&mut self) {
         // TODO: Reasoning why.
-        unsafe {
-            assert!((*self.ptr).ref_0 >= 1, "Inode::drop");
-        }
+        assert!(self.ptr.ref_0 >= 1, "Inode::drop");
     }
 }
 

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -109,10 +109,7 @@ impl File {
 
         match self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
-                let ip = InodeGuard {
-                    guard: (*ip).lock(),
-                    ptr: ip,
-                };
+                let ip = (*ip).lock(ip);
                 ip.stati(&mut st);
                 ip.unlock();
                 if (*p)
@@ -145,10 +142,7 @@ impl File {
         match &mut self.typ {
             FileType::Pipe { pipe } => pipe.read(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
-                let mut ip = InodeGuard {
-                    guard: (**ip).lock(),
-                    ptr: *ip,
-                };
+                let mut ip = (**ip).lock(*ip);
                 let ret = ip.read(1, addr, *off, n as u32);
                 if let Ok(v) = ret {
                     *off = off.wrapping_add(v as u32);
@@ -185,10 +179,7 @@ impl File {
                 for bytes_written in (0..n).step_by(max) {
                     let bytes_to_write = cmp::min(n - bytes_written, max as i32);
                     begin_op();
-                    let mut ip = InodeGuard {
-                        guard: (**ip).lock(),
-                        ptr: *ip,
-                    };
+                    let mut ip = (**ip).lock(*ip);
 
                     let bytes_written = ip
                         .write(

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -27,8 +27,8 @@ unsafe impl Send for File {}
 ///
 /// # Invariant
 ///
-/// When SleeplockWIP<Inode> is held, there is allocated space in Buf cache to store the content of inode,
-/// and inode's valid is always true.
+/// `guard` should contain Some(_) when InodeGuard is used.
+/// The fields in InodeInner are meaningful only when `guard` contains Some(_). (not None)
 pub struct InodeGuard<'a> {
     guard: SleepLockGuard<'a, Option<InodeInner>>,
     pub ptr: &'a Inode,

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -469,7 +469,7 @@ impl Inode {
     pub unsafe fn lock(&self) -> InodeGuard<'_> {
         assert!(self.ref_0 >= 1, "Inode::lock");
         let mut guard = self.inner.lock();
-        if !self.inner.get_mut_unchecked().valid {
+        if !guard.valid {
             let bp: *mut Buf = Buf::read(self.dev, SB.iblock(self.inum));
             let dip: *mut Dinode = ((*bp).inner.data.as_mut_ptr() as *mut Dinode)
                 .add((self.inum as usize).wrapping_rem(IPB));

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -242,7 +242,7 @@ impl Inode {
             );
             brelease(&mut *bp);
             (*self).valid = 1;
-            if (*self).typ as i32 == 0 {
+            if (*self).typ == 0 {
                 panic!("Inode::lock: no type");
             }
         };
@@ -468,7 +468,7 @@ impl Inode {
                 .add((inum as usize).wrapping_rem(IPB));
 
             // a free inode
-            if (*dip).typ as i32 == 0 {
+            if (*dip).typ == 0 {
                 ptr::write_bytes(dip, 0, 1);
                 (*dip).typ = typ;
 
@@ -677,7 +677,7 @@ pub unsafe fn stati(ip: *mut Inode, mut st: *mut Stat) {
 pub unsafe fn dirlookup(dp: *mut Inode, name: &FileName, poff: *mut u32) -> *mut Inode {
     let mut off: u32 = 0;
     let mut de: Dirent = Default::default();
-    if (*dp).typ as i32 != T_DIR {
+    if (*dp).typ != T_DIR {
         panic!("dirlookup not DIR");
     }
     while off < (*dp).size {

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -206,7 +206,7 @@ impl InodeGuard<'_> {
 
     /// Copy stat information from inode.
     /// Caller must hold ip->lock.
-    pub unsafe fn stati(&self, mut st: *mut Stat) {
+    pub unsafe fn stati(&self, st: &mut Stat) {
         (*st).dev = (*self.ptr).dev as i32;
         (*st).ino = (*self.ptr).inum;
         (*st).typ = self.guard.typ;

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -259,13 +259,7 @@ impl InodeGuard<'_> {
         (*dip).minor = self.minor as i16;
         (*dip).nlink = self.nlink;
         (*dip).size = self.size;
-        // (*dip).addrs.as_mut_ptr().copy_from(&self.addrs as _, 13);
         (*dip).addrs.copy_from_slice(&self.addrs);
-        // ptr::copy(
-        //     self.addrs.as_ptr() as *const libc::CVoid,
-        //     (*dip).addrs.as_mut_ptr() as *mut libc::CVoid,
-        //     mem::size_of::<[u32; 13]>(),
-        // );
         log_write(bp);
         brelease(&mut *bp);
     }
@@ -491,11 +485,6 @@ impl Inode {
             guard.nlink = (*dip).nlink;
             guard.size = (*dip).size;
             guard.addrs.copy_from_slice(&(*dip).addrs);
-            // ptr::copy(
-            //     (*dip).addrs.as_mut_ptr() as *const libc::CVoid,
-            //     guard.addrs.as_mut_ptr() as *mut libc::CVoid,
-            //     mem::size_of::<[u32; 13]>(),
-            // );
             brelease(&mut *bp);
             guard.valid = true;
             assert_ne!(guard.typ, T_NONE, "Inode::lock: no type");

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -425,12 +425,11 @@ impl InodeGuard<'_> {
     /// Look for a directory entry in a directory.
     /// If found, set *poff to byte offset of entry.
     pub unsafe fn dirlookup(&mut self, name: &FileName, poff: *mut u32) -> Result<*mut Inode, ()> {
-        let mut off: u32 = 0;
         let mut de: Dirent = Default::default();
         if self.guard.typ != T_DIR {
             panic!("dirlookup not DIR");
         }
-        while off < self.guard.size {
+        for off in (0..self.guard.size).step_by(::core::mem::size_of::<Dirent>()) {
             let bytes_read = self.read(
                 0,
                 &mut de as *mut Dirent as usize,
@@ -448,7 +447,6 @@ impl InodeGuard<'_> {
                 }
                 return Ok(iget((*self.ptr).dev, de.inum as u32));
             }
-            off = (off as usize).wrapping_add(::core::mem::size_of::<Dirent>()) as u32
         }
         Err(())
     }

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -61,7 +61,7 @@ pub struct Superblock {
 }
 
 /// dirent size
-pub const DIRENTSIZE: usize = mem::size_of::<Dirent>();
+pub const DIRENT_SIZE: usize = mem::size_of::<Dirent>();
 
 #[derive(Default)]
 pub struct Dirent {
@@ -94,8 +94,8 @@ impl Dirent {
 
     fn read_entry(&mut self, ip: &mut InodeGuard<'_>, off: u32, panic_msg: &'static str) {
         unsafe {
-            let bytes_read = ip.read(0, self as *mut Dirent as usize, off, DIRENTSIZE as u32);
-            assert_eq!(bytes_read, Ok(DIRENTSIZE), "{}", panic_msg)
+            let bytes_read = ip.read(0, self as *mut Dirent as usize, off, DIRENT_SIZE as u32);
+            assert_eq!(bytes_read, Ok(DIRENT_SIZE), "{}", panic_msg)
         }
     }
 }
@@ -236,12 +236,12 @@ impl InodeGuard<'_> {
             if de.inum == 0 {
                 break;
             }
-            off = (off as usize).wrapping_add(DIRENTSIZE) as u32
+            off = (off as usize).wrapping_add(DIRENT_SIZE) as u32
         }
         de.inum = inum as u16;
         de.set_name(name);
-        let bytes_write = self.write(0, &mut de as *mut Dirent as usize, off, DIRENTSIZE as u32);
-        assert_eq!(bytes_write, Ok(DIRENTSIZE), "dirlink");
+        let bytes_write = self.write(0, &mut de as *mut Dirent as usize, off, DIRENT_SIZE as u32);
+        assert_eq!(bytes_write, Ok(DIRENT_SIZE), "dirlink");
         Ok(())
     }
 
@@ -404,7 +404,7 @@ impl InodeGuard<'_> {
     pub unsafe fn dirlookup(&mut self, name: &FileName) -> Result<(*mut Inode, u32), ()> {
         let mut de: Dirent = Default::default();
         assert_eq!(self.typ, T_DIR, "dirlookup not DIR");
-        for off in (0..self.size).step_by(DIRENTSIZE) {
+        for off in (0..self.size).step_by(DIRENT_SIZE) {
             de.read_entry(self, off, "dirlookup read");
             if de.inum != 0 && name == de.get_name() {
                 // entry matches path element

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -220,9 +220,8 @@ impl InodeGuard<'_> {
         let mut de: Dirent = Default::default();
 
         // Check that name is not present.
-        let ip = self.dirlookup(name, ptr::null_mut());
-        if ip.is_ok() {
-            (*ip.unwrap()).put();
+        if let Ok(ip) = self.dirlookup(name, ptr::null_mut()) {
+            (*ip).put();
             return false;
         };
 
@@ -485,10 +484,10 @@ impl InodeGuard<'_> {
             }
             let bp: *mut Buf = Buf::read((*self.ptr).dev, addr);
             let a: *mut u32 = (*bp).inner.data.as_mut_ptr() as *mut u32;
-            addr = *a.offset(bn as isize);
+            addr = *a.add(bn);
             if addr == 0 {
                 addr = balloc((*self.ptr).dev);
-                *a.offset(bn as isize) = addr;
+                *a.add(bn) = addr;
                 log_write(bp);
             }
             brelease(&mut *bp);

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -92,6 +92,7 @@ impl Dirent {
         unsafe { FileName::from_bytes(&self.name[..len]) }
     }
 
+    // TODO: Use iterator
     fn read_entry(&mut self, ip: &mut InodeGuard<'_>, off: u32, panic_msg: &'static str) {
         unsafe {
             let bytes_read = ip.read(0, self as *mut Dirent as usize, off, DIRENT_SIZE as u32);

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -191,10 +191,7 @@ static mut ICACHE: Spinlock<[Inode; NINODE]> = Spinlock::new("ICACHE", [Inode::z
 impl InodeGuard<'_> {
     /// Unlock the given inode.
     pub unsafe fn unlock(self) {
-        if
-        // (self as *mut Inode).is_null() || (*self).inner.lock.holding() == 0 ||
-        // Always hold lock when using lockguard
-        (*self.ptr).ref_0 < 1 {
+        if (*self.ptr).ref_0 < 1 {
             panic!("Inode::unlock");
         }
         drop(self.guard);
@@ -513,7 +510,7 @@ impl Inode {
     /// Lock the given inode.
     /// Reads the inode from disk if necessary.
     pub unsafe fn lock(&mut self) -> SleepLockGuard<'_, InodeInner> {
-        if (self as *mut Inode).is_null() || (*self).ref_0 < 1 {
+        if (*self).ref_0 < 1 {
             panic!("Inode::lock");
         }
         let mut ret = (*self).inner.lock();

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -228,17 +228,16 @@ impl InodeGuard<'_> {
         // Look for an empty Dirent.
         let mut off: i32 = 0;
         while (off as u32) < self.guard.size {
-            if self
-                .read(
-                    0,
-                    &mut de as *mut Dirent as usize,
-                    off as u32,
-                    ::core::mem::size_of::<Dirent>() as u32,
-                )
-                .map_or(true, |v| v != ::core::mem::size_of::<Dirent>())
-            {
-                panic!("dirlink read");
-            }
+            let bytes_read = self.read(
+                0,
+                &mut de as *mut Dirent as usize,
+                off as u32,
+                ::core::mem::size_of::<Dirent>() as u32,
+            );
+            assert!(
+                !bytes_read.map_or(true, |v| v != ::core::mem::size_of::<Dirent>()),
+                "dirlink read"
+            );
             if de.inum as i32 == 0 {
                 break;
             }
@@ -246,17 +245,16 @@ impl InodeGuard<'_> {
         }
         de.inum = inum as u16;
         de.set_name(name);
-        if self
-            .write(
-                0,
-                &mut de as *mut Dirent as usize,
-                off as u32,
-                ::core::mem::size_of::<Dirent>() as u32,
-            )
-            .map_or(true, |v| v != ::core::mem::size_of::<Dirent>())
-        {
-            panic!("dirlink");
-        }
+        let bytes_write = self.write(
+            0,
+            &mut de as *mut Dirent as usize,
+            off as u32,
+            ::core::mem::size_of::<Dirent>() as u32,
+        );
+        assert!(
+            !bytes_write.map_or(true, |v| v != ::core::mem::size_of::<Dirent>()),
+            "dirlink"
+        );
         true
     }
 
@@ -354,9 +352,9 @@ impl InodeGuard<'_> {
                 break;
             } else {
                 brelease(&mut *bp);
-                tot = (tot).wrapping_add(m);
-                off = (off).wrapping_add(m);
-                dst = (dst).wrapping_add(m as usize)
+                tot = tot.wrapping_add(m);
+                off = off.wrapping_add(m);
+                dst = dst.wrapping_add(m as usize)
             }
         }
         Ok(n as usize)
@@ -407,9 +405,9 @@ impl InodeGuard<'_> {
             } else {
                 log_write(bp);
                 brelease(&mut *bp);
-                tot = (tot).wrapping_add(m);
-                off = (off).wrapping_add(m);
-                src = (src).wrapping_add(m as usize)
+                tot = tot.wrapping_add(m);
+                off = off.wrapping_add(m);
+                src = src.wrapping_add(m as usize)
             }
         }
         if n > 0 {
@@ -433,17 +431,16 @@ impl InodeGuard<'_> {
             panic!("dirlookup not DIR");
         }
         while off < self.guard.size {
-            if self
-                .read(
-                    0,
-                    &mut de as *mut Dirent as usize,
-                    off,
-                    ::core::mem::size_of::<Dirent>() as u32,
-                )
-                .map_or(true, |v| v != ::core::mem::size_of::<Dirent>())
-            {
-                panic!("dirlookup read");
-            }
+            let bytes_read = self.read(
+                0,
+                &mut de as *mut Dirent as usize,
+                off,
+                ::core::mem::size_of::<Dirent>() as u32,
+            );
+            assert!(
+                !bytes_read.map_or(true, |v| v != ::core::mem::size_of::<Dirent>()),
+                "dirlookup read"
+            );
             if de.inum as i32 != 0 && name == de.get_name() {
                 // entry matches path element
                 if !poff.is_null() {
@@ -767,6 +764,5 @@ unsafe fn iget(dev: u32, inum: u32) -> *mut Inode {
     (*ip).inum = inum;
     (*ip).ref_0 = 1;
     (*ip).valid = false;
-    drop(inode);
     ip
 }

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -490,7 +490,7 @@ impl Inode {
     /// Lock the given inode.
     /// Reads the inode from disk if necessary.
     // (@kimjungwow) lock() receives `ptr` because usertest halts at `fourfiles` when `ptr` isn't given.
-    pub unsafe fn lock(&mut self, _ptr: *mut Inode) -> InodeGuard<'_> {
+    pub unsafe fn lock(&mut self) -> InodeGuard<'_> {
         assert!(self.ref_0 >= 1, "Inode::lock");
         let ptr = self as *mut _;
         let mut guard = self.inner.lock();
@@ -530,8 +530,7 @@ impl Inode {
 
             // self->ref == 1 means no other process can have self locked,
             // so this acquiresleep() won't block (or deadlock).
-            let ptr: *mut Inode = self;
-            let mut ip = (*self).lock(ptr);
+            let mut ip = (*self).lock();
 
             drop(inode);
 

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -192,7 +192,7 @@ impl Inode {
     /// Copy a modified in-memory inode to disk.
     /// Must be called after every change to an ip->xxx field
     /// that lives on disk, since i-node cache is write-through.
-    /// Caller must hold ip->lock.
+    /// Caller must hold self->lock.
     pub unsafe fn update(&mut self) {
         let bp: *mut Buf = Buf::read(self.dev, SB.iblock(self.inum));
         let mut dip: *mut Dinode = ((*bp).inner.data.as_mut_ptr() as *mut Dinode)
@@ -267,7 +267,10 @@ impl Inode {
     pub unsafe fn put(&mut self) {
         let mut inode = ICACHE.lock();
 
-        if (*self).ref_0 == 1 && (*self).inner.valid != 0 && (*self).inner.nlink as i32 == 0 {
+        if (*self).ref_0 == 1
+        // TODO: Make Inode safe and don't check below line
+        && (*self).inner.valid != 0 && (*self).inner.nlink as i32 == 0
+        {
             // inode has no links and no other references: truncate and free.
 
             // self->ref == 1 means no other process can have self locked,

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -547,11 +547,7 @@ impl Inode {
     pub unsafe fn put(&mut self) {
         let mut inode = ICACHE.lock();
 
-        if (*self).ref_0 == 1
-        // TODO: Make Inode safe and don't check below line
-        && (*self).valid
-        // && (*self).inner.nlink as i32 == 0
-        {
+        if (*self).ref_0 == 1 && (*self).valid {
             // inode has no links and no other references: truncate and free.
 
             // self->ref == 1 means no other process can have self locked,

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -219,14 +219,14 @@ impl InodeGuard<'_> {
 
     // Directories
     /// Write a new directory entry (name, inum) into the directory dp.
-    pub unsafe fn dirlink(&mut self, name: &FileName, inum: u32) -> i32 {
+    pub unsafe fn dirlink(&mut self, name: &FileName, inum: u32) -> bool {
         let mut de: Dirent = Default::default();
 
         // Check that name is not present.
         let ip: *mut Inode = self.dirlookup(name, ptr::null_mut());
         if !ip.is_null() {
             (*ip).put();
-            return -1;
+            return false;
         }
 
         // Look for an empty Dirent.
@@ -259,7 +259,7 @@ impl InodeGuard<'_> {
         {
             panic!("dirlink");
         }
-        0
+        true
     }
 
     /// Copy a modified in-memory inode to disk.

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -747,18 +747,6 @@ unsafe fn bfree(dev: i32, b: u32) {
     brelease(&mut *bp);
 }
 
-// TODO Can remove
-pub unsafe fn iinit() {
-    // let mut inode = ICACHE.lock();
-    // for i in 0..NINODE {
-    //     inode
-    //         .deref_mut()
-    //         .get_unchecked_mut(i)
-    //         .inner
-    //         .initlock("inode");
-    // }
-}
-
 /// Find the inode with number inum on device dev
 /// and return the in-memory copy. Does not lock
 /// the inode and does not read it from disk.
@@ -786,12 +774,7 @@ unsafe fn iget(dev: u32, inum: u32) -> *mut Inode {
     (*ip).dev = dev;
     (*ip).inum = inum;
     (*ip).ref_0 = 1;
-
-    // TODO: add lock
-    // let mut guard = (*ip).lock();
-    // guard.valid = 0;
     (*ip).valid = false;
     drop(inode);
-    // drop(guard);
     ip
 }

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -216,13 +216,13 @@ impl InodeGuard<'_> {
 
     // Directories
     /// Write a new directory entry (name, inum) into the directory dp.
-    pub unsafe fn dirlink(&mut self, name: &FileName, inum: u32) -> bool {
+    pub unsafe fn dirlink(&mut self, name: &FileName, inum: u32) -> Result<(), ()> {
         let mut de: Dirent = Default::default();
 
         // Check that name is not present.
         if let Ok(ip) = self.dirlookup(name, ptr::null_mut()) {
             (*ip).put();
-            return false;
+            return Err(());
         };
 
         // Look for an empty Dirent.
@@ -255,7 +255,7 @@ impl InodeGuard<'_> {
             !bytes_write.map_or(true, |v| v != ::core::mem::size_of::<Dirent>()),
             "dirlink"
         );
-        true
+        Ok(())
     }
 
     /// Copy a modified in-memory inode to disk.

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -22,8 +22,7 @@ use crate::{
     spinlock::Spinlock,
     stat::{Stat, T_DIR},
 };
-use core::mem;
-use core::{ops::DerefMut, ptr};
+use core::{mem, ops::DerefMut, ptr};
 
 mod path;
 pub use path::{FileName, Path};
@@ -232,16 +231,16 @@ impl InodeGuard<'_> {
                 0,
                 &mut de as *mut Dirent as usize,
                 off as u32,
-                ::core::mem::size_of::<Dirent>() as u32,
+                mem::size_of::<Dirent>() as u32,
             );
             assert!(
-                !bytes_read.map_or(true, |v| v != ::core::mem::size_of::<Dirent>()),
+                !bytes_read.map_or(true, |v| v != mem::size_of::<Dirent>()),
                 "dirlink read"
             );
             if de.inum as i32 == 0 {
                 break;
             }
-            off = (off as usize).wrapping_add(::core::mem::size_of::<Dirent>()) as i32
+            off = (off as usize).wrapping_add(mem::size_of::<Dirent>()) as i32
         }
         de.inum = inum as u16;
         de.set_name(name);
@@ -249,10 +248,10 @@ impl InodeGuard<'_> {
             0,
             &mut de as *mut Dirent as usize,
             off as u32,
-            ::core::mem::size_of::<Dirent>() as u32,
+            mem::size_of::<Dirent>() as u32,
         );
         assert!(
-            !bytes_write.map_or(true, |v| v != ::core::mem::size_of::<Dirent>()),
+            !bytes_write.map_or(true, |v| v != mem::size_of::<Dirent>()),
             "dirlink"
         );
         Ok(())
@@ -274,7 +273,7 @@ impl InodeGuard<'_> {
         ptr::copy(
             self.guard.addrs.as_mut_ptr() as *const libc::CVoid,
             (*dip).addrs.as_mut_ptr() as *mut libc::CVoid,
-            ::core::mem::size_of::<[u32; 13]>(),
+            mem::size_of::<[u32; 13]>(),
         );
         log_write(bp);
         brelease(&mut *bp);
@@ -429,15 +428,15 @@ impl InodeGuard<'_> {
         if self.guard.typ != T_DIR {
             panic!("dirlookup not DIR");
         }
-        for off in (0..self.guard.size).step_by(::core::mem::size_of::<Dirent>()) {
+        for off in (0..self.guard.size).step_by(mem::size_of::<Dirent>()) {
             let bytes_read = self.read(
                 0,
                 &mut de as *mut Dirent as usize,
                 off,
-                ::core::mem::size_of::<Dirent>() as u32,
+                mem::size_of::<Dirent>() as u32,
             );
             assert!(
-                !bytes_read.map_or(true, |v| v != ::core::mem::size_of::<Dirent>()),
+                !bytes_read.map_or(true, |v| v != mem::size_of::<Dirent>()),
                 "dirlookup read"
             );
             if de.inum as i32 != 0 && name == de.get_name() {
@@ -517,7 +516,7 @@ impl Inode {
             ptr::copy(
                 (*dip).addrs.as_mut_ptr() as *const libc::CVoid,
                 ret.addrs.as_mut_ptr() as *mut libc::CVoid,
-                ::core::mem::size_of::<[u32; 13]>(),
+                mem::size_of::<[u32; 13]>(),
             );
             brelease(&mut *bp);
             self.valid = true;
@@ -645,7 +644,7 @@ impl Superblock {
         ptr::copy(
             (*bp).inner.data.as_mut_ptr() as *const libc::CVoid,
             self as *mut Superblock as *mut libc::CVoid,
-            ::core::mem::size_of::<Superblock>(),
+            mem::size_of::<Superblock>(),
         );
         brelease(&mut *bp);
     }

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -518,7 +518,10 @@ impl Inode {
     pub unsafe fn put(&mut self) {
         let mut inode = ICACHE.lock();
 
-        if self.ref_0 == 1 && self.inner.get_mut_unchecked().valid && self.inner.get_mut_unchecked().nlink == 0 {
+        if self.ref_0 == 1
+            && self.inner.get_mut_unchecked().valid
+            && self.inner.get_mut_unchecked().nlink == 0
+        {
             // inode has no links and no other references: truncate and free.
 
             // self->ref == 1 means no other process can have self locked,

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -254,7 +254,7 @@ impl InodeGuard<'_> {
     /// Must be called after every change to an ip->xxx field
     /// that lives on disk, since i-node cache is write-through.
     /// Caller must hold self->lock.
-    pub unsafe fn update(&mut self) {
+    pub unsafe fn update(&self) {
         let bp: *mut Buf = Buf::read((*self.ptr).dev, SB.iblock((*self.ptr).inum));
         let mut dip: *mut Dinode = ((*bp).inner.data.as_mut_ptr() as *mut Dinode)
             .add(((*self.ptr).inum as usize).wrapping_rem(IPB));
@@ -264,7 +264,7 @@ impl InodeGuard<'_> {
         (*dip).nlink = self.nlink;
         (*dip).size = self.size;
         ptr::copy(
-            self.addrs.as_mut_ptr() as *const libc::CVoid,
+            self.addrs.as_ptr() as *const libc::CVoid,
             (*dip).addrs.as_mut_ptr() as *mut libc::CVoid,
             mem::size_of::<[u32; 13]>(),
         );

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -544,7 +544,7 @@ impl Inode {
                 ptr,
             };
             if inodeguard.guard.nlink != 0 {
-                self.ref_0 -=1;
+                self.ref_0 -= 1;
                 return;
             }
 

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -326,7 +326,7 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let bp = Buf::read((*self.ptr).dev, self.bmap(off.wrapping_div(BSIZE as u32)));
+            let bp = Buf::read((*self.ptr).dev, self.bmap((off as usize).wrapping_div(BSIZE)));
             let m = core::cmp::min(
                 n.wrapping_sub(tot),
                 (BSIZE as u32).wrapping_sub(off.wrapping_rem(BSIZE as u32)),
@@ -375,7 +375,7 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let bp = Buf::read((*self.ptr).dev, self.bmap(off.wrapping_div(BSIZE as u32)));
+            let bp = Buf::read((*self.ptr).dev, self.bmap((off as usize).wrapping_div(BSIZE)));
             let m = core::cmp::min(
                 n.wrapping_sub(tot),
                 (BSIZE as u32).wrapping_sub(off.wrapping_rem(BSIZE as u32)),
@@ -454,18 +454,18 @@ impl InodeGuard<'_> {
     /// listed in block self->addrs[NDIRECT].
     /// Return the disk block address of the nth block in inode self.
     /// If there is no such block, bmap allocates one.
-    unsafe fn bmap(&mut self, mut bn: u32) -> u32 {
+    unsafe fn bmap(&mut self, mut bn: usize) -> u32 {
         let mut addr: u32;
-        if bn < NDIRECT as u32 {
-            addr = self.guard.addrs[bn as usize];
+        if bn < NDIRECT {
+            addr = self.guard.addrs[bn];
             if addr == 0 {
                 addr = balloc((*self.ptr).dev);
-                self.guard.addrs[bn as usize] = addr
+                self.guard.addrs[bn] = addr
             }
             return addr;
         }
-        bn = (bn).wrapping_sub(NDIRECT as u32);
-        if (bn as usize) < NINDIRECT {
+        bn = (bn).wrapping_sub(NDIRECT);
+        if bn < NINDIRECT {
             // Load indirect block, allocating if necessary.
             addr = self.guard.addrs[NDIRECT];
             if addr == 0 {

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -231,7 +231,6 @@ impl InodeGuard<'_> {
 
         // Look for an empty Dirent.
         let mut off: u32 = 0;
-        // TODO : Dirent를 순회하는 iterator 만들기 : DIRENTSIZE만큼씩 읽고, 그 결과가 DIRENTSIZE가 아니면 panic
         while off < self.size {
             de.read_entry(self, off, "dirlink read");
             if de.inum == 0 {
@@ -407,7 +406,7 @@ impl InodeGuard<'_> {
         assert_eq!(self.typ, T_DIR, "dirlookup not DIR");
         for off in (0..self.size).step_by(DIRENTSIZE) {
             de.read_entry(self, off, "dirlookup read");
-            if de.inum as i32 != 0 && name == de.get_name() {
+            if de.inum != 0 && name == de.get_name() {
                 // entry matches path element
                 return Ok((iget(self.ptr.dev, de.inum as u32), off));
             }

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -536,12 +536,9 @@ impl Inode {
             // self->ref == 1 means no other process can have self locked,
             // so this acquiresleep() won't block (or deadlock).
             let ptr: *mut Inode = self;
-            let mut ip = InodeGuard {
-                guard: self.inner.lock(),
-                ptr,
-            };
+            let mut ip = (*self).lock(ptr);
             if ip.guard.nlink != 0 {
-                self.ref_0 -= 1;
+                (*ip.ptr).ref_0 -= 1;
                 return;
             }
 
@@ -550,7 +547,7 @@ impl Inode {
             ip.itrunc();
             ip.guard.typ = 0;
             ip.update();
-            self.valid = false;
+            (*ip.ptr).valid = false;
 
             drop(ip.guard);
 

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -229,15 +229,15 @@ impl InodeGuard<'_> {
         // Look for an empty Dirent.
         let mut off: i32 = 0;
         while (off as u32) < self.guard.size {
-            if {
-                let x = self.read(
+            if self
+                .read(
                     0,
                     &mut de as *mut Dirent as usize,
                     off as u32,
                     ::core::mem::size_of::<Dirent>() as u32,
-                );
-                x.is_err() || x.unwrap() != ::core::mem::size_of::<Dirent>()
-            } {
+                )
+                .map_or(true, |v| v != ::core::mem::size_of::<Dirent>())
+            {
                 panic!("dirlink read");
             }
             if de.inum as i32 == 0 {
@@ -247,15 +247,15 @@ impl InodeGuard<'_> {
         }
         de.inum = inum as u16;
         de.set_name(name);
-        if {
-            let x = self.write(
+        if self
+            .write(
                 0,
                 &mut de as *mut Dirent as usize,
                 off as u32,
                 ::core::mem::size_of::<Dirent>() as u32,
-            );
-            x.is_err() || x.unwrap() != ::core::mem::size_of::<Dirent>()
-        } {
+            )
+            .map_or(true, |v| v != ::core::mem::size_of::<Dirent>())
+        {
             panic!("dirlink");
         }
         true
@@ -434,15 +434,15 @@ impl InodeGuard<'_> {
             panic!("dirlookup not DIR");
         }
         while off < self.guard.size {
-            if {
-                let x = self.read(
+            if self
+                .read(
                     0,
                     &mut de as *mut Dirent as usize,
                     off,
                     ::core::mem::size_of::<Dirent>() as u32,
-                );
-                x.is_err() || x.unwrap() != ::core::mem::size_of::<Dirent>()
-            } {
+                )
+                .map_or(true, |v| v != ::core::mem::size_of::<Dirent>())
+            {
                 panic!("dirlookup read");
             }
             if de.inum as i32 != 0 && name == de.get_name() {

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -467,7 +467,7 @@ impl InodeGuard<'_> {
             log_write(bp);
         }
         brelease(&mut *bp);
-        return addr;
+        addr
     }
 }
 

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -293,7 +293,7 @@ impl InodeGuard<'_> {
     unsafe fn itrunc(&mut self) {
         for i in 0..NDIRECT {
             if self.guard.addrs[i] != 0 {
-                bfree((*self.ptr).dev as i32, self.guard.addrs[i as usize]);
+                bfree((*self.ptr).dev as i32, self.guard.addrs[i]);
                 self.guard.addrs[i] = 0
             }
         }
@@ -348,9 +348,9 @@ impl InodeGuard<'_> {
                 break;
             } else {
                 brelease(&mut *bp);
-                tot = (tot as u32).wrapping_add(m) as u32 as u32;
-                off = (off as u32).wrapping_add(m) as u32 as u32;
-                dst = (dst as usize).wrapping_add(m as usize) as usize as usize
+                tot = (tot).wrapping_add(m);
+                off = (off).wrapping_add(m);
+                dst = (dst).wrapping_add(m as usize)
             }
         }
         n as i32
@@ -398,9 +398,9 @@ impl InodeGuard<'_> {
             } else {
                 log_write(bp);
                 brelease(&mut *bp);
-                tot = (tot as u32).wrapping_add(m) as u32 as u32;
-                off = (off as u32).wrapping_add(m) as u32 as u32;
-                src = (src as usize).wrapping_add(m as usize) as usize as usize
+                tot = (tot).wrapping_add(m);
+                off = (off).wrapping_add(m);
+                src = (src).wrapping_add(m as usize)
             }
         }
         if n > 0 {
@@ -441,7 +441,7 @@ impl InodeGuard<'_> {
                 }
                 return iget((*self.ptr).dev, de.inum as u32);
             }
-            off = (off as usize).wrapping_add(::core::mem::size_of::<Dirent>()) as u32 as u32
+            off = (off as usize).wrapping_add(::core::mem::size_of::<Dirent>()) as u32
         }
         ptr::null_mut()
     }
@@ -587,7 +587,7 @@ impl Inode {
                 // mark it allocated on the disk
                 log_write(bp);
                 brelease(&mut *bp);
-                return iget(dev, inum as u32);
+                return iget(dev, inum);
             }
             brelease(&mut *bp);
         }
@@ -634,7 +634,7 @@ impl Superblock {
     /// Block containing inode i
     const fn iblock(self, i: u32) -> u32 {
         i.wrapping_div(IPB as u32)
-            .wrapping_add(self.inodestart as u32)
+            .wrapping_add(self.inodestart)
     }
 
     /// Block of free map containing bit for block b

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -187,6 +187,7 @@ struct Dinode {
 
 static mut ICACHE: Spinlock<[Inode; NINODE]> = Spinlock::new("ICACHE", [Inode::zeroed(); NINODE]);
 
+//TODO(@kimjungwow) : move inode-related methods to another file
 impl InodeGuard<'_> {
     /// Unlock the given inode.
     pub unsafe fn unlock(self) {
@@ -494,7 +495,7 @@ impl Inode {
 
     /// Lock the given inode.
     /// Reads the inode from disk if necessary.
-    // lock() receives `ptr` because usertest halts at `fourfiles` when `ptr` isn't given.
+    // (@kimjungwow) lock() receives `ptr` because usertest halts at `fourfiles` when `ptr` isn't given.
     pub unsafe fn lock(&mut self, ptr: *mut Inode) -> InodeGuard<'_> {
         assert!(self.ref_0 >= 1, "Inode::lock");
         let mut guard = self.inner.lock();

--- a/kernel-rs/src/fs.rs
+++ b/kernel-rs/src/fs.rs
@@ -469,19 +469,30 @@ impl Inode {
     pub unsafe fn lock(&self) -> InodeGuard<'_> {
         assert!(self.ref_0 >= 1, "Inode::lock");
         let mut guard = self.inner.lock();
-        if !self.inner.get_mut_unchecked().valid {
+        if !self.inner.get_mut_unchecked().is_some() {
             let bp: *mut Buf = Buf::read(self.dev, SB.iblock(self.inum));
             let dip: *mut Dinode = ((*bp).inner.data.as_mut_ptr() as *mut Dinode)
                 .add((self.inum as usize).wrapping_rem(IPB));
-            guard.typ = (*dip).typ;
-            guard.major = (*dip).major as u16;
-            guard.minor = (*dip).minor as u16;
-            guard.nlink = (*dip).nlink;
-            guard.size = (*dip).size;
-            guard.addrs.copy_from_slice(&(*dip).addrs);
+            *guard = Some(InodeInner {
+                typ: (*dip).typ,
+                major: (*dip).major as u16,
+                minor: (*dip).minor as u16,
+                nlink: (*dip).nlink,
+                size: (*dip).size,
+                addrs: [0; 13],
+            });
+            guard
+                .deref_mut()
+                .as_mut()
+                .unwrap()
+                .addrs
+                .copy_from_slice(&(*dip).addrs);
             brelease(&mut *bp);
-            guard.valid = true;
-            assert_ne!(guard.typ, T_NONE, "Inode::lock: no type");
+            assert_ne!(
+                guard.deref_mut().as_mut().unwrap().typ,
+                T_NONE,
+                "Inode::lock: no type"
+            );
         };
         InodeGuard::new(guard, &*self)
     }
@@ -498,8 +509,8 @@ impl Inode {
         let mut inode = ICACHE.lock();
 
         if self.ref_0 == 1
-            && self.inner.get_mut_unchecked().valid
-            && self.inner.get_mut_unchecked().nlink == 0
+            && self.inner.get_mut_unchecked().is_some()
+            && self.inner.get_mut_unchecked().as_mut().unwrap().nlink == 0
         {
             // inode has no links and no other references: truncate and free.
 
@@ -512,7 +523,7 @@ impl Inode {
             ip.itrunc();
             ip.typ = 0;
             ip.update();
-            ip.valid = false;
+            *self.inner.get_mut_unchecked() = None;
 
             drop(ip);
 
@@ -553,18 +564,7 @@ impl Inode {
             dev: 0,
             inum: 0,
             ref_0: 0,
-            inner: SleeplockWIP::new(
-                "inode",
-                InodeInner {
-                    valid: false,
-                    typ: 0,
-                    major: 0,
-                    minor: 0,
-                    nlink: 0,
-                    size: 0,
-                    addrs: [0; 13],
-                },
-            ),
+            inner: SleeplockWIP::new("inode", None),
         }
     }
 }
@@ -711,6 +711,6 @@ unsafe fn iget(dev: u32, inum: u32) -> *mut Inode {
     (*ip).dev = dev;
     (*ip).inum = inum;
     (*ip).ref_0 = 1;
-    (*ip).inner.get_mut_unchecked().valid = false;
+    *(*ip).inner.get_mut_unchecked() = None;
     ip
 }

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -143,7 +143,7 @@ impl Path {
 
             let mut ip = (*ptr).lock();
             if ip.typ != T_DIR {
-                ip.unlockput();
+                ip.unlockput(ptr);
                 return Err(());
             }
             if parent && path.inner.is_empty() {
@@ -152,7 +152,7 @@ impl Path {
                 return Ok((ptr, Some(name)));
             }
             let next = ip.dirlookup(name);
-            ip.unlockput();
+            ip.unlockput(ptr);
             ptr = next?.0
         }
         if parent {

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -143,7 +143,7 @@ impl Path {
             path = new_path;
 
             (*ip).lock();
-            if (*ip).typ as i32 != T_DIR {
+            if (*ip).typ != T_DIR {
                 (*ip).unlockput();
                 return Err(());
             }

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -141,7 +141,7 @@ impl Path {
         while let Some((new_path, name)) = path.skipelem() {
             path = new_path;
 
-            let mut ip = (*ptr).lock(ptr);
+            let mut ip = (*ptr).lock();
             if ip.typ != T_DIR {
                 ip.unlockput();
                 return Err(());

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -1,7 +1,7 @@
 use core::cmp;
 use cstr_core::CStr;
 
-use super::{iget, Inode, InodeGuard, DIRSIZ, ROOTDEV, ROOTINO, T_DIR};
+use super::{iget, Inode, DIRSIZ, ROOTDEV, ROOTINO, T_DIR};
 use crate::proc::myproc;
 
 #[derive(PartialEq)]
@@ -141,10 +141,7 @@ impl Path {
         while let Some((new_path, name)) = path.skipelem() {
             path = new_path;
 
-            let mut ip = InodeGuard {
-                guard: (*ptr).lock(),
-                ptr,
-            };
+            let mut ip = (*ptr).lock(ptr);
             if ip.guard.typ != T_DIR {
                 ip.unlockput();
                 return Err(());

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -143,7 +143,7 @@ impl Path {
 
             let mut ip = (*ptr).lock();
             if ip.typ != T_DIR {
-                ip.unlockput(ptr);
+                ip.unlockput();
                 return Err(());
             }
             if parent && path.inner.is_empty() {
@@ -152,7 +152,7 @@ impl Path {
                 return Ok((ptr, Some(name)));
             }
             let next = ip.dirlookup(name);
-            ip.unlockput(ptr);
+            ip.unlockput();
             ptr = next?.0
         }
         if parent {

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -143,7 +143,7 @@ impl Path {
             path = new_path;
 
             (*ip).lock();
-            if (*ip).typ != T_DIR {
+            if (*ip).inner.typ != T_DIR {
                 (*ip).unlockput();
                 return Err(());
             }

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -153,7 +153,6 @@ impl Path {
             }
             let next = ip.dirlookup(name);
             ip.unlockput();
-            // let (temp, _) = next?;
             ptr = next?.0
         }
         if parent {

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -142,7 +142,7 @@ impl Path {
             path = new_path;
 
             let mut ip = (*ptr).lock(ptr);
-            if ip.guard.typ != T_DIR {
+            if ip.typ != T_DIR {
                 ip.unlockput();
                 return Err(());
             }

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -148,7 +148,7 @@ impl Path {
             }
             if parent && path.inner.is_empty() {
                 // Stop one level early.
-                ip.unlock();
+                drop(ip);
                 return Ok((ptr, Some(name)));
             }
             let next = ip.dirlookup(name);

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -155,13 +155,9 @@ impl Path {
                 ip.unlock();
                 return Ok((ptr, Some(name)));
             }
-            let next: *mut Inode = ip.dirlookup(name, ptr::null_mut());
-            if next.is_null() {
-                ip.unlockput();
-                return Err(());
-            }
+            let next = ip.dirlookup(name, ptr::null_mut());
             ip.unlockput();
-            ptr = next
+            ptr = next?
         }
         if parent {
             (*ptr).put();

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -1,5 +1,4 @@
 use core::cmp;
-use core::ptr;
 use cstr_core::CStr;
 
 use super::{iget, Inode, InodeGuard, DIRSIZ, ROOTDEV, ROOTINO, T_DIR};
@@ -155,9 +154,10 @@ impl Path {
                 ip.unlock();
                 return Ok((ptr, Some(name)));
             }
-            let next = ip.dirlookup(name, ptr::null_mut());
+            let next = ip.dirlookup(name);
             ip.unlockput();
-            ptr = next?
+            // let (temp, _) = next?;
+            ptr = next?.0
         }
         if parent {
             (*ptr).put();

--- a/kernel-rs/src/kernel_main.rs
+++ b/kernel-rs/src/kernel_main.rs
@@ -1,7 +1,6 @@
 use crate::{
     bio::binit,
     console::Console,
-    fs::iinit,
     kalloc::kinit,
     plic::{plicinit, plicinithart},
     printf::printfinit,
@@ -51,9 +50,6 @@ pub unsafe fn kernel_main() {
 
         // Buffer cache.
         binit();
-
-        // Inode cache.
-        iinit();
 
         // Emulated hard disk.
         virtio_disk_init();

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -32,10 +32,6 @@ impl<T> SleeplockWIP<T> {
             waitchannel: WaitChannel::new(),
         }
     }
-    pub fn initlock(&mut self, name: &'static str) {
-        self.spinlock = Spinlock::new(name, -1);
-        self.waitchannel = WaitChannel::new();
-    }
 
     pub fn into_inner(self) -> T {
         self.data.into_inner()

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -24,6 +24,14 @@ pub struct SleeplockWIP<T> {
 unsafe impl<T: Send> Sync for SleeplockWIP<T> {}
 
 impl<T> SleeplockWIP<T> {
+    // TODO: transient measure
+    pub const fn new(name: &'static str, data: T) -> Self {
+        Self {
+            spinlock: Spinlock::new(name, -1),
+            data: UnsafeCell::new(data),
+            waitchannel: WaitChannel::new(),
+        }
+    }
     pub fn initlock(&mut self, name: &'static str) {
         self.spinlock = Spinlock::new(name, -1);
         self.waitchannel = WaitChannel::new();
@@ -42,7 +50,6 @@ impl<T> SleeplockWIP<T> {
             self.waitchannel.sleep(guard.raw() as *mut RawSpinlock);
         }
         *guard = (*myproc()).pid;
-        drop(guard);
         SleepLockGuard {
             lock: self,
             _marker: PhantomData,

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -24,7 +24,6 @@ pub struct SleeplockWIP<T> {
 unsafe impl<T: Send> Sync for SleeplockWIP<T> {}
 
 impl<T> SleeplockWIP<T> {
-    // TODO: transient measure
     pub const fn new(name: &'static str, data: T) -> Self {
         Self {
             spinlock: Spinlock::new(name, -1),

--- a/kernel-rs/src/stat.rs
+++ b/kernel-rs/src/stat.rs
@@ -1,3 +1,6 @@
+/// None
+pub const T_NONE: i16 = 0;
+
 /// Directory
 pub const T_DIR: i16 = 1;
 

--- a/kernel-rs/src/stat.rs
+++ b/kernel-rs/src/stat.rs
@@ -1,11 +1,11 @@
 /// Directory
-pub const T_DIR: i32 = 1;
+pub const T_DIR: i16 = 1;
 
 /// File
-pub const T_FILE: i32 = 2;
+pub const T_FILE: i16 = 2;
 
 /// Device
-pub const T_DEVICE: i32 = 3;
+pub const T_DEVICE: i16 = 3;
 
 #[derive(Default, Copy, Clone)]
 pub struct Stat {

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -101,7 +101,7 @@ pub unsafe fn sys_link() -> usize {
         return usize::MAX;
     });
     (*ip).lock();
-    if (*ip).typ as i32 == T_DIR {
+    if (*ip).typ == T_DIR {
         (*ip).unlockput();
         end_op();
         return usize::MAX;
@@ -171,7 +171,7 @@ pub unsafe fn sys_unlink() -> usize {
             if ((*ip).nlink as i32) < 1 {
                 panic!("unlink: nlink < 1");
             }
-            if (*ip).typ as i32 == T_DIR && isdirempty(ip) == 0 {
+            if (*ip).typ == T_DIR && isdirempty(ip) == 0 {
                 (*ip).unlockput();
             } else {
                 ptr::write_bytes(&mut de as *mut Dirent, 0, 1);
@@ -185,7 +185,7 @@ pub unsafe fn sys_unlink() -> usize {
                 {
                     panic!("unlink: writei");
                 }
-                if (*ip).typ as i32 == T_DIR {
+                if (*ip).typ == T_DIR {
                     (*dp).nlink -= 1;
                     (*dp).update();
                 }
@@ -211,7 +211,7 @@ unsafe fn create(path: &Path, typ: i16, major: u16, minor: u16) -> *mut Inode {
     if !ip.is_null() {
         (*dp).unlockput();
         (*ip).lock();
-        if typ as i32 == T_FILE && ((*ip).typ as i32 == T_FILE || (*ip).typ as i32 == T_DEVICE) {
+        if typ == T_FILE && ((*ip).typ == T_FILE || (*ip).typ == T_DEVICE) {
             return ip;
         }
         (*ip).unlockput();
@@ -228,7 +228,7 @@ unsafe fn create(path: &Path, typ: i16, major: u16, minor: u16) -> *mut Inode {
     (*ip).update();
 
     // Create . and .. entries.
-    if typ as i32 == T_DIR {
+    if typ == T_DIR {
         // for ".."
         (*dp).nlink += 1;
         (*dp).update();
@@ -256,7 +256,7 @@ pub unsafe fn sys_open() -> usize {
     begin_op();
     let omode = FcntlFlags::from_bits_truncate(omode);
     if omode.contains(FcntlFlags::O_CREATE) {
-        ip = create(path, T_FILE as i16, 0, 0);
+        ip = create(path, T_FILE, 0, 0);
         if ip.is_null() {
             end_op();
             return usize::MAX;
@@ -267,13 +267,13 @@ pub unsafe fn sys_open() -> usize {
             return usize::MAX;
         });
         (*ip).lock();
-        if (*ip).typ as i32 == T_DIR && omode != FcntlFlags::O_RDONLY {
+        if (*ip).typ == T_DIR && omode != FcntlFlags::O_RDONLY {
             (*ip).unlockput();
             end_op();
             return usize::MAX;
         }
     }
-    if (*ip).typ as i32 == T_DEVICE && ((*ip).major as usize >= NDEV) {
+    if (*ip).typ == T_DEVICE && ((*ip).major as usize >= NDEV) {
         (*ip).unlockput();
         end_op();
         return usize::MAX;
@@ -301,7 +301,7 @@ pub unsafe fn sys_open() -> usize {
     };
     let f = (*myproc()).open_files[fd as usize].as_mut().unwrap();
 
-    if (*ip).typ as i32 == T_DEVICE {
+    if (*ip).typ == T_DEVICE {
         (*f).typ = FileType::Device {
             ip,
             major: (*ip).major,
@@ -322,7 +322,7 @@ pub unsafe fn sys_mkdir() -> usize {
         end_op();
         return usize::MAX;
     });
-    let ip = create(Path::new(path), T_DIR as _, 0, 0);
+    let ip = create(Path::new(path), T_DIR, 0, 0);
     if ip.is_null() {
         end_op();
         return usize::MAX;
@@ -342,7 +342,7 @@ pub unsafe fn sys_mknod() -> usize {
     let path = ok_or!(argstr(0, &mut path), return usize::MAX);
     let major = ok_or!(argint(1), return usize::MAX) as u16;
     let minor = ok_or!(argint(2), return usize::MAX) as u16;
-    let ip = create(Path::new(path), T_DEVICE as i16, major, minor);
+    let ip = create(Path::new(path), T_DEVICE, major, minor);
     if ip.is_null() {
         return usize::MAX;
     }
@@ -363,7 +363,7 @@ pub unsafe fn sys_chdir() -> usize {
         return usize::MAX;
     });
     (*ip).lock();
-    if (*ip).typ as i32 != T_DIR {
+    if (*ip).typ != T_DIR {
         (*ip).unlockput();
         end_op();
         return usize::MAX;

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -107,7 +107,7 @@ pub unsafe fn sys_link() -> usize {
     }
     ip.nlink += 1;
     ip.update();
-    ip.unlock();
+    drop(ip);
     if let Ok((ptr2, name)) = Path::new(new).nameiparent() {
         let mut dp = (*ptr2).lock(ptr2);
         if (*ptr2).dev != (*ptr).dev || dp.dirlink(name, (*ptr).inum).is_err() {
@@ -306,7 +306,7 @@ pub unsafe fn sys_open() -> usize {
         (*f).typ = FileType::Inode { ip: ip.ptr, off: 0 };
     }
 
-    ip.unlock();
+    drop(ip);
     end_op();
     fd as usize
 }
@@ -362,7 +362,7 @@ pub unsafe fn sys_chdir() -> usize {
         end_op();
         return usize::MAX;
     }
-    ip.unlock();
+    drop(ip);
     (*(*p).cwd).put();
     end_op();
     (*p).cwd = ptr;

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -142,14 +142,15 @@ impl InodeGuard<'_> {
         let mut de: Dirent = Default::default();
         let mut off = (2usize).wrapping_mul(mem::size_of::<Dirent>()) as i32;
         while (off as u32) < self.guard.size {
-            if self.read(
-                0,
-                &mut de as *mut Dirent as usize,
-                off as u32,
-                mem::size_of::<Dirent>() as u32,
-            ) as usize
-                != mem::size_of::<Dirent>()
-            {
+            if {
+                let x = self.read(
+                    0,
+                    &mut de as *mut Dirent as usize,
+                    off as u32,
+                    mem::size_of::<Dirent>() as u32,
+                );
+                x.is_err() || x.unwrap() != mem::size_of::<Dirent>()
+            } {
                 panic!("isdirempty: readi");
             }
             if de.inum as i32 != 0 {

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -191,6 +191,7 @@ pub unsafe fn sys_unlink() -> usize {
     usize::MAX
 }
 
+// TODO: Returning lockguard can be dangerous. ('static lifetime too)
 unsafe fn create(path: &Path, typ: i16, major: u16, minor: u16) -> Result<InodeGuard<'static>, ()> {
     let (ptr, name) = path.nameiparent()?;
     let mut dp = (*ptr).lock();
@@ -230,7 +231,6 @@ unsafe fn create(path: &Path, typ: i16, major: u16, minor: u16) -> Result<InodeG
     Ok(ip)
 }
 
-#[allow(clippy::cast_ref_to_mut)]
 pub unsafe fn sys_open() -> usize {
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
     let path = ok_or!(argstr(0, &mut path), return usize::MAX);

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -116,7 +116,7 @@ pub unsafe fn sys_link() -> usize {
             guard: (*dp).lock(),
             ptr: dp,
         };
-        if (*dp).dev != (*ip).dev || dp_inodeguard.dirlink(name, (*ip).inum) < 0 {
+        if (*dp).dev != (*ip).dev || !dp_inodeguard.dirlink(name, (*ip).inum) {
             dp_inodeguard.unlockput();
         } else {
             dp_inodeguard.unlockput();
@@ -260,13 +260,13 @@ unsafe fn create(path: &Path, typ: i16, major: u16, minor: u16) -> Result<InodeG
         dp_inodeguard.update();
 
         // No ip->nlink++ for ".": avoid cyclic ref count.
-        if ip_inodeguard.dirlink(FileName::from_bytes(b"."), (*ip).inum) < 0
-            || ip_inodeguard.dirlink(FileName::from_bytes(b".."), (*dp).inum) < 0
+        if !ip_inodeguard.dirlink(FileName::from_bytes(b"."), (*ip).inum)
+            || !ip_inodeguard.dirlink(FileName::from_bytes(b".."), (*dp).inum)
         {
             panic!("create dots");
         }
     }
-    if dp_inodeguard.dirlink(&name, (*ip).inum) < 0 {
+    if !dp_inodeguard.dirlink(&name, (*ip).inum) {
         panic!("create: dirlink");
     }
     dp_inodeguard.unlockput();

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -190,14 +190,15 @@ pub unsafe fn sys_unlink() -> usize {
             if ip_inodeguard.guard.typ == T_DIR && ip_inodeguard.isdirempty() == 0 {
                 ip_inodeguard.unlockput();
             } else {
-                if dp_inodeguard.write(
-                    0,
-                    &mut de as *mut Dirent as usize,
-                    off,
-                    mem::size_of::<Dirent>() as u32,
-                ) as usize
-                    != mem::size_of::<Dirent>()
-                {
+                if {
+                    let x = dp_inodeguard.write(
+                        0,
+                        &mut de as *mut Dirent as usize,
+                        off,
+                        mem::size_of::<Dirent>() as u32,
+                    );
+                    x.is_err() || x.unwrap() != mem::size_of::<Dirent>()
+                } {
                     panic!("unlink: writei");
                 }
                 if ip_inodeguard.guard.typ == T_DIR {

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -231,6 +231,7 @@ unsafe fn create(path: &Path, typ: i16, major: u16, minor: u16) -> Result<InodeG
     Ok(ip)
 }
 
+#[allow(clippy::cast_ref_to_mut)]
 pub unsafe fn sys_open() -> usize {
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
     let path = ok_or!(argstr(0, &mut path), return usize::MAX);

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -138,7 +138,7 @@ pub unsafe fn sys_link() -> usize {
 
 impl InodeGuard<'_> {
     /// Is the directory dp empty except for "." and ".." ?
-    unsafe fn isdirempty(&mut self) -> i32 {
+    unsafe fn isdirempty(&mut self) -> bool {
         let mut de: Dirent = Default::default();
         let mut off = (2usize).wrapping_mul(mem::size_of::<Dirent>()) as i32;
         while (off as u32) < self.guard.size {
@@ -154,11 +154,11 @@ impl InodeGuard<'_> {
                 panic!("isdirempty: readi");
             }
             if de.inum as i32 != 0 {
-                return 0;
+                return false;
             }
             off = (off as usize).wrapping_add(mem::size_of::<Dirent>()) as i32
         }
-        1
+        true
     }
 }
 
@@ -188,7 +188,7 @@ pub unsafe fn sys_unlink() -> usize {
             if (ip_inodeguard.guard.nlink as i32) < 1 {
                 panic!("unlink: nlink < 1");
             }
-            if ip_inodeguard.guard.typ == T_DIR && ip_inodeguard.isdirempty() == 0 {
+            if ip_inodeguard.guard.typ == T_DIR && !ip_inodeguard.isdirempty() {
                 ip_inodeguard.unlockput();
             } else {
                 if {

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -6,7 +6,7 @@ use crate::{
     exec::exec,
     fcntl::FcntlFlags,
     file::{FileType, Inode, InodeGuard, RcFile},
-    fs::{Dirent, FileName, Path, DIRENTSIZE},
+    fs::{Dirent, FileName, Path, DIRENT_SIZE},
     kalloc::{kalloc, kfree},
     log::{begin_op, end_op},
     ok_or,
@@ -131,14 +131,14 @@ impl InodeGuard<'_> {
     /// Is the directory dp empty except for "." and ".." ?
     unsafe fn isdirempty(&mut self) -> bool {
         let mut de: Dirent = Default::default();
-        for off in (2 * DIRENTSIZE as u32..self.size).step_by(DIRENTSIZE) {
+        for off in (2 * DIRENT_SIZE as u32..self.size).step_by(DIRENT_SIZE) {
             let bytes_read = self.read(
                 0,
                 &mut de as *mut Dirent as usize,
                 off as u32,
-                DIRENTSIZE as u32,
+                DIRENT_SIZE as u32,
             );
-            assert_eq!(bytes_read, Ok(DIRENTSIZE), "isdirempty: readi");
+            assert_eq!(bytes_read, Ok(DIRENT_SIZE), "isdirempty: readi");
             if de.inum != 0 {
                 return false;
             }
@@ -170,8 +170,8 @@ pub unsafe fn sys_unlink() -> usize {
                 ip.unlockput();
             } else {
                 let bytes_write =
-                    dp.write(0, &mut de as *mut Dirent as usize, off, DIRENTSIZE as u32);
-                assert_eq!(bytes_write, Ok(DIRENTSIZE), "unlink: writei");
+                    dp.write(0, &mut de as *mut Dirent as usize, off, DIRENT_SIZE as u32);
+                assert_eq!(bytes_write, Ok(DIRENT_SIZE), "unlink: writei");
                 if ip.typ == T_DIR {
                     dp.nlink -= 1;
                     dp.update();

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -116,7 +116,7 @@ pub unsafe fn sys_link() -> usize {
             guard: (*ptr2).lock(),
             ptr: ptr2,
         };
-        if (*ptr2).dev != (*ptr).dev || !dp.dirlink(name, (*ptr).inum) {
+        if (*ptr2).dev != (*ptr).dev || dp.dirlink(name, (*ptr).inum).is_err() {
             dp.unlockput();
         } else {
             dp.unlockput();
@@ -258,15 +258,10 @@ unsafe fn create(path: &Path, typ: i16, major: u16, minor: u16) -> Result<InodeG
         dp.update();
 
         // No ip->nlink++ for ".": avoid cyclic ref count.
-        if !ip.dirlink(FileName::from_bytes(b"."), (*ptr2).inum)
-            || !ip.dirlink(FileName::from_bytes(b".."), (*ptr).inum)
-        {
-            panic!("create dots");
-        }
+        assert!(ip.dirlink(FileName::from_bytes(b"."), (*ptr2).inum).is_ok()
+        && ip.dirlink(FileName::from_bytes(b".."), (*ptr).inum).is_ok(),"create dots");
     }
-    if !dp.dirlink(&name, (*ptr2).inum) {
-        panic!("create: dirlink");
-    }
+    assert!(dp.dirlink(&name, (*ptr2).inum).is_ok(), "create: dirlink");
     dp.unlockput();
     Ok(ip)
 }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -179,12 +179,11 @@ pub unsafe fn sys_unlink() -> usize {
 
     // Cannot unlink "." or "..".
     if !(name.as_bytes() == b"." || name.as_bytes() == b"..") {
-        let ptr = dp.dirlookup(&name, &mut off);
         // TODO: use other Result related functions
-        if ptr.is_ok() {
+        if let Ok(ptr) = dp.dirlookup(&name, &mut off) {
             let mut ip = InodeGuard {
-                guard: (*ptr.unwrap()).lock(),
-                ptr: ptr.unwrap(),
+                guard: (*ptr).lock(),
+                ptr,
             };
             if ip.guard.nlink < 1 {
                 panic!("unlink: nlink < 1");
@@ -228,13 +227,12 @@ unsafe fn create(path: &Path, typ: i16, major: u16, minor: u16) -> Result<InodeG
         guard: (*ptr).lock(),
         ptr,
     };
-    let ptr2 = dp.dirlookup(&name, ptr::null_mut());
     // TODO: use other Result related functions
-    if ptr2.is_ok() {
+    if let Ok(ptr2) = dp.dirlookup(&name, ptr::null_mut()) {
         dp.unlockput();
         let ip = InodeGuard {
-            guard: (*ptr2.unwrap()).lock(),
-            ptr: ptr2.unwrap(),
+            guard: (*ptr2).lock(),
+            ptr: ptr2,
         };
         if typ == T_FILE && (ip.guard.typ == T_FILE || ip.guard.typ == T_DEVICE) {
             return Ok(ip);

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -441,7 +441,7 @@ pub unsafe fn sys_exec() -> usize {
     }
 
     let ret = if success {
-        exec(Path::new(path), argv.as_mut_ptr()) as usize
+        ok_or!(exec(Path::new(path), argv.as_mut_ptr()), usize::MAX)
     } else {
         usize::MAX
     };

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -193,7 +193,7 @@ impl DescriptorPool {
             }
         }
 
-        Some(descs.into_inner().unwrap())
+        descs.into_inner().ok()
     }
 
     /// Mark a descriptor as free.


### PR DESCRIPTION
- 아래와 같이 struct Inode를 리팩토링했습니다. 이유는
  - Inode의 Sleeplock이 보호하는 대상을 명확히 하고
  - Inode의 Sleeplock을 쥔 상태에서 호출되는 함수는 `impl InodeGuard<'_>`에서 다루기 위함입니다.
```Rust
pub struct InodeGuard<'a> {
    guard: SleepLockGuard<'a, InodeInner>,
    pub ptr: &'a Inode,
}
pub struct InodeInner {
    /// inode has been read from disk?
    pub valid: bool,
    /// copy of disk inode
    pub typ: i16,
    pub major: u16,
    pub minor: u16,
    pub nlink: i16,
    pub size: u32,
    pub addrs: [u32; 13],
}

/// in-memory copy of an inode
pub struct Inode {
    /// Device number
    pub dev: u32,

    /// Inode number
    pub inum: u32,

    /// Reference count
    pub ref_0: i32,

    // pub inner: InodeInner,
    pub inner: SleeplockWIP<InodeInner>,
}
```
- [x] Inode를 Sleeplock으로 감싸며, `lock()` 실행 시 `InodeGuard`를 리턴한다. `InodeGuard`는 Inode의 valid 필드도 접근/수정해야 해서 InodeGuard의 ptr 필드는 `*mut Inode`이다.
  - [x] Inode의 sleeplock을 쥔 상태에서만 실행되는 함수들은 `impl InodeGuard`로 옮김
- [x] struct field의 타입 / 함수의 리턴 타입을 적절히 변경
- [x] Inode 관련 함수 중 실패할 때 -1을 리턴하는 함수가 Result를 리턴하도록 변경 (sysfile.rs 제외)
  - [x] 불필요한 if 문 대신`map_or()`, `?` 연산자 등을 적절히 사용
- [ ] 불필요한 wrapping 대신 +-*/% 연산자 사용
- [ ] `InodeGuard`에 꼭 `ptr : *mut Inode`가 있어야 하는지 고민하기 : valid 필드를 InodeInner에 넣는 등의 방법으로 해결할 수 있을지 고민하기
- [ ] #218, #224, #231
- `Buf`의 Sleeplock도 SleeplockWIP로 변경? (우선순위 고민)

