### PR TITLE
[#271] remove mod->log dependency

### DIFF
--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -174,7 +174,10 @@ impl FileSystem {
         unsafe {
             let superblock = Superblock::new(dev);
             assert_eq!(superblock.magic, FSMAGIC, "invalid file system");
-            let log = Sleepablelock::new("LOG", Log::new(dev, &superblock));
+            let log = Sleepablelock::new(
+                "LOG",
+                Log::new(dev, superblock.logstart as i32, superblock.nlog as i32),
+            );
             Self { superblock, log }
         }
     }

--- a/kernel-rs/src/log.rs
+++ b/kernel-rs/src/log.rs
@@ -22,7 +22,7 @@
 //! Log appends are synchronous.
 use crate::{
     bio::{Buf, BufUnlocked},
-    fs::{Superblock, BSIZE},
+    fs::BSIZE,
     param::{LOGSIZE, MAXOPBLOCKS},
     sleepablelock::Sleepablelock,
     virtio_disk::Disk,
@@ -57,15 +57,15 @@ struct LogHeaderInMemory {
 }
 
 impl Log {
-    pub fn new(dev: i32, superblock: &Superblock) -> Self {
+    pub fn new(dev: i32, start: i32, size: i32) -> Self {
         assert!(
             mem::size_of::<LogHeader>() < BSIZE,
             "Log::new: too big LogHeader"
         );
 
         let mut log = Self {
-            start: superblock.logstart as i32,
-            size: superblock.nlog as i32,
+            start,
+            size,
             outstanding: 0,
             committing: false,
             dev,


### PR DESCRIPTION
- `Log::new`에서 `&Superblock`대신 `superblock.logstart`, `superblock.nlog`의 값만 받으면 mod->log dependency가 사라집니다.