### PR TITLE
implemented ProcData

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -88,7 +88,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if (*myproc()).killed() {
+                if (*(*myproc()).data.get()).killed() {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -16,6 +16,7 @@ pub unsafe fn exec(path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
     let mut elf: ElfHdr = Default::default();
     let mut ph: ProgHdr = Default::default();
     let mut p: *mut Proc = myproc();
+    let mut data = &mut *(*p).data.get();
 
     fs().begin_op();
     let ptr = ok_or!(path.namei(), {
@@ -82,7 +83,7 @@ pub unsafe fn exec(path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
     drop(ip);
 
     p = myproc();
-    let oldsz: usize = (*p).sz;
+    let oldsz: usize = data.sz;
 
     // Allocate two pages at the next page boundary.
     // Use the second as the user stack.
@@ -136,7 +137,7 @@ pub unsafe fn exec(path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
         // arguments to user main(argc, argv)
         // argc is returned via the system call return
         // value, which goes in a0.
-        (*(*p).tf).a1 = sp;
+        (*data.tf).a1 = sp;
 
         // Save program name for debugging.
         let mut s = path.as_bytes().as_ptr();
@@ -154,14 +155,14 @@ pub unsafe fn exec(path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
         );
 
         // Commit to the user image.
-        let mut oldpagetable = core::mem::replace((*p).pagetable.assume_init_mut(), pt);
-        (*p).sz = sz;
+        let mut oldpagetable = core::mem::replace(data.pagetable.assume_init_mut(), pt);
+        data.sz = sz;
 
         // initial program counter = main
-        (*(*p).tf).epc = elf.entry;
+        (*data.tf).epc = elf.entry;
 
         // initial stack pointer
-        (*(*p).tf).sp = sp;
+        (*data.tf).sp = sp;
         proc_freepagetable(&mut oldpagetable, oldsz);
 
         // this ends up in a0, the first argument to main(argc, argv)

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -83,7 +83,7 @@ impl File {
         match self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = (*ip).lock().stat();
-                (*p).pagetable.assume_init_mut().copyout(
+                (*(*p).data.get()).pagetable.assume_init_mut().copyout(
                     addr,
                     &mut st as *mut Stat as *mut u8,
                     ::core::mem::size_of::<Stat>() as usize,

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -156,15 +156,17 @@ impl PipeInner {
     unsafe fn try_write(&mut self, addr: usize, n: usize) -> Result<usize, ()> {
         let mut ch: u8 = 0;
         let proc = myproc();
+        let data = &mut *(*proc).data.get();
+
         for i in 0..n {
             if self.nwrite == self.nread.wrapping_add(PIPESIZE as u32) {
                 //DOC: pipewrite-full
-                if !self.readopen || (*proc).killed() {
+                if !self.readopen || data.killed() {
                     return Err(());
                 }
                 return Ok(i);
             }
-            if (*proc)
+            if data
                 .pagetable
                 .assume_init_mut()
                 .copyin(&mut ch, addr.wrapping_add(i), 1usize)
@@ -180,10 +182,11 @@ impl PipeInner {
 
     unsafe fn try_read(&mut self, addr: usize, n: usize) -> Result<usize, PipeError> {
         let proc = myproc();
+        let data = &mut *(*proc).data.get();
 
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {
-            if (*proc).killed() {
+            if data.killed() {
                 return Err(PipeError::InvalidStatus);
             }
             return Err(PipeError::WaitForIO);
@@ -196,7 +199,7 @@ impl PipeInner {
             }
             let ch = self.data[self.nread as usize % PIPESIZE];
             self.nread = self.nread.wrapping_add(1);
-            if (*proc)
+            if data
                 .pagetable
                 .assume_init_mut()
                 .copyout(addr.wrapping_add(i), &ch, 1usize)

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -462,7 +462,7 @@ impl ProcData {
         self.killed.store(true, Ordering::Release);
     }
 
-    pub unsafe fn killed(&self) -> bool {
+    pub unsafe fn killed(&mut self) -> bool {
         self.killed.load(Ordering::Acquire)
     }
 
@@ -542,22 +542,24 @@ impl ProcessSystem {
         for p in &self.process_pool {
             let mut guard = p.lock();
             if guard.deref_inner().state == Procstate::UNUSED {
+                let data = &mut *guard.data.get();
                 guard.deref_mut_inner().pid = allocpid();
 
                 // Allocate a trapframe page.
-                (*guard.data.get()).tf = kernel().alloc() as *mut Trapframe;
-                if (*guard.data.get()).tf.is_null() {
+                data.tf = kernel().alloc() as *mut Trapframe;
+                if data.tf.is_null() {
                     return Err(());
                 }
 
                 // An empty user page table.
-                (*guard.data.get()).pagetable = mem::MaybeUninit::new(proc_pagetable(p as *const _ as *mut _));
+                data.pagetable = mem::MaybeUninit::new(proc_pagetable(p as *const _ as *mut _));
 
                 // Set up new context to start executing at forkret,
                 // which returns to user space.
-                ptr::write_bytes(&mut guard.context as *mut Context, 0, 1);
-                guard.context.ra = forkret as usize;
-                guard.context.sp = p.kstack.wrapping_add(PGSIZE);
+                // This is safe according to following paper: Stacked Borrows (https://plv.mpi-sws.org/rustbelt/stacked-borrows/paper.pdf).
+                ptr::write_bytes(&mut data.context, 0, 1);
+                data.context.ra = forkret as usize;
+                data.context.sp = data.kstack.wrapping_add(PGSIZE);
                 return Ok(guard);
             }
         }
@@ -594,7 +596,7 @@ impl ProcessSystem {
         for p in &self.process_pool {
             let mut guard = p.lock();
             if guard.deref_inner().pid == pid {
-                guard.kill();
+                (*guard.data.get()).kill();
                 guard.wakeup();
                 return 0;
             }
@@ -615,31 +617,32 @@ impl ProcessSystem {
 
     /// Set up first user process.
     pub unsafe fn user_proc_init(&mut self) {
-        let mut p = self.alloc().expect("user_proc_init");
+        let mut guard = self.alloc().expect("user_proc_init");
 
-        self.initial_proc = p.raw() as *mut _;
+        self.initial_proc = guard.raw() as *mut _;
 
+        let data = &mut *guard.data.get();
         // Allocate one user page and copy init's instructions
         // and data into it.
-        (*p).pagetable.assume_init_mut().uvminit(&INITCODE);
-        (*p).sz = PGSIZE;
+        data.pagetable.assume_init_mut().uvminit(&INITCODE);
+        data.sz = PGSIZE;
 
         // Prepare for the very first "return" from kernel to user.
 
         // User program counter.
-        (*(*p).tf).epc = 0;
+        (*data.tf).epc = 0;
 
         // User stack pointer.
-        (*(*p).tf).sp = PGSIZE;
+        (*data.tf).sp = PGSIZE;
         safestrcpy(
-            (*p).name.as_mut_ptr(),
+            (*guard).name.as_mut_ptr(),
             b"initcode\x00" as *const u8,
             ::core::mem::size_of::<[u8; 16]>() as i32,
         );
-        (*p).cwd = Path::new(CStr::from_bytes_with_nul_unchecked(b"/\x00"))
+        data.cwd = Path::new(CStr::from_bytes_with_nul_unchecked(b"/\x00"))
             .namei()
             .unwrap_or(ptr::null_mut());
-        p.deref_mut_inner().state = Procstate::RUNNABLE;
+        guard.deref_mut_inner().state = Procstate::RUNNABLE;
     }
 
     /// Create a new process, copying the parent.
@@ -650,32 +653,34 @@ impl ProcessSystem {
         // Allocate process.
         let mut np = ok_or!(self.alloc(), return -1);
 
+        let mut pdata = &mut *(*p).data.get();
+        let mut npdata =&mut *np.data.get();
         // Copy user memory from parent to child.
-        if (*p)
+        if pdata
             .pagetable
             .assume_init_mut()
-            .uvmcopy((*np).pagetable.assume_init_mut(), (*p).sz)
+            .uvmcopy(npdata.pagetable.assume_init_mut(), pdata.sz)
             .is_err()
         {
             freeproc(np);
             return -1;
         }
-        (*np).sz = (*p).sz;
+        npdata.sz = pdata.sz;
         np.deref_mut_inner().parent = p;
 
         // Copy saved user registers.
-        *(*np).tf = *(*p).tf;
+        *npdata.tf = *pdata.tf;
 
         // Cause fork to return 0 in the child.
-        (*(*np).tf).a0 = 0;
+        (*npdata.tf).a0 = 0;
 
         // Increment reference counts on open file descriptors.
         for i in 0..NOFILE {
-            if let Some(file) = &(*p).open_files[i] {
-                (*np).open_files[i] = Some(file.clone())
+            if let Some(file) = &pdata.open_files[i] {
+                npdata.open_files[i] = Some(file.clone())
             }
         }
-        (*np).cwd = (*(*p).cwd).idup();
+        npdata.cwd = (*pdata.cwd).idup();
         safestrcpy(
             (*np).name.as_mut_ptr(),
             (*p).name.as_mut_ptr(),
@@ -690,6 +695,7 @@ impl ProcessSystem {
     /// Return -1 if this process has no children.
     pub unsafe fn wait(&self, addr: usize) -> i32 {
         let p: *mut Proc = myproc();
+        let mut data = *(*p).data.get();
 
         // Hold p->lock for the whole time to avoid lost
         // Wakeups from a child's exit().
@@ -709,7 +715,7 @@ impl ProcessSystem {
                     if np.deref_inner().state == Procstate::ZOMBIE {
                         let pid = np.deref_inner().pid;
                         if addr != 0
-                            && (*p)
+                            && data
                                 .pagetable
                                 .assume_init_mut()
                                 .copyout(
@@ -728,7 +734,7 @@ impl ProcessSystem {
             }
 
             // No point waiting if we don't have any children.
-            if !havekids || (*p).killed() {
+            if !havekids || data.killed() {
                 return -1;
             }
 
@@ -746,11 +752,12 @@ impl ProcessSystem {
     /// until its parent calls wait().
     pub unsafe fn exit_current(&self, status: i32) {
         let p = myproc();
+        let mut data = *(*p).data.get();
         if p == self.initial_proc {
             panic!("init exiting");
         }
 
-        (*p).close_files();
+        data.close_files();
 
         // We might re-parent a child to init. We can't be precise about
         // waking up init, since we can't acquire its lock once we've
@@ -812,7 +819,7 @@ impl ProcessSystem {
 
 pub unsafe fn procinit(procs: &mut ProcessSystem, page_table: &mut PageTable) {
     for (i, p) in procs.process_pool.iter_mut().enumerate() {
-        p.palloc(page_table, i);
+        (*p.data.get()).palloc(page_table, i);
     }
 }
 
@@ -846,21 +853,22 @@ fn allocpid() -> i32 {
 /// including user pages.
 /// p->lock must be held.
 unsafe fn freeproc(mut p: ProcGuard) {
-    if !(*p).tf.is_null() {
-        kernel().free((*p).tf as _);
+    let mut data = &mut *p.data.get();
+    if !data.tf.is_null() {
+        kernel().free(data.tf as _);
     }
-    (*p).tf = ptr::null_mut();
-    if !(*p).pagetable.assume_init_mut().is_null() {
-        let sz = (*p).sz;
-        proc_freepagetable((*p).pagetable.assume_init_mut(), sz);
+    data.tf = ptr::null_mut();
+    if !data.pagetable.assume_init_mut().is_null() {
+        let sz = data.sz;
+        proc_freepagetable(data.pagetable.assume_init_mut(), sz);
     }
-    (*p).pagetable = mem::MaybeUninit::uninit();
-    (*p).sz = 0;
+    data.pagetable = mem::MaybeUninit::uninit();
+    data.sz = 0;
     p.deref_mut_inner().pid = 0;
     p.deref_mut_inner().parent = ptr::null_mut();
     (*p).name[0] = 0;
     p.deref_mut_inner().waitchannel = ptr::null();
-    (*p).killed = AtomicBool::new(false);
+    data.killed = AtomicBool::new(false);
     p.deref_mut_inner().xstate = 0;
     p.deref_mut_inner().state = Procstate::UNUSED;
 }
@@ -888,7 +896,7 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> PageTable {
 
     // Map the trapframe just below TRAMPOLINE, for trampoline.S.
     pagetable
-        .mappages(TRAPFRAME, PGSIZE, (*p).tf as usize, PTE_R | PTE_W)
+        .mappages(TRAPFRAME, PGSIZE, (*(*p).data.get()).tf as usize, PTE_R | PTE_W)
         .expect("proc_pagetable: mappages TRAPFRAME");
     pagetable
 }
@@ -915,22 +923,23 @@ const INITCODE: [u8; 51] = [
 /// Return 0 on success, -1 on failure.
 pub unsafe fn resizeproc(n: i32) -> i32 {
     let mut p = myproc();
-    let sz = (*p).sz;
+    let mut data = *(*p).data.get();
+    let sz = data.sz;
     let sz = match n.cmp(&0) {
         cmp::Ordering::Equal => sz,
         cmp::Ordering::Greater => {
-            let sz = (*p)
+            let sz = data
                 .pagetable
                 .assume_init_mut()
                 .uvmalloc(sz, sz.wrapping_add(n as usize));
             ok_or!(sz, return -1)
         }
-        cmp::Ordering::Less => (*p)
+        cmp::Ordering::Less => data
             .pagetable
             .assume_init_mut()
             .uvmdealloc(sz, sz.wrapping_add(n as usize)),
     };
-    (*p).sz = sz;
+    data.sz = sz;
     0
 }
 
@@ -956,7 +965,7 @@ pub unsafe fn scheduler() -> ! {
                 // before jumping back to us.
                 guard.deref_mut_inner().state = Procstate::RUNNING;
                 (*c).proc = p as *const _ as *mut _;
-                swtch(&mut (*c).scheduler, &mut guard.context);
+                swtch(&mut (*c).scheduler, &mut (*guard.data.get()).context);
 
                 // Process is done running for now.
                 // It should have changed its p->state before coming back.
@@ -986,7 +995,7 @@ unsafe fn sched(p: &mut ProcGuard) {
         panic!("sched interruptible");
     }
     let interrupt_enabled = (*kernel().mycpu()).interrupt_enabled;
-    swtch(&mut (*p).context, &mut (*kernel().mycpu()).scheduler);
+    swtch(&mut (*(*p).data.get()).context, &mut (*kernel().mycpu()).scheduler);
     (*kernel().mycpu()).interrupt_enabled = interrupt_enabled;
 }
 
@@ -1016,7 +1025,7 @@ unsafe fn forkret() {
 pub unsafe fn either_copyout(user_dst: bool, dst: usize, src: &[u8]) -> Result<(), ()> {
     let p = myproc();
     if user_dst {
-        (*p).pagetable
+        (*(*p).data.get()).pagetable
             .assume_init_mut()
             .copyout(dst, src.as_ptr(), src.len())
             .map_or(Err(()), |_v| Ok(()))
@@ -1037,7 +1046,7 @@ pub unsafe fn either_copyin(
 ) -> Result<(), ()> {
     let p = myproc();
     if user_src {
-        (*p).pagetable
+        (*(*p).data.get()).pagetable
             .assume_init_mut()
             .copyin(dst, src, len)
             .map_or(Err(()), |_v| Ok(()))

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -18,6 +18,7 @@ use core::{
     ops::{Deref, DerefMut},
     ptr, str,
     sync::atomic::{AtomicBool, Ordering},
+    cell::UnsafeCell,
 };
 
 use cstr_core::CStr;
@@ -242,9 +243,9 @@ impl WaitChannel {
         // so it's okay to release lk.
 
         //DOC: sleeplock0
-        if lk != (*p).inner.raw() as *mut RawSpinlock {
+        if lk != (*p).info.raw() as *mut RawSpinlock {
             //DOC: sleeplock1
-            mem::forget((*p).inner.lock());
+            mem::forget((*p).info.lock());
             (*lk).release();
         }
 
@@ -259,8 +260,8 @@ impl WaitChannel {
         mem::forget(guard);
 
         // Reacquire original lock.
-        if lk != (*p).inner.raw() as *mut RawSpinlock {
-            (*p).inner.unlock();
+        if lk != (*p).info.raw() as *mut RawSpinlock {
+            (*p).info.unlock();
             (*lk).acquire();
         };
     }
@@ -272,8 +273,8 @@ impl WaitChannel {
     }
 }
 
-/// Proc::inner's spinlock must be held when using these.
-struct ProcInner {
+/// Proc::info's spinlock must be held when using these.
+struct ProcInfo {
     /// Process state.
     state: Procstate,
 
@@ -293,12 +294,8 @@ struct ProcInner {
     pid: i32,
 }
 
-/// Per-process state.
-pub struct Proc {
-    inner: Spinlock<ProcInner>,
-
-    /// These are private to the process, so p->lock need not be held.
-
+/// Proc::data are private to the process, so lock need not be held.
+struct ProcData {
     /// If true, the process have been killed.
     killed: AtomicBool,
 
@@ -322,6 +319,13 @@ pub struct Proc {
 
     /// Current directory.
     pub cwd: *mut Inode,
+}
+
+/// Per-process state.
+pub struct Proc {
+    info: Spinlock<ProcInfo>,
+
+    data: UnsafeCell<ProcData>,    
 
     /// Process name (debugging).
     pub name: [u8; 16],
@@ -333,12 +337,12 @@ struct ProcGuard {
 }
 
 impl ProcGuard {
-    fn deref_inner(&self) -> &ProcInner {
-        unsafe { (*self.ptr).inner.get_mut_unchecked() }
+    fn deref_inner(&self) -> &ProcInfo {
+        unsafe { (*self.ptr).info.get_mut_unchecked() }
     }
 
-    fn deref_mut_inner(&mut self) -> &mut ProcInner {
-        unsafe { (*self.ptr).inner.get_mut_unchecked() }
+    fn deref_mut_inner(&mut self) -> &mut ProcInfo {
+        unsafe { (*self.ptr).info.get_mut_unchecked() }
     }
 
     unsafe fn from_raw(ptr: *const Proc) -> Self {
@@ -363,7 +367,7 @@ impl Drop for ProcGuard {
     fn drop(&mut self) {
         unsafe {
             let proc = &*self.ptr;
-            proc.inner.unlock();
+            proc.info.unlock();
         }
     }
 }
@@ -426,20 +430,9 @@ impl Procstate {
     }
 }
 
-impl Proc {
-    const fn zero() -> Self {
+impl ProcData {
+    const fn new() -> Self {
         Self {
-            inner: Spinlock::new(
-                "proc",
-                ProcInner {
-                    state: Procstate::UNUSED,
-                    parent: ptr::null_mut(),
-                    child_waitchannel: WaitChannel::new(),
-                    waitchannel: ptr::null(),
-                    xstate: 0,
-                    pid: 0,
-                },
-            ),
             killed: AtomicBool::new(false),
             kstack: 0,
             sz: 0,
@@ -447,14 +440,8 @@ impl Proc {
             tf: ptr::null_mut(),
             context: Context::new(),
             open_files: [None; NOFILE],
-            cwd: ptr::null_mut(),
-            name: [0; 16],
+            cwd: ptr::null_mut(),    
         }
-    }
-
-    fn lock(&self) -> ProcGuard {
-        mem::forget(self.inner.lock());
-        ProcGuard { ptr: self }
     }
 
     /// Allocate a page for the process's kernel stack.
@@ -470,39 +457,66 @@ impl Proc {
         self.kstack = va;
     }
 
-    pub unsafe fn pid(&self) -> i32 {
-        self.inner.get_mut_unchecked().pid
-    }
-
-    pub unsafe fn state(&self) -> Procstate {
-        self.inner.get_mut_unchecked().state
-    }
-
     /// Kill and wake the process up.
-    pub fn kill(&self) {
+    pub unsafe fn kill(&mut self) {
         self.killed.store(true, Ordering::Release);
     }
 
-    pub fn killed(&self) -> bool {
+    pub unsafe fn killed(&self) -> bool {
         self.killed.load(Ordering::Acquire)
-    }
-
-    /// Wake process from sleep().
-    fn wakeup(&mut self) {
-        if self.inner.get_mut().state == Procstate::SLEEPING {
-            self.inner.get_mut().state = Procstate::RUNNABLE
-        }
     }
 
     /// Close all open files.
     unsafe fn close_files(&mut self) {
-        for file in &mut self.open_files {
+        for file in self.open_files.into_iter() {
             *file = None;
         }
         fs().begin_op();
         (*self.cwd).put();
         fs().end_op();
         self.cwd = ptr::null_mut();
+    }
+}
+
+impl Proc {
+    const fn zero() -> Self {
+        Self {
+            info: Spinlock::new(
+                "proc",
+                ProcInfo {
+                    state: Procstate::UNUSED,
+                    parent: ptr::null_mut(),
+                    child_waitchannel: WaitChannel::new(),
+                    waitchannel: ptr::null(),
+                    xstate: 0,
+                    pid: 0,
+                },
+            ),
+            data: UnsafeCell::new(
+                ProcData::new(),
+            ),
+            name: [0; 16],
+        }
+    }
+
+    fn lock(&self) -> ProcGuard {
+        mem::forget(self.info.lock());
+        ProcGuard { ptr: self }
+    }
+
+    pub unsafe fn pid(&self) -> i32 {
+        self.info.get_mut_unchecked().pid
+    }
+
+    pub unsafe fn state(&self) -> Procstate {
+        self.info.get_mut_unchecked().state
+    }
+
+    /// Wake process from sleep().
+    fn wakeup(&mut self) {
+        if self.info.get_mut().state == Procstate::SLEEPING {
+            self.info.get_mut().state = Procstate::RUNNABLE
+        }
     }
 }
 
@@ -531,13 +545,13 @@ impl ProcessSystem {
                 guard.deref_mut_inner().pid = allocpid();
 
                 // Allocate a trapframe page.
-                guard.tf = kernel().alloc() as *mut Trapframe;
-                if guard.tf.is_null() {
+                (*guard.data.get()).tf = kernel().alloc() as *mut Trapframe;
+                if (*guard.data.get()).tf.is_null() {
                     return Err(());
                 }
 
                 // An empty user page table.
-                guard.pagetable = mem::MaybeUninit::new(proc_pagetable(p as *const _ as *mut _));
+                (*guard.data.get()).pagetable = mem::MaybeUninit::new(proc_pagetable(p as *const _ as *mut _));
 
                 // Set up new context to start executing at forkret,
                 // which returns to user space.
@@ -559,7 +573,7 @@ impl ProcessSystem {
             // Acquiring the lock first could cause a deadlock
             // if pp or a child of pp were also in exit()
             // and about to try to lock p.
-            if pp.inner.get_mut_unchecked().parent == p.raw() as *mut _ {
+            if pp.info.get_mut_unchecked().parent == p.raw() as *mut _ {
                 // pp->parent can't change between the check and the acquire()
                 // because only the parent changes it, and we're the parent.
                 let mut guard = pp.lock();
@@ -687,7 +701,7 @@ impl ProcessSystem {
                 // This code uses np->parent without holding np->lock.
                 // Acquiring the lock first would cause a deadlock,
                 // since np might be an ancestor, and we already hold p->lock.
-                if np.inner.get_mut_unchecked().parent == p {
+                if np.info.get_mut_unchecked().parent == p {
                     // np->parent can't change between the check and the acquire()
                     // because only the parent changes it, and we're the parent.
                     let mut np = np.lock();
@@ -723,7 +737,7 @@ impl ProcessSystem {
             guard
                 .deref_mut_inner()
                 .child_waitchannel
-                .sleep_raw((*p).inner.raw() as *mut _);
+                .sleep_raw((*p).info.raw() as *mut _);
         }
     }
 
@@ -783,7 +797,7 @@ impl ProcessSystem {
     pub unsafe fn dump(&self) {
         println!();
         for p in &self.process_pool {
-            let inner = p.inner.get_mut_unchecked();
+            let inner = p.info.get_mut_unchecked();
             if inner.state != Procstate::UNUSED {
                 println!(
                     "{} {} {}",
@@ -988,7 +1002,7 @@ pub unsafe fn proc_yield() {
 /// will swtch to forkret.
 unsafe fn forkret() {
     // Still holding p->lock from scheduler.
-    (*(myproc as unsafe fn() -> *mut Proc)()).inner.unlock();
+    (*(myproc as unsafe fn() -> *mut Proc)()).info.unlock();
     // File system initialization must be run in the context of a
     // regular process (e.g., because it calls sleep), and thus cannot
     // be run from main().

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -23,11 +23,12 @@ impl RcFile {
     /// Allocate a file descriptor for the given file.
     /// Takes over file reference from caller on success.
     unsafe fn fdalloc(self) -> Result<i32, Self> {
-        let mut p: *mut Proc = myproc();
+        let p: *mut Proc = myproc();
+        let mut data = &mut *(*p).data.get();
         for fd in 0..NOFILE {
             // user pointer to struct stat
-            if (*p).open_files[fd].is_none() {
-                (*p).open_files[fd] = Some(self);
+            if data.open_files[fd].is_none() {
+                data.open_files[fd] = Some(self);
                 return Ok(fd as i32);
             }
         }
@@ -43,7 +44,10 @@ unsafe fn argfd(n: usize) -> Result<(i32, *mut RcFile), ()> {
         return Err(());
     }
 
-    let f = some_or!(&mut (*myproc()).open_files[fd as usize], return Err(()));
+    let f = some_or!(
+        &mut (*(*myproc()).data.get()).open_files[fd as usize],
+        return Err(())
+    );
 
     Ok((fd, f))
 }
@@ -72,7 +76,7 @@ pub unsafe fn sys_write() -> usize {
 
 pub unsafe fn sys_close() -> usize {
     let (fd, _) = ok_or!(argfd(0), return usize::MAX);
-    (*myproc()).open_files[fd as usize] = None;
+    (*(*myproc()).data.get()).open_files[fd as usize] = None;
     0
 }
 
@@ -317,7 +321,8 @@ pub unsafe fn sys_mknod() -> usize {
 
 pub unsafe fn sys_chdir() -> usize {
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
-    let mut p: *mut Proc = myproc();
+    let p: *mut Proc = myproc();
+    let mut data = &mut *(*p).data.get();
     fs().begin_op();
     let path = ok_or!(argstr(0, &mut path), {
         fs().end_op();
@@ -334,9 +339,9 @@ pub unsafe fn sys_chdir() -> usize {
         return usize::MAX;
     }
     drop(ip);
-    (*(*p).cwd).put();
+    (*data.cwd).put();
     fs().end_op();
-    (*p).cwd = ptr;
+    data.cwd = ptr;
     0
 }
 
@@ -387,18 +392,19 @@ pub unsafe fn sys_exec() -> usize {
 }
 
 pub unsafe fn sys_pipe() -> usize {
-    let mut p: *mut Proc = myproc();
+    let p: *mut Proc = myproc();
+    let mut data = &mut *(*p).data.get();
     // user pointer to array of two integers
     let fdarray = ok_or!(argaddr(0), return usize::MAX);
     let (pipereader, pipewriter) = ok_or!(AllocatedPipe::alloc(), return usize::MAX);
 
     let mut fd0 = ok_or!(pipereader.fdalloc(), return usize::MAX);
     let mut fd1 = ok_or!(pipewriter.fdalloc(), {
-        (*p).open_files[fd0 as usize] = None;
+        data.open_files[fd0 as usize] = None;
         return usize::MAX;
     });
 
-    if (*p)
+    if data
         .pagetable
         .assume_init_mut()
         .copyout(
@@ -407,7 +413,7 @@ pub unsafe fn sys_pipe() -> usize {
             mem::size_of::<i32>(),
         )
         .is_err()
-        || (*p)
+        || data
             .pagetable
             .assume_init_mut()
             .copyout(
@@ -417,8 +423,8 @@ pub unsafe fn sys_pipe() -> usize {
             )
             .is_err()
     {
-        (*p).open_files[fd0 as usize] = None;
-        (*p).open_files[fd1 as usize] = None;
+        data.open_files[fd0 as usize] = None;
+        data.open_files[fd1 as usize] = None;
         return usize::MAX;
     }
     0

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -27,7 +27,7 @@ pub unsafe fn sys_wait() -> usize {
 
 pub unsafe fn sys_sbrk() -> usize {
     let n = ok_or!(argint(0), return usize::MAX);
-    let addr: i32 = (*myproc()).sz as i32;
+    let addr: i32 = (*(*myproc()).data.get()).sz as i32;
     if resizeproc(n) < 0 {
         return usize::MAX;
     }
@@ -39,7 +39,7 @@ pub unsafe fn sys_sleep() -> usize {
     let mut ticks = kernel().ticks.lock();
     let ticks0 = *ticks;
     while ticks.wrapping_sub(ticks0) < n as u32 {
-        if (*myproc()).killed() {
+        if (*(*myproc()).data.get()).killed() {
             return usize::MAX;
         }
         ticks.sleep();


### PR DESCRIPTION
[Major patch]
`struct Proc`의 남은 field들을 `UnsafeCell<ProcData>`로 wrap했습니다.
- 내용 관련하여 Stacked Borrows(https://plv.mpi-sws.org/rustbelt/stacked-borrows/paper.pdf) 를 참조하면 좋습니다.
- `name`은 creation, exit에서만 변경되어 UnsafeCell로 묶지 않았습니다.

[Minor patch]
`struct ProcInner`와 `struct Proc`의 field `inner`를 각각 `struct ProcInfo`와 `info`로 변경했습니다.

[Milestone]
`myproc` 함수의 구조 때문에 임시로 `struct ProcData`와 `struct Proc`의 field `data`를 `pub`으로 설정했습니다.
이번 PR의 scope는 `myproc`을 `ExecutionGuard`를 이용해 refactoring 하고 `struct Procdata`와 `data`를 private으로 다시 변경하는 것까지입니다.