### PR TITLE
[Closes #217] Idiomatic initialization for RcFile

### DIFF
--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -58,11 +58,12 @@ pub type RcFile = Rc<FTableTag>;
 
 impl RcFile {
     /// Allocate a file structure.
-    pub fn alloc(typ: FileType, readable: bool, writable: bool) -> Option<Self> {
-        // TODO: idiomatic initialization.
-        FTableTag {}.alloc(|p| unsafe {
-            ptr::write(p, File::new(typ, readable, writable));
-        })
+    pub fn alloc() -> Option<Self> {
+        FTableTag {}.alloc()
+    }
+
+    pub unsafe fn update(&mut self, f: File) {
+        ptr::write(&mut **self, f);
     }
 }
 


### PR DESCRIPTION
- Closes #217 
- `RcFile::alloc()`에서는 메모리 할당만 하고, 실제로 초기화하는 것은 (File::Pipe 값을 넣는 것은) `RcFile::update()`에서 진행합니다.
- 이를 위해 `arena.rs`에 `DerefMut`을 추가했습니다.