### PR TITLE
[Closes #226] copyin, copyout 함수 인자로 &[u8] 적용

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -67,12 +67,11 @@ impl Console {
 
     unsafe fn write(&mut self, src: UVAddr, n: i32) {
         for i in 0..n {
-            let mut c: u8 = 0;
-            if VAddr::copyin(&mut c, UVAddr::new(src.into_usize() + (i as usize)), 1usize).is_err()
-            {
+            let mut c = [0 as u8];
+            if VAddr::copyin(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
                 break;
             }
-            self.putc(c as i32);
+            self.putc(c[0] as i32);
         }
     }
 

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -107,8 +107,8 @@ pub unsafe fn exec(path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
         }
         pt.copyout(
             UVAddr::new(sp),
-            argv[argc],
-            (strlen(argv[argc]) + 1) as usize,
+            ::core::slice::from_raw_parts_mut(argv[argc],
+            (strlen(argv[argc]) + 1) as usize),
         )?;
         ustack[argc] = sp;
         argc = argc.wrapping_add(1)
@@ -126,9 +126,9 @@ pub unsafe fn exec(path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
         && pt
             .copyout(
                 UVAddr::new(sp),
-                ustack.as_mut_ptr() as *mut u8,
+                ::core::slice::from_raw_parts_mut(ustack.as_mut_ptr() as *mut u8,
                 argc.wrapping_add(1)
-                    .wrapping_mul(::core::mem::size_of::<usize>()),
+                    .wrapping_mul(::core::mem::size_of::<usize>())),
             )
             .is_ok()
     {

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -107,8 +107,7 @@ pub unsafe fn exec(path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
         }
         pt.copyout(
             UVAddr::new(sp),
-            ::core::slice::from_raw_parts_mut(argv[argc],
-            (strlen(argv[argc]) + 1) as usize),
+            ::core::slice::from_raw_parts_mut(argv[argc], (strlen(argv[argc]) + 1) as usize),
         )?;
         ustack[argc] = sp;
         argc = argc.wrapping_add(1)
@@ -126,9 +125,11 @@ pub unsafe fn exec(path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
         && pt
             .copyout(
                 UVAddr::new(sp),
-                ::core::slice::from_raw_parts_mut(ustack.as_mut_ptr() as *mut u8,
-                argc.wrapping_add(1)
-                    .wrapping_mul(::core::mem::size_of::<usize>())),
+                ::core::slice::from_raw_parts_mut(
+                    ustack.as_mut_ptr() as *mut u8,
+                    argc.wrapping_add(1)
+                        .wrapping_mul(::core::mem::size_of::<usize>()),
+                ),
             )
             .is_ok()
     {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -90,8 +90,8 @@ impl File {
                 let mut st = ip.deref().lock().stat();
                 (*(*p).data.get()).pagetable.assume_init_mut().copyout(
                     UVAddr::new(addr),
-                    &mut st as *mut Stat as *mut u8,
-                    ::core::mem::size_of::<Stat>() as usize,
+                    ::core::slice::from_raw_parts_mut(&mut st as *mut Stat as *mut u8,
+                    ::core::mem::size_of::<Stat>() as usize),
                 )
             }
             _ => Err(()),

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -90,8 +90,10 @@ impl File {
                 let mut st = ip.deref().lock().stat();
                 (*(*p).data.get()).pagetable.assume_init_mut().copyout(
                     UVAddr::new(addr),
-                    ::core::slice::from_raw_parts_mut(&mut st as *mut Stat as *mut u8,
-                    ::core::mem::size_of::<Stat>() as usize),
+                    ::core::slice::from_raw_parts_mut(
+                        &mut st as *mut Stat as *mut u8,
+                        ::core::mem::size_of::<Stat>() as usize,
+                    ),
                 )
             }
             _ => Err(()),

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -255,16 +255,9 @@ impl InodeGuard<'_> {
                 n.wrapping_sub(tot),
                 (BSIZE as u32).wrapping_sub(off.wrapping_rem(BSIZE as u32)),
             );
-            if VAddr::copyin(
-                bp.deref_mut_inner()
-                    .data
-                    .as_mut_ptr()
-                    .offset(off.wrapping_rem(BSIZE as u32) as isize),
-                src,
-                m as _,
-            )
-            .is_err()
-            {
+            let begin = off.wrapping_rem(BSIZE as u32) as usize;
+            let end = begin + m as usize;
+            if VAddr::copyin(&mut bp.deref_mut_inner().data[begin..end], src).is_err() {
                 break;
             } else {
                 fs().log_write(bp);

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -155,7 +155,7 @@ pub enum PipeError {
 
 impl PipeInner {
     unsafe fn try_write(&mut self, addr: usize, n: usize) -> Result<usize, ()> {
-        let mut ch: u8 = 0;
+        let ch: u8 = 0;
         let proc = myproc();
         let data = &mut *(*proc).data.get();
 
@@ -170,7 +170,7 @@ impl PipeInner {
             if data
                 .pagetable
                 .assume_init_mut()
-                .copyin(&mut ch, UVAddr::new(addr.wrapping_add(i)), 1usize)
+                .copyin(&mut [ch], UVAddr::new(addr.wrapping_add(i)))
                 .is_err()
             {
                 break;

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -155,7 +155,7 @@ pub enum PipeError {
 
 impl PipeInner {
     unsafe fn try_write(&mut self, addr: usize, n: usize) -> Result<usize, ()> {
-        let ch: u8 = 0;
+        let mut ch = [0 as u8];
         let proc = myproc();
         let data = &mut *(*proc).data.get();
 
@@ -170,12 +170,12 @@ impl PipeInner {
             if data
                 .pagetable
                 .assume_init_mut()
-                .copyin(&mut [ch], UVAddr::new(addr.wrapping_add(i)))
+                .copyin(&mut ch, UVAddr::new(addr.wrapping_add(i)))
                 .is_err()
             {
                 break;
             }
-            self.data[self.nwrite as usize % PIPESIZE] = ch;
+            self.data[self.nwrite as usize % PIPESIZE] = ch[0];
             self.nwrite = self.nwrite.wrapping_add(1);
         }
         Ok(n)

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -198,12 +198,12 @@ impl PipeInner {
             if self.nread == self.nwrite {
                 return Ok(i);
             }
-            let ch = self.data[self.nread as usize % PIPESIZE];
+            let ch = [self.data[self.nread as usize % PIPESIZE]];
             self.nread = self.nread.wrapping_add(1);
             if data
                 .pagetable
                 .assume_init_mut()
-                .copyout(UVAddr::new(addr.wrapping_add(i)), &ch, 1usize)
+                .copyout(UVAddr::new(addr.wrapping_add(i)), &ch)
                 .is_err()
             {
                 return Ok(i);

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -724,8 +724,8 @@ impl ProcessSystem {
                                 .assume_init_mut()
                                 .copyout(
                                     UVAddr::new(addr),
-                                    &mut np.deref_mut_info().xstate as *mut i32 as *mut u8,
-                                    ::core::mem::size_of::<i32>(),
+                                    ::core::slice::from_raw_parts_mut(&mut np.deref_mut_info().xstate as *mut i32 as *mut u8,
+                                    ::core::mem::size_of::<i32>()),
                                 )
                                 .is_err()
                         {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -724,8 +724,10 @@ impl ProcessSystem {
                                 .assume_init_mut()
                                 .copyout(
                                     UVAddr::new(addr),
-                                    ::core::slice::from_raw_parts_mut(&mut np.deref_mut_info().xstate as *mut i32 as *mut u8,
-                                    ::core::mem::size_of::<i32>()),
+                                    ::core::slice::from_raw_parts_mut(
+                                        &mut np.deref_mut_info().xstate as *mut i32 as *mut u8,
+                                        ::core::mem::size_of::<i32>(),
+                                    ),
                                 )
                                 .is_err()
                         {

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -19,9 +19,9 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
         .pagetable
         .assume_init_mut()
         .copyin(
-            ip as *mut u8,
+            ::core::slice::from_raw_parts_mut(ip as *mut u8, ::core::mem::size_of::<usize>()),
             UVAddr::new(addr),
-            ::core::mem::size_of::<usize>(),
+            // ::core::mem::size_of::<usize>(),
         )
         .is_err()
     {

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -35,9 +35,9 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
 pub unsafe fn fetchstr(addr: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
     let p: *mut Proc = myproc();
     (*(*p).data.get()).pagetable.assume_init_mut().copyinstr(
-        buf.as_mut_ptr(),
+        buf,
         UVAddr::new(addr),
-        buf.len(),
+        // buf.len(),
     )?;
 
     Ok(CStr::from_ptr(buf.as_ptr()))

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -33,10 +33,10 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
 /// Returns reference to the string in the buffer.
 pub unsafe fn fetchstr(addr: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
     let p: *mut Proc = myproc();
-    (*(*p).data.get()).pagetable.assume_init_mut().copyinstr(
-        buf,
-        UVAddr::new(addr),
-    )?;
+    (*(*p).data.get())
+        .pagetable
+        .assume_init_mut()
+        .copyinstr(buf, UVAddr::new(addr))?;
 
     Ok(CStr::from_ptr(buf.as_ptr()))
 }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -21,7 +21,6 @@ pub unsafe fn fetchaddr(addr: usize, ip: *mut usize) -> i32 {
         .copyin(
             ::core::slice::from_raw_parts_mut(ip as *mut u8, ::core::mem::size_of::<usize>()),
             UVAddr::new(addr),
-            // ::core::mem::size_of::<usize>(),
         )
         .is_err()
     {
@@ -37,7 +36,6 @@ pub unsafe fn fetchstr(addr: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
     (*(*p).data.get()).pagetable.assume_init_mut().copyinstr(
         buf,
         UVAddr::new(addr),
-        // buf.len(),
     )?;
 
     Ok(CStr::from_ptr(buf.as_ptr()))

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -365,8 +365,10 @@ pub unsafe fn sys_pipe() -> usize {
         .assume_init_mut()
         .copyout(
             UVAddr::new(fdarray),
-            ::core::slice::from_raw_parts_mut(&mut fd0 as *mut i32 as *mut u8,
-            mem::size_of::<i32>()),
+            ::core::slice::from_raw_parts_mut(
+                &mut fd0 as *mut i32 as *mut u8,
+                mem::size_of::<i32>(),
+            ),
         )
         .is_err()
         || data
@@ -374,8 +376,10 @@ pub unsafe fn sys_pipe() -> usize {
             .assume_init_mut()
             .copyout(
                 UVAddr::new(fdarray.wrapping_add(mem::size_of::<i32>())),
-                ::core::slice::from_raw_parts_mut(&mut fd1 as *mut i32 as *mut u8,
-                mem::size_of::<i32>()),
+                ::core::slice::from_raw_parts_mut(
+                    &mut fd1 as *mut i32 as *mut u8,
+                    mem::size_of::<i32>(),
+                ),
             )
             .is_err()
     {

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -365,8 +365,8 @@ pub unsafe fn sys_pipe() -> usize {
         .assume_init_mut()
         .copyout(
             UVAddr::new(fdarray),
-            &mut fd0 as *mut i32 as *mut u8,
-            mem::size_of::<i32>(),
+            ::core::slice::from_raw_parts_mut(&mut fd0 as *mut i32 as *mut u8,
+            mem::size_of::<i32>()),
         )
         .is_err()
         || data
@@ -374,8 +374,8 @@ pub unsafe fn sys_pipe() -> usize {
             .assume_init_mut()
             .copyout(
                 UVAddr::new(fdarray.wrapping_add(mem::size_of::<i32>())),
-                &mut fd1 as *mut i32 as *mut u8,
-                mem::size_of::<i32>(),
+                ::core::slice::from_raw_parts_mut(&mut fd1 as *mut i32 as *mut u8,
+                mem::size_of::<i32>()),
             )
             .is_err()
     {

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -336,7 +336,6 @@ impl<A: VAddr> PageTable<A> {
     /// Copy from kernel to user.
     /// Copy len bytes from src to virtual address dstva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    // TODO: Refactor src to type &[u8]
     pub unsafe fn copyout(&mut self, dstva: UVAddr, src: &[u8]) -> Result<(), ()> {
         let mut dst = dstva.into_usize();
         let mut len = src.len();

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -547,12 +547,14 @@ impl PageTable<UVAddr> {
     /// Return OK(()) on success, Err(()) on error.
     pub unsafe fn copyinstr(
         &mut self,
-        mut dst: *mut u8,
+        dst: &mut [u8],
         srcva: UVAddr,
-        mut max: usize,
+        // mut max: usize,
     ) -> Result<(), ()> {
         let mut got_null: i32 = 0;
         let mut src = srcva.into_usize();
+        let mut offset = 0;
+        let mut max = dst.len();
         while got_null == 0 && max > 0 {
             let va0 = pgrounddown(src);
             let pa0 = some_or!(self.walkaddr(VAddr::new(va0)), return Err(())).into_usize();
@@ -563,15 +565,18 @@ impl PageTable<UVAddr> {
             let mut p = (pa0 + (src - va0)) as *mut u8;
             while n > 0 {
                 if *p as i32 == '\u{0}' as i32 {
-                    *dst = '\u{0}' as i32 as u8;
+                    // *dst 
+                    dst[offset]= '\u{0}' as i32 as u8;
                     got_null = 1;
                     break;
                 } else {
-                    *dst = *p;
+                    // *dst = *p;
+                    dst[offset] = *p;
                     n -= 1;
                     max -= 1;
                     p = p.offset(1);
-                    dst = dst.offset(1)
+                    // dst = dst.offset(1)
+                    offset += 1;
                 }
             }
             src = va0 + PGSIZE

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -337,11 +337,7 @@ impl<A: VAddr> PageTable<A> {
     /// Copy len bytes from src to virtual address dstva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
     // TODO: Refactor src to type &[u8]
-    pub unsafe fn copyout(
-        &mut self,
-        dstva: UVAddr,
-        src: &[u8],
-    ) -> Result<(), ()> {
+    pub unsafe fn copyout(&mut self, dstva: UVAddr, src: &[u8]) -> Result<(), ()> {
         let mut dst = dstva.into_usize();
         let mut len = src.len();
         let mut offset = 0;
@@ -352,7 +348,11 @@ impl<A: VAddr> PageTable<A> {
             if n > len {
                 n = len
             }
-            ptr::copy(src[offset..(offset+n)].as_ptr(), (pa0 + (dst - va0)) as *mut u8, n);
+            ptr::copy(
+                src[offset..(offset + n)].as_ptr(),
+                (pa0 + (dst - va0)) as *mut u8,
+                n,
+            );
             len -= n;
             offset += n;
             dst = va0 + PGSIZE;
@@ -516,11 +516,7 @@ impl PageTable<UVAddr> {
     /// Copy from user to kernel.
     /// Copy len bytes to dst from virtual address srcva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub unsafe fn copyin(
-        &mut self,
-        dst: &mut [u8],
-        srcva: UVAddr,
-    ) -> Result<(), ()> {
+    pub unsafe fn copyin(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
         let mut src = srcva.into_usize();
         let mut len = dst.len();
         let mut offset = 0;
@@ -531,7 +527,11 @@ impl PageTable<UVAddr> {
             if n > len {
                 n = len
             }
-            ptr::copy((pa0 + (src - va0)) as *mut u8, dst[offset..(offset+n)].as_mut_ptr(), n);
+            ptr::copy(
+                (pa0 + (src - va0)) as *mut u8,
+                dst[offset..(offset + n)].as_mut_ptr(),
+                n,
+            );
             len -= n;
             offset += n;
             src = va0 + PGSIZE
@@ -543,11 +543,7 @@ impl PageTable<UVAddr> {
     /// Copy bytes to dst from virtual address srcva in a given page table,
     /// until a '\0', or max.
     /// Return OK(()) on success, Err(()) on error.
-    pub unsafe fn copyinstr(
-        &mut self,
-        dst: &mut [u8],
-        srcva: UVAddr,
-    ) -> Result<(), ()> {
+    pub unsafe fn copyinstr(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
         let mut got_null: i32 = 0;
         let mut src = srcva.into_usize();
         let mut offset = 0;
@@ -562,7 +558,7 @@ impl PageTable<UVAddr> {
             let mut p = (pa0 + (src - va0)) as *mut u8;
             while n > 0 {
                 if *p as i32 == '\u{0}' as i32 {
-                    dst[offset]= '\u{0}' as i32 as u8;
+                    dst[offset] = '\u{0}' as i32 as u8;
                     got_null = 1;
                     break;
                 } else {


### PR DESCRIPTION
- closes #226 

---

수정한 내용입니다.

- `VAddr`의 `copyin` `dst`에서 `&mut [u8]`을 인자로 받도록 수정
- `copyin`, `copyinstr`의 `dst`에서 `&mut [u8]`을 인자로 받도록 수정
- `copyout`의 `src`에서 `&[u8]`을 인자로 받도록 수정
