### PR TITLE
[Unsafe 줄이기] argfd returns not *mut RcFile but &'a RcFile

### DIFF
--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -42,7 +42,7 @@ impl RcFile {
 
 /// Fetch the nth word-sized system call argument as a file descriptor
 /// and return both the descriptor and the corresponding struct file.
-unsafe fn argfd<'a>(n: usize) -> Result<(i32, &'a RcFile), ()> {
+unsafe fn argfd(n: usize) -> Result<(i32, &'static RcFile), ()> {
     let fd = argint(n)?;
     if fd < 0 || fd >= NOFILE as i32 {
         return Err(());


### PR DESCRIPTION
### `argfd()`가 `*mut RcFile`이 아닌 `&'a RcFile`을 리턴하도록 수정했습니다.

**raw pointer를 리턴하는 함수들을 reference를 리턴하도록 바꾸면 unsafe lines를 줄일 수 있을 것 같아** 이와 같이 수정했습니다.  
다른 함수들도 비슷한 수정을 할 수 있을 것 같은데 (mut이 필요 없는데 raw pointer를 리턴하는 경우), 올바른 방향인지 확인하고자 작은 수정이지만 PR 올립니다.