### PR TITLE
Remove Buf -> Disk dependency (related to #271)

### DIFF
--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -123,11 +123,6 @@ impl Buf {
         let buf = BufUnlocked::new(dev, blockno);
         buf.lock()
     }
-
-    /// Write self's contents to disk.  Must be locked.
-    pub unsafe fn write(&mut self) {
-        Disk::virtio_rw(&mut kernel().disk.lock(), self, true);
-    }
 }
 
 impl Drop for Buf {

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -79,9 +79,6 @@ impl Console {
         }
     }
 
-    // TODO: This should be removed after `WaitChannel::sleep` gets refactored to take
-    // `SpinlockGuard`.
-    #[allow(clippy::while_immutable_condition)]
     unsafe fn read(this: &mut SleepablelockGuard<'_, Self>, mut dst: UVAddr, mut n: i32) -> i32 {
         let target = n as u32;
         while n > 0 {

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -4,12 +4,12 @@ use super::{
 
 use crate::{
     arena::{Arena, ArenaObject, ArrayArena, Rc},
-    bio::Buf,
     kernel::kernel,
     param::NINODE,
     sleeplock::Sleeplock,
     spinlock::Spinlock,
     stat::{Stat, T_DIR, T_NONE},
+    virtio_disk::Disk,
     vm::{KVAddr, VAddr},
 };
 use core::{mem, ops::Deref, ptr};
@@ -151,7 +151,7 @@ impl InodeGuard<'_> {
     /// Must be called after every change to an ip->xxx field
     /// that lives on disk, since i-node cache is write-through.
     pub unsafe fn update(&self) {
-        let mut bp = Buf::new(self.dev, kernel().fs().superblock.iblock(self.inum));
+        let mut bp = Disk::virtio_get_buf(self.dev, kernel().fs().superblock.iblock(self.inum));
         let mut dip: *mut Dinode = (bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
             .add((self.inum as usize).wrapping_rem(IPB));
         let inner = self.deref_inner();
@@ -174,7 +174,7 @@ impl InodeGuard<'_> {
             }
         }
         if self.deref_inner().addrs[NDIRECT] != 0 {
-            let mut bp = Buf::new(self.dev, self.deref_inner().addrs[NDIRECT]);
+            let mut bp = Disk::virtio_get_buf(self.dev, self.deref_inner().addrs[NDIRECT]);
             let a = bp.deref_mut_inner().data.as_mut_ptr() as *mut u32;
             for j in 0..NINDIRECT {
                 if *a.add(j) != 0 {
@@ -205,7 +205,8 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let mut bp = Buf::new(self.dev, self.bmap((off as usize).wrapping_div(BSIZE)));
+            let mut bp =
+                Disk::virtio_get_buf(self.dev, self.bmap((off as usize).wrapping_div(BSIZE)));
             let m = core::cmp::min(
                 n.wrapping_sub(tot),
                 (BSIZE as u32).wrapping_sub(off.wrapping_rem(BSIZE as u32)),
@@ -233,7 +234,8 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let mut bp = Buf::new(self.dev, self.bmap((off as usize).wrapping_div(BSIZE)));
+            let mut bp =
+                Disk::virtio_get_buf(self.dev, self.bmap((off as usize).wrapping_div(BSIZE)));
             let m = core::cmp::min(
                 n.wrapping_sub(tot),
                 (BSIZE as u32).wrapping_sub(off.wrapping_rem(BSIZE as u32)),
@@ -293,7 +295,7 @@ impl InodeGuard<'_> {
             addr = unsafe { balloc(self.dev) };
             self.deref_inner_mut().addrs[NDIRECT] = addr;
         }
-        let mut bp = Buf::new(self.dev, addr);
+        let mut bp = Disk::virtio_get_buf(self.dev, addr);
         let a: *mut u32 = bp.deref_mut_inner().data.as_mut_ptr() as *mut u32;
         unsafe {
             addr = *a.add(bn);
@@ -453,7 +455,7 @@ impl Inode {
     pub fn lock(&self) -> InodeGuard<'_> {
         let mut guard = self.inner.lock();
         if !guard.valid {
-            let mut bp = Buf::new(self.dev, kernel().fs().superblock.iblock(self.inum));
+            let mut bp = Disk::virtio_get_buf(self.dev, kernel().fs().superblock.iblock(self.inum));
             let dip: &mut Dinode = unsafe {
                 &mut *((bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
                     .add((self.inum as usize).wrapping_rem(IPB)))
@@ -493,7 +495,7 @@ impl Inode {
     /// Returns an unlocked but allocated and referenced inode.
     pub unsafe fn alloc(dev: u32, typ: i16) -> RcInode {
         for inum in 1..kernel().fs().superblock.ninodes {
-            let mut bp = Buf::new(dev, kernel().fs().superblock.iblock(inum));
+            let mut bp = Disk::virtio_get_buf(dev, kernel().fs().superblock.iblock(inum));
             let dip = (bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
                 .add((inum as usize).wrapping_rem(IPB));
 

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     log::Log,
     sleepablelock::Sleepablelock,
     stat::T_DIR,
+    virtio_disk::Disk,
     vm::{KVAddr, VAddr},
 };
 use core::{mem, ptr};
@@ -131,7 +132,7 @@ impl Superblock {
     /// Read the super block.
     unsafe fn new(dev: i32) -> Self {
         let mut result = mem::MaybeUninit::uninit();
-        let mut bp = Buf::new(dev as u32, 1);
+        let mut bp = Disk::virtio_get_buf(dev as u32, 1);
         ptr::copy(
             bp.deref_mut_inner().data.as_mut_ptr(),
             result.as_mut_ptr() as *mut Superblock as *mut u8,
@@ -200,7 +201,7 @@ impl FileSystem {
 
 /// Zero a block.
 unsafe fn bzero(dev: i32, bno: i32) {
-    let mut bp = Buf::new(dev as u32, bno as u32);
+    let mut bp = Disk::virtio_get_buf(dev as u32, bno as u32);
     ptr::write_bytes(bp.deref_mut_inner().data.as_mut_ptr(), 0, BSIZE);
     kernel().fs().log_write(bp);
 }
@@ -210,7 +211,7 @@ unsafe fn bzero(dev: i32, bno: i32) {
 unsafe fn balloc(dev: u32) -> u32 {
     let mut bi: u32 = 0;
     for b in num_iter::range_step(0, kernel().fs().superblock.size, BPB) {
-        let mut bp = Buf::new(dev, kernel().fs().superblock.bblock(b));
+        let mut bp = Disk::virtio_get_buf(dev, kernel().fs().superblock.bblock(b));
         while bi < BPB && (b + bi) < kernel().fs().superblock.size {
             let m = 1 << (bi % 8);
             if bp.deref_mut_inner().data[(bi / 8) as usize] as i32 & m == 0 {
@@ -229,7 +230,7 @@ unsafe fn balloc(dev: u32) -> u32 {
 
 /// Free a disk block.
 unsafe fn bfree(dev: i32, b: u32) {
-    let mut bp = Buf::new(dev as u32, kernel().fs().superblock.bblock(b));
+    let mut bp = Disk::virtio_get_buf(dev as u32, kernel().fs().superblock.bblock(b));
     let bi: i32 = b.wrapping_rem(BPB) as i32;
     let m: i32 = (1) << (bi % 8);
     assert_ne!(

--- a/kernel-rs/src/log.rs
+++ b/kernel-rs/src/log.rs
@@ -23,8 +23,10 @@
 use crate::{
     bio::{Buf, BufUnlocked},
     fs::{Superblock, BSIZE},
+    kernel::kernel,
     param::{LOGSIZE, MAXOPBLOCKS},
     sleepablelock::Sleepablelock,
+    virtio_disk::Disk,
 };
 use arrayvec::ArrayVec;
 use core::{mem, ptr};
@@ -96,7 +98,7 @@ impl Log {
             );
 
             // Write dst to disk.
-            dbuf.write();
+            Disk::virtio_rw(&mut kernel().disk.lock(), &mut dbuf, true);
         }
     }
 
@@ -121,7 +123,7 @@ impl Log {
         for (i, b) in self.lh.block.iter().enumerate() {
             (*hb).block[i as usize] = b.blockno as i32;
         }
-        buf.write();
+        Disk::virtio_rw(&mut kernel().disk.lock(), &mut buf, true);
     }
 
     unsafe fn recover_from_log(&mut self) {
@@ -195,7 +197,7 @@ impl Log {
             );
 
             // Write the log.
-            to.write();
+            Disk::virtio_rw(&mut kernel().disk.lock(), &mut to, true);
         }
     }
 

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -198,8 +198,6 @@ impl Disk {
         }
     }
 
-    // TODO: This should be removed after `WaitChannel::sleep` gets refactored to take `SpinlockGuard`.
-    #[allow(clippy::while_immutable_condition)]
     pub unsafe fn virtio_rw(this: &mut SleepablelockGuard<'_, Self>, b: &mut Buf, write: bool) {
         let sector: usize = (*b).blockno.wrapping_mul((BSIZE / 512) as u32) as _;
 


### PR DESCRIPTION
### `bio.rs`에서 `virtio_disk_rw()`를 실행하지 않게 하여 `Buf -> Disk` dependency를 제거했습니다.

- Related to #271 
- `Buf::write()`
  - **buf를 disk를 쓰는 주체는 Disk로 판단**하고, `Buf::write()`가 아닌 `virtio_disk_rw()`를 직접 사용하도록 바꾸었습니다.
- `Buf::lock()`와 `Buf::new()`
  - **블록의 가장 최신 내용을 읽어오는 행위의 주체 역시 Disk로 판단**했습니다. 따라서 기존 `Buf::new()`의 역할을 `virtio_get_buf()`가 하도록 바꾸었습니다.
  - `Buf::lock()` 내부에서 buf.inner.valid가 false인 경우 Disk로 부터 읽어오는 (`virtio_disk_rw()`) 과정이 있었습니다. 이를 `virtio_get_buf()` 내부에서 대신합니다.
  - **따라서 `virtio_get_buf()`가 아닌 `Buf::lock()`을 사용하는 경우, Buf에 담긴 내용이 가장 최신의 내용임이 보장되지 않습니다.** 현재 `Buf::lock()`을 사용하는 경우는 `log.rs::install_trans()`의 `let mut dbuf = dbuf.lock();` 한 곳인데, 이 때 `dbuf`는 `ptr::copy`에 의해 다른 내용으로 덮어쓰여져서 문제가 없습니다.