### PR TITLE
Merge mit pdos [3] (related to #261)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,9 +186,9 @@ ifndef CPUS
 CPUS := 3
 endif
 
-QEMUEXTRA = -drive file=fs1.img,if=none,format=raw,id=x1 -device virtio-blk-device,drive=x1,bus=virtio-mmio-bus.1
 QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic
-QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0 -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
+QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
 
 qemu: $K/kernel fs.img
 	$(QEMU) $(QEMUOPTS)

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -49,6 +49,10 @@ impl Console {
         }
     }
 
+    pub fn uartintr(&self) {
+        self.uart.intr()
+    }
+
     /// Send one character to the uart.
     pub fn putc(&mut self, c: i32) {
         // From printf.rs.
@@ -57,11 +61,11 @@ impl Console {
         }
         if c == BACKSPACE {
             // If the user typed backspace, overwrite with a space.
-            self.uart.putc('\u{8}' as i32);
-            self.uart.putc(' ' as i32);
-            self.uart.putc('\u{8}' as i32);
+            self.uart.putc('\u{8}' as i32, false);
+            self.uart.putc(' ' as i32, false);
+            self.uart.putc('\u{8}' as i32, false);
         } else {
-            self.uart.putc(c);
+            self.uart.putc(c, false);
         };
     }
 
