### PR TITLE
[subissue for #214] Implement ProcData

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -85,7 +85,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if (*(*myproc()).data.get()).killed() {
+                if (*myproc()).killed() {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -85,7 +85,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if (*myproc()).killed() {
+                if (*(*myproc()).data.get()).killed() {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -89,7 +89,7 @@ impl File {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.deref().lock().stat();
                 (*(*p).data.get()).pagetable.assume_init_mut().copyout(
-                    addr,
+                    UVAddr::new(addr),
                     &mut st as *mut Stat as *mut u8,
                     ::core::mem::size_of::<Stat>() as usize,
                 )

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -88,8 +88,8 @@ impl File {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.deref().lock().stat();
-                (*p).pagetable.assume_init_mut().copyout(
-                    UVAddr::new(addr),
+                (*(*p).data.get()).pagetable.assume_init_mut().copyout(
+                    addr,
                     &mut st as *mut Stat as *mut u8,
                     ::core::mem::size_of::<Stat>() as usize,
                 )

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -135,7 +135,7 @@ impl Path {
         let mut ptr = if self.is_absolute() {
             Inode::get(ROOTDEV as u32, ROOTINO)
         } else {
-            (*myproc()).cwd.clone().unwrap()
+            (*(*myproc()).data.get()).cwd.clone().unwrap()
         };
 
         let mut path = self;

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -162,7 +162,7 @@ impl PipeInner {
         for i in 0..n {
             if self.nwrite == self.nread.wrapping_add(PIPESIZE as u32) {
                 //DOC: pipewrite-full
-                if !self.readopen || data.killed() {
+                if !self.readopen || (*proc).killed() {
                     return Err(());
                 }
                 return Ok(i);
@@ -187,7 +187,7 @@ impl PipeInner {
 
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {
-            if data.killed() {
+            if (*proc).killed() {
                 return Err(PipeError::InvalidStatus);
             }
             return Err(PipeError::WaitForIO);

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -11,10 +11,11 @@ use cstr_core::CStr;
 /// Fetch the usize at addr from the current process.
 pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
     let p: *mut Proc = myproc();
-    if addr >= (*p).sz || addr.wrapping_add(::core::mem::size_of::<usize>()) > (*p).sz {
+    let data = &mut *(*p).data.get();
+    if addr >= data.sz || addr.wrapping_add(::core::mem::size_of::<usize>()) > data.sz {
         return -1;
     }
-    if (*p)
+    if data
         .pagetable
         .assume_init_mut()
         .copyin(
@@ -33,7 +34,8 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
 /// Returns reference to the string in the buffer.
 pub unsafe fn fetchstr(addr: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
     let p: *mut Proc = myproc();
-    (*p).pagetable
+    (*(*p).data.get())
+        .pagetable
         .assume_init_mut()
         .copyinstr(buf.as_mut_ptr(), UVAddr::new(addr), buf.len())?;
 
@@ -42,13 +44,14 @@ pub unsafe fn fetchstr(addr: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
 
 unsafe fn argraw(n: usize) -> usize {
     let p = myproc();
+    let data = &mut *(*p).data.get();
     match n {
-        0 => (*(*p).tf).a0,
-        1 => (*(*p).tf).a1,
-        2 => (*(*p).tf).a2,
-        3 => (*(*p).tf).a3,
-        4 => (*(*p).tf).a4,
-        5 => (*(*p).tf).a5,
+        0 => (*data.tf).a0,
+        1 => (*data.tf).a1,
+        2 => (*data.tf).a2,
+        3 => (*data.tf).a3,
+        4 => (*data.tf).a4,
+        5 => (*data.tf).a5,
         _ => panic!("argraw"),
     }
 }
@@ -100,10 +103,11 @@ const SYSCALLS: [Option<unsafe fn() -> usize>; 23] = [
 ];
 
 pub unsafe fn syscall() {
-    let mut p: *mut Proc = myproc();
-    let num: i32 = (*(*p).tf).a7 as i32;
+    let p: *mut Proc = myproc();
+    let mut data = &mut *(*p).data.get();
+    let num: i32 = (*data.tf).a7 as i32;
     if num > 0 && (num as usize) < SYSCALLS.len() && SYSCALLS[num as usize].is_some() {
-        (*(*p).tf).a0 = SYSCALLS[num as usize].expect("non-null function pointer")()
+        (*data.tf).a0 = SYSCALLS[num as usize].expect("non-null function pointer")()
     } else {
         println!(
             "{} {}: unknown sys call {}",
@@ -111,6 +115,6 @@ pub unsafe fn syscall() {
             str::from_utf8(&(*p).name).unwrap_or("???"),
             num
         );
-        (*(*p).tf).a0 = usize::MAX
+        (*data.tf).a0 = usize::MAX
     };
 }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -34,10 +34,11 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
 /// Returns reference to the string in the buffer.
 pub unsafe fn fetchstr(addr: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
     let p: *mut Proc = myproc();
-    (*(*p).data.get())
-        .pagetable
-        .assume_init_mut()
-        .copyinstr(buf.as_mut_ptr(), UVAddr::new(addr), buf.len())?;
+    (*(*p).data.get()).pagetable.assume_init_mut().copyinstr(
+        buf.as_mut_ptr(),
+        UVAddr::new(addr),
+        buf.len(),
+    )?;
 
     Ok(CStr::from_ptr(buf.as_ptr()))
 }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -287,7 +287,7 @@ pub unsafe fn sys_mknod() -> usize {
 
 pub unsafe fn sys_chdir() -> usize {
     let mut path: [u8; MAXPATH] = [0; MAXPATH];
-    let mut p: *mut Proc = myproc();
+    let p: *mut Proc = myproc();
     let mut data = &mut *(*p).data.get();
     let _tx = fs().begin_transaction();
     let path = ok_or!(argstr(0, &mut path), return usize::MAX);

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -39,7 +39,7 @@ pub unsafe fn sys_sleep() -> usize {
     let mut ticks = kernel().ticks.lock();
     let ticks0 = *ticks;
     while ticks.wrapping_sub(ticks0) < n as u32 {
-        if (*(*myproc()).data.get()).killed() {
+        if (*myproc()).killed() {
             return usize::MAX;
         }
         ticks.sleep();

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -27,7 +27,7 @@ pub unsafe fn sys_wait() -> usize {
 
 pub unsafe fn sys_sbrk() -> usize {
     let n = ok_or!(argint(0), return usize::MAX);
-    let addr: i32 = (*myproc()).sz as i32;
+    let addr: i32 = (*(*myproc()).data.get()).sz as i32;
     if resizeproc(n) < 0 {
         return usize::MAX;
     }
@@ -39,7 +39,7 @@ pub unsafe fn sys_sleep() -> usize {
     let mut ticks = kernel().ticks.lock();
     let ticks0 = *ticks;
     while ticks.wrapping_sub(ticks0) < n as u32 {
-        if (*myproc()).killed() {
+        if (*(*myproc()).data.get()).killed() {
             return usize::MAX;
         }
         ticks.sleep();

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn usertrap() {
     if r_scause() == 8 {
         // system call
 
-        if data.killed() {
+        if (*p).killed() {
             kernel().procs.exit_current(-1);
         }
 
@@ -84,11 +84,11 @@ pub unsafe extern "C" fn usertrap() {
                 r_sepc() as *const u8,
                 r_stval() as *const u8
             );
-            data.kill();
+            (*p).kill();
         }
     }
 
-    if data.killed() {
+    if (*p).killed() {
         kernel().procs.exit_current(-1);
     }
 

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -171,7 +171,8 @@ impl VAddr for KVAddr {
 impl VAddr for UVAddr {
     unsafe fn copyin(dst: *mut u8, src: Self, len: usize) -> Result<(), ()> {
         let p = myproc();
-        (*p).pagetable
+        (*(*p).data.get())
+            .pagetable
             .assume_init_mut()
             .copyin(dst as *mut u8, src, len)
             .map_or(Err(()), |_v| Ok(()))
@@ -179,7 +180,8 @@ impl VAddr for UVAddr {
 
     unsafe fn copyout(dst: Self, src: &[u8]) -> Result<(), ()> {
         let p = myproc();
-        (*p).pagetable
+        (*(*p).data.get())
+            .pagetable
             .assume_init_mut()
             .copyout(dst, src.as_ptr(), src.len())
             .map_or(Err(()), |_v| Ok(()))


### PR DESCRIPTION
#256 에서 update(rebased).
@efenniht 

`ExecutionGuard`의 implementation은 새 issue (#258) 를 만들어 다음 PR에서 진행하겠습니다.

[Major patch]
`struct Proc`의 남은 field들을 `UnsafeCell<ProcData>`로 wrap했습니다.
- 내용 관련하여 Stacked Borrows(https://plv.mpi-sws.org/rustbelt/stacked-borrows/paper.pdf) 를 참조하면 좋습니다.
- `name`은 `creation, exit`에서만 변경되어 `UnsafeCell`로 묶지 않았습니다.

[Minor patch]
`struct ProcInner`와 `struct Proc`의 `field inner`를 각각 `struct ProcInfo`와 `info`로 변경했습니다.