### PR TITLE
Add helper functions in Spinlock and Sleeplock.

### DIFF
--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -48,6 +48,17 @@ impl<T> SleeplockWIP<T> {
             _marker: PhantomData,
         }
     }
+
+    /// # Safety
+    ///
+    /// `self` must not be shared by other threads.
+    pub unsafe fn get_mut_unchecked(&self) -> &mut T {
+        &mut *self.data.get()
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.data.get() }
+    }
 }
 
 impl<T> SleepLockGuard<'_, T> {

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -154,6 +154,17 @@ impl<T> Spinlock<T> {
             _marker: PhantomData,
         }
     }
+
+    /// # Safety
+    ///
+    /// `self` must not be shared by other threads.
+    pub unsafe fn get_mut_unchecked(&self) -> &mut T {
+        &mut *self.data.get()
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.data.get() }
+    }
 }
 
 impl<T> SpinLockGuard<'_, T> {


### PR DESCRIPTION
`Sleeplock`과 `Spinlock` 에 `get_mut` 과 `get_mut_unchecked` 를 추가합니다.

 - `get_mut` 은 해당 락을 가리키는 레퍼런스가 유일할 때 락을 걸지 않고 내부 data를 mutable하게 빌릴 수 있습니다.
 - `get_mut_unchecked` 는 일반적으로 사용하면 안 되지만, 리팩토링 중간 과정에서 유용하게 쓸 수 있습니다: lock으로 보호하는 부분과 보호하지 않는 부분을 나누는 리팩토링을 할 때, 락을 걸지 않고 inner를 접근하는 코드가 있을 수 있습니다. 그 경우 먼저 `get_mut_unchecked` 를 사용하여 (비록 unsafe 하더라도) 최소한의 수정으로 테스트 가능한 커밋을 만들고, 추후에 올바르게 코드를 수정하여 급격한 코드 변화로 인한 디버깅 비용을 줄일 수 있습니다. (cc @kimjungwow @coolofficials)

메서드만 추가하는 것이므로 바로 머지하겠습니다.