@@ -71,7 +75,7 @@ impl Console {
             if VAddr::copyin(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
                 break;
             }
-            self.putc(c[0] as i32);
+            self.uart.putc(c[0] as i32, true);
         }
     }
 

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -214,7 +214,7 @@ impl Kernel {
             // arguments to user main(argc, argv)
             // argc is returned via the system call return
             // value, which goes in a0.
-            (*data.tf).a1 = sp;
+            (*data.trapframe).a1 = sp;
 
             // Save program name for debugging.
             let mut s = path.as_bytes().as_ptr();
@@ -236,10 +236,10 @@ impl Kernel {
             data.sz = sz;
 
             // initial program counter = main
-            (*data.tf).epc = elf.entry;
+            (*data.trapframe).epc = elf.entry;
 
             // initial stack pointer
-            (*data.tf).sp = sp;
+            (*data.trapframe).sp = sp;
             proc_freepagetable(&mut oldpagetable, oldsz);
 
             // this ends up in a0, the first argument to main(argc, argv)

--- a/kernel-rs/src/fcntl.rs
+++ b/kernel-rs/src/fcntl.rs
@@ -4,5 +4,6 @@ bitflags! {
         const O_WRONLY = 0x1;
         const O_RDWR = 0x2;
         const O_CREATE = 0x200;
+        const O_TRUNC = 0x400;
     }
 }

--- a/kernel-rs/src/memlayout.rs
+++ b/kernel-rs/src/memlayout.rs
@@ -78,6 +78,6 @@ pub const fn kstack(p: usize) -> usize {
 ///   fixed-size stack
 ///   expandable heap
 ///   ...
-///   TRAPFRAME (p->tf, used by the trampoline)
+///   TRAPFRAME (p->trapframe, used by the trampoline)
 ///   TRAMPOLINE (the same page as in the kernel)
 pub const TRAPFRAME: usize = TRAMPOLINE.wrapping_sub(PGSIZE);

--- a/kernel-rs/src/plic.rs
+++ b/kernel-rs/src/plic.rs
@@ -23,7 +23,6 @@ pub unsafe fn plicinithart() {
 /// ask the PLIC what interrupt we should serve.
 pub unsafe fn plic_claim() -> usize {
     let hart: usize = cpuid();
-    //int irq = *(u32*)(PLIC + 0x201004);
     let irq: usize = *(plic_sclaim(hart) as *mut usize);
     irq
 }
@@ -31,6 +30,5 @@ pub unsafe fn plic_claim() -> usize {
 /// tell the PLIC we've served this IRQ.
 pub unsafe fn plic_complete(irq: usize) {
     let hart: usize = cpuid();
-    //*(u32*)(PLIC + 0x201004) = irq;
     *(plic_sclaim(hart) as *mut usize) = irq;
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -64,7 +64,7 @@ pub struct Cpu {
     pub proc: *mut Proc,
 
     /// swtch() here to enter scheduler().
-    pub scheduler: Context,
+    pub context: Context,
 
     /// Depth of push_off() nesting.
     pub noff: i32,
@@ -379,7 +379,7 @@ impl ProcGuard {
         let interrupt_enabled = (*kernel().mycpu()).interrupt_enabled;
         swtch(
             &mut (*self.data.get()).context,
-            &mut (*kernel().mycpu()).scheduler,
+            &mut (*kernel().mycpu()).context,
         );
         (*kernel().mycpu()).interrupt_enabled = interrupt_enabled;
     }
@@ -412,7 +412,7 @@ impl Cpu {
     pub const fn new() -> Self {
         Self {
             proc: ptr::null_mut(),
-            scheduler: Context::new(),
+            context: Context::new(),
             noff: 0,
             interrupt_enabled: false,
         }
@@ -983,7 +983,7 @@ pub unsafe fn scheduler() -> ! {
                 // before jumping back to us.
                 guard.deref_mut_info().state = Procstate::RUNNING;
                 (*c).proc = p as *const _ as *mut _;
-                swtch(&mut (*c).scheduler, &mut (*guard.data.get()).context);
+                swtch(&mut (*c).context, &mut (*guard.data.get()).context);
 
                 // Process is done running for now.
                 // It should have changed its p->state before coming back.

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -42,12 +42,12 @@ unsafe fn argraw(n: usize) -> usize {
     let p = myproc();
     let data = &mut *(*p).data.get();
     match n {
-        0 => (*data.tf).a0,
-        1 => (*data.tf).a1,
-        2 => (*data.tf).a2,
-        3 => (*data.tf).a3,
-        4 => (*data.tf).a4,
-        5 => (*data.tf).a5,
+        0 => (*data.trapframe).a0,
+        1 => (*data.trapframe).a1,
+        2 => (*data.trapframe).a2,
+        3 => (*data.trapframe).a3,
+        4 => (*data.trapframe).a4,
+        5 => (*data.trapframe).a5,
         _ => panic!("argraw"),
     }
 }
@@ -76,7 +76,7 @@ impl Kernel {
     pub unsafe fn syscall(&self) {
         let p: *mut Proc = myproc();
         let mut data = &mut *(*p).data.get();
-        let num: i32 = (*data.tf).a7 as i32;
+        let num: i32 = (*data.trapframe).a7 as i32;
 
         let result = match num {
             1 => self.sys_fork(),
@@ -112,6 +112,6 @@ impl Kernel {
             }
         };
 
-        (*data.tf).a0 = result;
+        (*data.trapframe).a0 = result;
     }
 }

--- a/kernel-rs/src/virtio.rs
+++ b/kernel-rs/src/virtio.rs
@@ -38,6 +38,10 @@ pub enum MmioRegs {
     QueueReady = 0x044,
     /// write-only
     QueueNotify = 0x050,
+    /// read-only
+    InterruptStatus = 0x060,
+    /// write-only
+    InterruptAck = 0x064,
     /// read/write
     Status = 0x070,
 }

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -291,6 +291,7 @@ impl Disk {
 
             self.used_idx = (self.used_idx.wrapping_add(1)).wrapping_rem(NUM as _)
         }
+        MmioRegs::InterruptAck.write(MmioRegs::InterruptStatus.read() & 0x3);
     }
 }
 

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -27,6 +27,8 @@
 
 //
 // send one character to the uart.
+// called by printf, and to echo input characters,
+// but not from write().
 //
 void
 consputc(int c)
@@ -40,9 +42,9 @@ consputc(int c)
 
   if(c == BACKSPACE){
     // if the user typed backspace, overwrite with a space.
-    uartputc('\b'); uartputc(' '); uartputc('\b');
+    uartputc('\b', 0); uartputc(' ', 0); uartputc('\b', 0);
   } else {
-    uartputc(c);
+    uartputc(c, 0);
   }
 }
 
@@ -70,7 +72,7 @@ consolewrite(int user_src, uint64 src, int n)
     char c;
     if(either_copyin(&c, user_src, src+i, 1) == -1)
       break;
-    consputc(c);
+    uartputc(c, 1);
   }
   release(&cons.lock);
 

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -52,6 +52,7 @@ struct inode*   nameiparent(char*, char*);
 int             readi(struct inode*, int, uint64, uint, uint);
 void            stati(struct inode*, struct stat*);
 int             writei(struct inode*, int, uint64, uint, uint);
+void            itrunc(struct inode*);
 
 // ramdisk.c
 void            ramdiskinit(void);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -149,7 +149,7 @@ void            usertrapret(void);
 // uart.c
 void            uartinit(void);
 void            uartintr(void);
-void            uartputc(int);
+void            uartputc(int, int);
 int             uartgetc(void);
 
 // vm.c

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -97,7 +97,7 @@ exec(char *path, char **argv)
   // arguments to user main(argc, argv)
   // argc is returned via the system call return
   // value, which goes in a0.
-  p->tf->a1 = sp;
+  p->trapframe->a1 = sp;
 
   // Save program name for debugging.
   for(last=s=path; *s; s++)
@@ -109,8 +109,8 @@ exec(char *path, char **argv)
   oldpagetable = p->pagetable;
   p->pagetable = pagetable;
   p->sz = sz;
-  p->tf->epc = elf.entry;  // initial program counter = main
-  p->tf->sp = sp; // initial stack pointer
+  p->trapframe->epc = elf.entry;  // initial program counter = main
+  p->trapframe->sp = sp; // initial stack pointer
   proc_freepagetable(oldpagetable, oldsz);
 
   return argc; // this ends up in a0, the first argument to main(argc, argv)

--- a/kernel/fcntl.h
+++ b/kernel/fcntl.h
@@ -2,3 +2,4 @@
 #define O_WRONLY  0x001
 #define O_RDWR    0x002
 #define O_CREATE  0x200
+#define O_TRUNC   0x400

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -22,7 +22,6 @@
 #include "file.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
-static void itrunc(struct inode*);
 // there should be one superblock per disk device, but we run with
 // only one device
 struct superblock sb; 
@@ -406,11 +405,8 @@ bmap(struct inode *ip, uint bn)
 }
 
 // Truncate inode (discard contents).
-// Only called when the inode has no links
-// to it (no directory entries referring to it)
-// and has no in-memory reference to it (is
-// not an open file or current directory).
-static void
+// Caller must hold ip->lock.
+void
 itrunc(struct inode *ip)
 {
   int i, j;
@@ -463,7 +459,7 @@ readi(struct inode *ip, int user_dst, uint64 dst, uint off, uint n)
   struct buf *bp;
 
   if(off > ip->size || off + n < off)
-    return -1;
+    return 0;
   if(off + n > ip->size)
     n = ip->size - off;
 

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -62,6 +62,6 @@
 //   fixed-size stack
 //   expandable heap
 //   ...
-//   TRAPFRAME (p->tf, used by the trampoline)
+//   TRAPFRAME (p->trapframe, used by the trampoline)
 //   TRAMPOLINE (the same page as in the kernel)
 #define TRAPFRAME (TRAMPOLINE - PGSIZE)

--- a/kernel/plic.c
+++ b/kernel/plic.c
@@ -33,7 +33,6 @@ int
 plic_claim(void)
 {
   int hart = cpuid();
-  //int irq = *(uint32*)(PLIC + 0x201004);
   int irq = *(uint32*)PLIC_SCLAIM(hart);
   return irq;
 }
@@ -43,6 +42,5 @@ void
 plic_complete(int irq)
 {
   int hart = cpuid();
-  //*(uint32*)(PLIC + 0x201004) = irq;
   *(uint32*)PLIC_SCLAIM(hart) = irq;
 }

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -456,7 +456,7 @@ scheduler(void)
         // before jumping back to us.
         p->state = RUNNING;
         c->proc = p;
-        swtch(&c->scheduler, &p->context);
+        swtch(&c->context, &p->context);
 
         // Process is done running for now.
         // It should have changed its p->state before coming back.
@@ -490,7 +490,7 @@ sched(void)
     panic("sched interruptible");
 
   intena = mycpu()->intena;
-  swtch(&p->context, &mycpu()->scheduler);
+  swtch(&p->context, &mycpu()->context);
   mycpu()->intena = intena;
 }
 

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -98,7 +98,7 @@ struct proc {
   uint64 kstack;               // Virtual address of kernel stack
   uint64 sz;                   // Size of process memory (bytes)
   pagetable_t pagetable;       // Page table
-  struct trapframe *tf;        // data page for trampoline.S
+  struct trapframe *trapframe; // data page for trampoline.S
   struct context context;      // swtch() here to run process
   struct file *ofile[NOFILE];  // Open files
   struct inode *cwd;           // Current directory

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -21,7 +21,7 @@ struct context {
 // Per-CPU state.
 struct cpu {
   struct proc *proc;          // The process running on this cpu, or null.
-  struct context scheduler;   // swtch() here to enter scheduler().
+  struct context context;     // swtch() here to enter scheduler().
   int noff;                   // Depth of push_off() nesting.
   int intena;                 // Were interrupts enabled before push_off()?
 };

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -37,17 +37,17 @@ argraw(int n)
   struct proc *p = myproc();
   switch (n) {
   case 0:
-    return p->tf->a0;
+    return p->trapframe->a0;
   case 1:
-    return p->tf->a1;
+    return p->trapframe->a1;
   case 2:
-    return p->tf->a2;
+    return p->trapframe->a2;
   case 3:
-    return p->tf->a3;
+    return p->trapframe->a3;
   case 4:
-    return p->tf->a4;
+    return p->trapframe->a4;
   case 5:
-    return p->tf->a5;
+    return p->trapframe->a5;
   }
   panic("argraw");
   return -1;
@@ -135,12 +135,12 @@ syscall(void)
   int num;
   struct proc *p = myproc();
 
-  num = p->tf->a7;
+  num = p->trapframe->a7;
   if(num > 0 && num < NELEM(syscalls) && syscalls[num]) {
-    p->tf->a0 = syscalls[num]();
+    p->trapframe->a0 = syscalls[num]();
   } else {
     printf("%d %s: unknown sys call %d\n",
             p->pid, p->name, num);
-    p->tf->a0 = -1;
+    p->trapframe->a0 = -1;
   }
 }

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -341,6 +341,10 @@ sys_open(void)
   f->readable = !(omode & O_WRONLY);
   f->writable = (omode & O_WRONLY) || (omode & O_RDWR);
 
+  if((omode & O_TRUNC) && ip->type == T_FILE){
+    itrunc(ip);
+  }
+
   iunlock(ip);
   end_op();
 

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -48,7 +48,7 @@ usertrap(void)
   struct proc *p = myproc();
   
   // save user program counter.
-  p->tf->epc = r_sepc();
+  p->trapframe->epc = r_sepc();
   
   if(r_scause() == 8){
     // system call
@@ -58,7 +58,7 @@ usertrap(void)
 
     // sepc points to the ecall instruction,
     // but we want to return to the next instruction.
-    p->tf->epc += 4;
+    p->trapframe->epc += 4;
 
     // an interrupt will change sstatus &c registers,
     // so don't enable until done with those registers.
@@ -100,10 +100,10 @@ usertrapret(void)
 
   // set up trapframe values that uservec will need when
   // the process next re-enters the kernel.
-  p->tf->kernel_satp = r_satp();         // kernel page table
-  p->tf->kernel_sp = p->kstack + PGSIZE; // process's kernel stack
-  p->tf->kernel_trap = (uint64)usertrap;
-  p->tf->kernel_hartid = r_tp();         // hartid for cpuid()
+  p->trapframe->kernel_satp = r_satp();         // kernel page table
+  p->trapframe->kernel_sp = p->kstack + PGSIZE; // process's kernel stack
+  p->trapframe->kernel_trap = (uint64)usertrap;
+  p->trapframe->kernel_hartid = r_tp();         // hartid for cpuid()
 
   // set up the registers that trampoline.S's sret will use
   // to get to user space.
@@ -115,7 +115,7 @@ usertrapret(void)
   w_sstatus(x);
 
   // set S Exception Program Counter to the saved user pc.
-  w_sepc(p->tf->epc);
+  w_sepc(p->trapframe->epc);
 
   // tell trampoline.S the user page table to switch to.
   uint64 satp = MAKE_SATP(p->pagetable);

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -91,8 +91,9 @@ usertrapret(void)
 {
   struct proc *p = myproc();
 
-  // turn off interrupts, since we're switching
-  // now from kerneltrap() to usertrap().
+  // we're about to switch the destination of traps from
+  // kerneltrap() to usertrap(), so turn off interrupts until
+  // we're back in user space, where usertrap() is correct.
   intr_off();
 
   // send syscalls, interrupts, and exceptions to trampoline.S
@@ -192,6 +193,9 @@ devintr()
       printf("unexpected interrupt irq=%d\n", irq);
     }
 
+    // the PLIC allows each device to raise at most one
+    // interrupt at a time; tell the PLIC the device is
+    // now allowed to interrupt again.
     if(irq)
       plic_complete(irq);
 

--- a/kernel/uart.c
+++ b/kernel/uart.c
@@ -18,7 +18,7 @@
 // the UART control registers.
 // some have different meanings for
 // read vs write.
-// http://byterunner.com/16550.html
+// see http://byterunner.com/16550.html
 #define RHR 0 // receive holding register (for input bytes)
 #define THR 0 // transmit holding register (for output bytes)
 #define IER 1 // interrupt enable register
@@ -29,6 +29,15 @@
 
 #define ReadReg(reg) (*(Reg(reg)))
 #define WriteReg(reg, v) (*(Reg(reg)) = (v))
+
+// the transmit output buffer.
+struct spinlock uart_tx_lock;
+#define UART_TX_BUF_SIZE 32
+char uart_tx_buf[UART_TX_BUF_SIZE];
+int uart_tx_w; // write next to uart_tx_buf[uart_tx_w++]
+int uart_tx_r; // read next from uart_tx_buf[uar_tx_r++]
+
+void uartstart();
 
 void
 uartinit(void)
@@ -52,18 +61,79 @@ uartinit(void)
   // reset and enable FIFOs.
   WriteReg(FCR, 0x07);
 
-  // enable receive interrupts.
-  WriteReg(IER, 0x01);
+  // enable transmit and receive interrupts.
+  WriteReg(IER, 0x02 | 0x01);
+
+  initlock(&uart_tx_lock, "uart");
 }
 
-// write one output character to the UART.
+// add a character to the output buffer and tell the
+// UART to start sending if it isn't already.
+//
+// usually called from the top-half -- by a process
+// calling write(). can also be called from a uart
+// interrupt to echo a received character, or by printf
+// or panic from anywhere in the kernel.
+//
+// the block argument controls what happens if the
+// buffer is full. for write(), block is 1, and the
+// process waits. for kernel printf's and echoed
+// characters, block is 0, and the character is
+// discarded; this is necessary since sleep() is
+// not possible in interrupts.
 void
-uartputc(int c)
+uartputc(int c, int block)
 {
-  // wait for Transmit Holding Empty to be set in LSR.
-  while((ReadReg(LSR) & (1 << 5)) == 0)
-    ;
-  WriteReg(THR, c);
+  acquire(&uart_tx_lock);
+  while(1){
+    if(((uart_tx_w + 1) % UART_TX_BUF_SIZE) == uart_tx_r){
+      // buffer is full.
+      if(block){
+        // wait for uartstart() to open up space in the buffer.
+        sleep(&uart_tx_r, &uart_tx_lock);
+      } else {
+        // caller does not want us to wait.
+        release(&uart_tx_lock);
+        return;
+      }
+    } else {
+      uart_tx_buf[uart_tx_w] = c;
+      uart_tx_w = (uart_tx_w + 1) % UART_TX_BUF_SIZE;
+      uartstart();
+      release(&uart_tx_lock);
+      return;
+    }
+  }
+}
+
+// if the UART is idle, and a character is waiting
+// in the transmit buffer, send it.
+// caller must hold uart_tx_lock.
+// called from both the top- and bottom-half.
+void
+uartstart()
+{
+  while(1){
+    if(uart_tx_w == uart_tx_r){
+      // transmit buffer is empty.
+      return;
+    }
+    
+    if((ReadReg(LSR) & (1 << 5)) == 0){
+      // the UART transmit holding register is full,
+      // so we cannot give it another byte.
+      // it will interrupt when it's ready for a new byte.
+      return;
+    }
+    
+    int c = uart_tx_buf[uart_tx_r];
+    uart_tx_r = (uart_tx_r + 1) % UART_TX_BUF_SIZE;
+    
+    // maybe uartputc() is waiting for space in the buffer.
+    wakeup(&uart_tx_r);
+    
+    WriteReg(THR, c);
+  }
 }
 
 // read one input character from the UART.
@@ -79,14 +149,22 @@ uartgetc(void)
   }
 }
 
-// trap.c calls here when the uart interrupts.
+// handle a uart interrupt, raised because input has
+// arrived, or the uart is ready for more output, or
+// both. called from trap.c.
 void
 uartintr(void)
 {
+  // read and process incoming characters.
   while(1){
     int c = uartgetc();
     if(c == -1)
       break;
     consoleintr(c);
   }
+
+  // send buffered characters.
+  acquire(&uart_tx_lock);
+  uartstart();
+  release(&uart_tx_lock);
 }

--- a/kernel/virtio_disk.c
+++ b/kernel/virtio_disk.c
@@ -264,6 +264,7 @@ virtio_disk_intr()
 
     disk.used_idx = (disk.used_idx + 1) % NUM;
   }
+  *R(VIRTIO_MMIO_INTERRUPT_ACK) = *R(VIRTIO_MMIO_INTERRUPT_STATUS) & 0x3;
 
   release(&disk.vdisk_lock);
 }

--- a/user/sh.c
+++ b/user/sh.c
@@ -386,7 +386,7 @@ parseredirs(struct cmd *cmd, char **ps, char *es)
       cmd = redircmd(cmd, q, eq, O_RDONLY, 0);
       break;
     case '>':
-      cmd = redircmd(cmd, q, eq, O_WRONLY|O_CREATE, 1);
+      cmd = redircmd(cmd, q, eq, O_WRONLY|O_CREATE|O_TRUNC, 1);
       break;
     case '+':  // >>
       cmd = redircmd(cmd, q, eq, O_WRONLY|O_CREATE, 1);


### PR DESCRIPTION
### Rust 코드에 반영되었는지 한 번 더 확인 후 리뷰 요청 드리겠습니다

- **추가로 uart.rs 관련 변경점이 많아 상욱님께도 리뷰 요청 드리겠습니다** : https://github.com/kaist-cp/rv6/commit/8a23e0fdd2846f56d1c48de163abe5f66c587f9f
- 2020/4/19 ~ 2020/7/20 까지의 커밋을 반영했습니다.  
- related to #261 

- [X] https://github.com/mit-pdos/xv6-riscv/commit/7a5fcb28b33d829a203d62063ec2b98ab6e72c7b : Write interrupt ack register in virtio_disk_intr()
  - `virtio_disk.c::virtio_disk_intr()`에서 `VIRTIO_MMIO_INTERRUPT_ACK`에 `VIRTIO_MMIO_INTERRUPT_STATUS & 0X3`을 넣는 코드를 추가함
  - Rust 반영 완료
    - `virtio.rs`의 `enum MmioRegs`에 `InterruptStatus, InterruptAck` 재생성 완료
    - `virtio_disk.rs::virtio_intr()`에 `MmioRegs::InterruptAck.write(MmioRegs::InterruptStatus.read() & 0x3);` 추가 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/f3979b7212f1bb9d72947f54abead5be973c6aed : make "echo hello > x" truncate file x.
  - `itrunc()` 함수 관련 변경 사항들
    - 주석 변경 -> Rust 반영 완료
    - `sys_open()`에서도 `itrunc()` 실행 -> Rust 반영 완료
  - `readi()` 관련 변경 사항
    - -1가 아닌 0 리턴 -> Rust 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/7a7cd1adefb6eb29523c8fcb762edfe489639f85 : drop QEMUEXTRA
  - `Makefile`에서 `QEMUEXTRA`제거 + `QEMUOPTS` 내용 추가 -> Rust 변경 사항 X
- [X] https://github.com/mit-pdos/xv6-riscv/commit/d6dad42aaffe7460025f103ed3807f589df6b24d : rename p->tf to p->trapframe, for consistency with p->context
  - `struct proc`의 `tf` 필드명을 `trapframe`으로 변경 : Rust 코드 모두에 반영 완료
  - `trampoline.S`의 주석에 있는 `tf`는 https://github.com/mit-pdos/xv6-riscv/commit/1f555198d61d1c447e874ae7e5a0868513822023 (2020년 8월 커밋)에서 일부 수정될 계획입니다.
- [X] https://github.com/mit-pdos/xv6-riscv/commit/3b053f5d58b4914c6389588ad4e556bc887bc99d : cpu->scheduler -> cpu->context to reduce confusion
  - `struct cpu`의 `scheduler` 필드명 (`struct context`)을 `context`로 변경 -> Rust 코드에 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/823864099d0d8def9d4bcf9e382cf42e05bd7afa : interrupt-driven uart output, hopefully a nice example for teaching.
  - 변경점이 많은 commit이어서 리뷰 요청드립니다 : https://github.com/kaist-cp/rv6/commit/8a23e0fdd2846f56d1c48de163abe5f66c587f9f
  - `uart.c`에 새로 생긴 tx 관련 변수들을 보호하는 `tx_lock: Speelablelock<UartTX>`을 `uart.rs::Uart` 내부에 추가했습니다.
  - `Uart::intr()`은 `&self`를, `Uart::start()`는 `&self, SleepablelockGuard<'_, UartTX>`를 받도록 하였습니다.
  - `struct Console`의 `uart` 필드가 `pub`이 필요없는 상태를 유지하기 위해.. Console::uartintr()`을 만들었습니다.

