### PR TITLE
[minor issue from #271] Make Dinode private

### DIFF
--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -562,8 +562,8 @@ unsafe fn balloc(dev: u32) -> u32 {
 /// Free a disk block.
 unsafe fn bfree(dev: i32, b: u32) {
     let mut bp = Disk::read(dev as u32, kernel().fs().superblock.bblock(b));
-    let bi: i32 = b.wrapping_rem(BPB) as i32;
-    let m: i32 = (1) << (bi % 8);
+    let bi = b.wrapping_rem(BPB) as i32;
+    let m = (1) << (bi % 8);
     assert_ne!(
         bp.deref_mut_inner().data[(bi / 8) as usize] as i32 & m,
         0,

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -545,7 +545,8 @@ unsafe fn balloc(dev: u32) -> u32 {
         let mut bp = Disk::read(dev, kernel().fs().superblock.bblock(b));
         while bi < BPB && (b + bi) < kernel().fs().superblock.size {
             let m = 1 << (bi % 8);
-            if bp.deref_mut_inner().data[(bi / 8) as usize] & m == 0 { // Is block free?
+            if bp.deref_mut_inner().data[(bi / 8) as usize] & m == 0 {
+                // Is block free?
                 bp.deref_mut_inner().data[(bi / 8) as usize] |= m; // Mark block in use.
                 kernel().fs().log_write(bp);
                 bzero(dev, b + bi);

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -538,7 +538,6 @@ unsafe fn bzero(dev: i32, bno: i32) {
     kernel().fs().log_write(bp);
 }
 
-/// Blocks.
 /// Allocate a zeroed disk block.
 unsafe fn balloc(dev: u32) -> u32 {
     let mut bi: u32 = 0;

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -1,6 +1,4 @@
-use super::{
-    Dirent, FileName, BSIZE, DIRENT_SIZE, BPB, MAXFILE, NDIRECT, NINDIRECT,
-};
+use super::{Dirent, FileName, BPB, BSIZE, DIRENT_SIZE, MAXFILE, NDIRECT, NINDIRECT};
 
 use crate::{
     arena::{Arena, ArenaObject, ArrayArena, Rc},

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -233,6 +233,6 @@ unsafe fn bfree(dev: u32, b: u32) {
         0,
         "freeing free block"
     );
-    bp.deref_mut_inner().data[(bi / 8) as usize] &= (!m) as u8;
+    bp.deref_mut_inner().data[(bi / 8) as usize] &= !(m as u8);
     kernel().fs().log_write(bp);
 }

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -12,6 +12,7 @@
 /// On-disk file system format used for both kernel and user programs are also included here.
 use crate::{
     bio::Buf,
+    kernel::kernel,
     log::Log,
     sleepablelock::Sleepablelock,
     stat::T_DIR,
@@ -193,4 +194,45 @@ impl FileSystem {
     pub unsafe fn log_write(&self, b: Buf) {
         self.log.lock().log_write(b);
     }
+}
+
+/// Zero a block.
+unsafe fn bzero(dev: u32, bno: u32) {
+    let mut bp = Disk::read(dev, bno);
+    ptr::write_bytes(bp.deref_mut_inner().data.as_mut_ptr(), 0, BSIZE);
+    kernel().fs().log_write(bp);
+}
+
+/// Allocate a zeroed disk block.
+unsafe fn balloc(dev: u32) -> u32 {
+    let mut bi: u32 = 0;
+    for b in num_iter::range_step(0, kernel().fs().superblock.size, BPB) {
+        let mut bp = Disk::read(dev, kernel().fs().superblock.bblock(b));
+        while bi < BPB && (b + bi) < kernel().fs().superblock.size {
+            let m = 1 << (bi % 8);
+            if bp.deref_mut_inner().data[(bi / 8) as usize] & m == 0 {
+                // Is block free?
+                bp.deref_mut_inner().data[(bi / 8) as usize] |= m; // Mark block in use.
+                kernel().fs().log_write(bp);
+                bzero(dev, b + bi);
+                return b + bi;
+            }
+            bi += 1;
+        }
+    }
+    panic!("balloc: out of blocks");
+}
+
+/// Free a disk block.
+unsafe fn bfree(dev: u32, b: u32) {
+    let mut bp = Disk::read(dev, kernel().fs().superblock.bblock(b));
+    let bi = b.wrapping_rem(BPB) as i32;
+    let m = (1) << (bi % 8);
+    assert_ne!(
+        bp.deref_mut_inner().data[(bi / 8) as usize] as i32 & m,
+        0,
+        "freeing free block"
+    );
+    bp.deref_mut_inner().data[(bi / 8) as usize] &= (!m) as u8;
+    kernel().fs().log_write(bp);
 }

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -12,7 +12,6 @@
 /// On-disk file system format used for both kernel and user programs are also included here.
 use crate::{
     bio::Buf,
-    kernel::kernel,
     log::Log,
     sleepablelock::Sleepablelock,
     stat::T_DIR,
@@ -24,7 +23,7 @@ use core::{mem, ptr};
 mod path;
 pub use path::{FileName, Path};
 mod inode;
-pub use inode::{Dinode, Inode, InodeGuard, InodeInner, RcInode};
+pub use inode::{Inode, InodeGuard, InodeInner, RcInode, IPB};
 
 /// Disk layout:
 /// [ boot block | super block | log | inode blocks |
@@ -115,9 +114,6 @@ const NDIRECT: usize = 12;
 const NINDIRECT: usize = BSIZE.wrapping_div(mem::size_of::<u32>());
 const MAXFILE: usize = NDIRECT.wrapping_add(NINDIRECT);
 
-/// Inodes per block.
-const IPB: usize = BSIZE.wrapping_div(mem::size_of::<Dinode>());
-
 impl Superblock {
     /// Block containing inode i
     const fn iblock(self, i: u32) -> u32 {
@@ -197,48 +193,4 @@ impl FileSystem {
     pub unsafe fn log_write(&self, b: Buf) {
         self.log.lock().log_write(b);
     }
-}
-
-/// Zero a block.
-unsafe fn bzero(dev: i32, bno: i32) {
-    let mut bp = Disk::read(dev as u32, bno as u32);
-    ptr::write_bytes(bp.deref_mut_inner().data.as_mut_ptr(), 0, BSIZE);
-    kernel().fs().log_write(bp);
-}
-
-/// Blocks.
-/// Allocate a zeroed disk block.
-unsafe fn balloc(dev: u32) -> u32 {
-    let mut bi: u32 = 0;
-    for b in num_iter::range_step(0, kernel().fs().superblock.size, BPB) {
-        let mut bp = Disk::read(dev, kernel().fs().superblock.bblock(b));
-        while bi < BPB && (b + bi) < kernel().fs().superblock.size {
-            let m = 1 << (bi % 8);
-            if bp.deref_mut_inner().data[(bi / 8) as usize] as i32 & m == 0 {
-                // Is block free?
-                bp.deref_mut_inner().data[(bi / 8) as usize] =
-                    (bp.deref_mut_inner().data[(bi / 8) as usize] as i32 | m) as u8; // Mark block in use.
-                kernel().fs().log_write(bp);
-                bzero(dev as i32, (b + bi) as i32);
-                return b + bi;
-            }
-            bi += 1;
-        }
-    }
-    panic!("balloc: out of blocks");
-}
-
-/// Free a disk block.
-unsafe fn bfree(dev: i32, b: u32) {
-    let mut bp = Disk::read(dev as u32, kernel().fs().superblock.bblock(b));
-    let bi: i32 = b.wrapping_rem(BPB) as i32;
-    let m: i32 = (1) << (bi % 8);
-    assert_ne!(
-        bp.deref_mut_inner().data[(bi / 8) as usize] as i32 & m,
-        0,
-        "freeing free block"
-    );
-    bp.deref_mut_inner().data[(bi / 8) as usize] =
-        (bp.deref_mut_inner().data[(bi / 8) as usize] as i32 & !m) as u8;
-    kernel().fs().log_write(bp);
 }


### PR DESCRIPTION
- minor한 depencency입니다.

---

- mod.rs에 있던 `bzero`, `balloc`, `bfree`는 inode에서만 사용되기 때문에 inode.rs로 옮겼습니다.
- mod.rs에 있던 IPB를 inode.rs에서 정의하고, Dinode를 private하게 바꿨습니다.