### PR TITLE
[Closes #218] Make FileType::Inode::Off Cell

### DIFF
--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -9,8 +9,7 @@ use crate::{
     spinlock::Spinlock,
     stat::Stat,
 };
-use core::cmp;
-use core::convert::TryFrom;
+use core::{cmp, convert::TryFrom};
 
 pub struct File {
     pub typ: FileType,
@@ -72,26 +71,17 @@ impl File {
 
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
-    pub unsafe fn stat(&mut self, addr: usize) -> Result<(), ()> {
+    pub unsafe fn stat(&self, addr: usize) -> Result<(), ()> {
         let p: *mut Proc = myproc();
 
         match self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = (*ip).lock().stat();
-                if (*p)
-                    .pagetable
-                    .assume_init_mut()
-                    .copyout(
-                        addr,
-                        &mut st as *mut Stat as *mut u8,
-                        ::core::mem::size_of::<Stat>() as usize,
-                    )
-                    .is_err()
-                {
-                    Err(())
-                } else {
-                    Ok(())
-                }
+                (*p).pagetable.assume_init_mut().copyout(
+                    addr,
+                    &mut st as *mut Stat as *mut u8,
+                    ::core::mem::size_of::<Stat>() as usize,
+                )
             }
             _ => Err(()),
         }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -9,7 +9,7 @@ use crate::{
     spinlock::Spinlock,
     stat::Stat,
 };
-use core::{cell::UnsafeCell, cmp, convert::TryFrom};
+use core::{cell::Cell, cmp, convert::TryFrom};
 pub struct File {
     pub typ: FileType,
     readable: bool,
@@ -21,17 +21,9 @@ unsafe impl Send for File {}
 
 pub enum FileType {
     None,
-    Pipe {
-        pipe: AllocatedPipe,
-    },
-    Inode {
-        ip: *mut Inode,
-        off: UnsafeCell<u32>,
-    },
-    Device {
-        ip: *mut Inode,
-        major: u16,
-    },
+    Pipe { pipe: AllocatedPipe },
+    Inode { ip: *mut Inode, off: Cell<u32> },
+    Device { ip: *mut Inode, major: u16 },
 }
 
 /// map major device number to device functions.
@@ -105,10 +97,10 @@ impl File {
             FileType::Pipe { pipe } => pipe.read(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
                 let mut ip = (**ip).lock();
-                let curr_off = *off.get();
+                let curr_off = off.get();
                 let ret = ip.read(true, addr, curr_off, n as u32);
                 if let Ok(v) = ret {
-                    *off.get() = curr_off.wrapping_add(v as u32);
+                    off.set(curr_off.wrapping_add(v as u32));
                 }
                 drop(ip);
                 ret
@@ -142,7 +134,7 @@ impl File {
                     let bytes_to_write = cmp::min(n - bytes_written, max as i32);
                     fs().begin_op();
                     let mut ip = (**ip).lock();
-                    let curr_off = *off.get();
+                    let curr_off = off.get();
                     let bytes_written = ip
                         .write(
                             true,
@@ -151,7 +143,7 @@ impl File {
                             bytes_to_write as u32,
                         )
                         .map(|v| {
-                            *off.get() = curr_off.wrapping_add(v as u32);
+                            off.set(curr_off.wrapping_add(v as u32));
                             v
                         });
                     drop(ip);

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -17,9 +17,7 @@ use crate::{
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
 };
 
-use core::mem;
-use core::ptr;
-use core::slice;
+use core::{cell::UnsafeCell, mem, ptr, slice};
 
 impl RcFile {
     /// Allocate a file descriptor for the given file.
@@ -276,7 +274,7 @@ pub unsafe fn sys_open() -> usize {
     } else {
         (*f).typ = FileType::Inode {
             ip: *(&ip.ptr as *const _ as *mut _),
-            off: 0,
+            off: UnsafeCell::new(0),
         };
     }
 

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -17,7 +17,7 @@ use crate::{
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
 };
 
-use core::{cell::Cell, mem, ptr, slice};
+use core::{cell::UnsafeCell, mem, ptr, slice};
 
 impl RcFile {
     /// Allocate a file descriptor for the given file.
@@ -274,7 +274,7 @@ pub unsafe fn sys_open() -> usize {
     } else {
         (*f).typ = FileType::Inode {
             ip: *(&ip.ptr as *const _ as *mut _),
-            off: Cell::new(0),
+            off: UnsafeCell::new(0),
         };
     }
 

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -17,7 +17,7 @@ use crate::{
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
 };
 
-use core::{cell::UnsafeCell, mem, ptr, slice};
+use core::{cell::Cell, mem, ptr, slice};
 
 impl RcFile {
     /// Allocate a file descriptor for the given file.
@@ -274,7 +274,7 @@ pub unsafe fn sys_open() -> usize {
     } else {
         (*f).typ = FileType::Inode {
             ip: *(&ip.ptr as *const _ as *mut _),
-            off: UnsafeCell::new(0),
+            off: Cell::new(0),
         };
     }
 


### PR DESCRIPTION
### FileType::Inode::Off의 타입을 u32에서 Cell<u32>로 바꿔서 `File::read(), write(), stat()`이 `&mut self`가 아닌 `&self`를 받도록 했습니다.

- Closes #218 
- https://github.com/kaist-cp/rv6/pull/211#discussion_r489970751 에서 언급되었듯, `File::read(), write(), stat()`가 `&mut self` 를 받는 것은 실제 의미와 다릅니다. 
(&mut self 는 File 에 대한 접근을 할 때 다른 스레드에서는 File 에 접근할 수 없다는 뜻인데, File 자체에 걸린 락이 없어서 그렇게 되지는 않습니다.)
- https://github.com/kaist-cp/rv6/issues/218#issue-705237761 에서는 `Inode` 의 lock 을 건 상태에서만 `off` 를 접근할 수 있는 타입을 말씀해주셨습니다. 
그런데 이 타입의 목적이 `File::read(), write(), stat()`이 `&mut self`가 아닌 `&self`을 받도록 하기 위함이면 FileType::Inode::Off의 타입을 u32에서 Cell<u32>로 바꿔도 괜찮을까요? 
**여러 개의 파일이 동시에 한 Inode를 가리킬 수 있어서 off 를 inode 에 집어넣을 수 없기 때문에, 저는 Inode의 lock을 쥐어야지만 off를 수정할 수 있음을 명시적으로 나타낼 필요는 없다고 판단했습니다.** 
물론 `File::read(), write()` 코드에서는 Inode의 lock을 먼저 쥔 뒤 `InodeGuard::read, write()`를 실행하고, off를 수정한 뒤, Inode의 lock을 drop합니다.