### PR TITLE
[Closes #243, Updated from #276] Fix: Procdump & Sleepablelock

### DIFF
--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -833,13 +833,19 @@ impl ProcessSystem {
     pub unsafe fn dump(&self) {
         println!();
         for p in &self.process_pool {
+            let mut name = [0; 16];
+            let mut count = 0;
+            while p.name[count] != 0 as u8 {
+                name[count] = p.name[count];
+                count += 1;
+            }
             let info = p.info.get_mut_unchecked();
             if info.state != Procstate::UNUSED {
                 println!(
                     "{} {} {}",
                     info.pid,
                     Procstate::to_str(&info.state),
-                    str::from_utf8(&p.name).unwrap_or("???")
+                    str::from_utf8(&name).unwrap_or("???")
                 );
             }
         }

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -37,7 +37,9 @@ impl<T> Sleepablelock<T> {
     }
 
     pub fn lock(&self) -> SleepablelockGuard<'_, T> {
-        self.lock.acquire();
+        if !self.lock.holding() {
+            self.lock.acquire();
+        }
 
         SleepablelockGuard {
             lock: self,
@@ -79,7 +81,9 @@ impl<T> SleepablelockGuard<'_, T> {
 
 impl<T> Drop for SleepablelockGuard<'_, T> {
     fn drop(&mut self) {
-        self.lock.lock.release();
+        if self.lock.lock.holding() {
+            self.lock.lock.release();
+        }
     }
 }
 


### PR DESCRIPTION
#Closes #243 
#Updated from #276 

xv6의 구현과 달리 lock을 하나만 잡도록 한 상태로 bug를 고쳤습니다. 
1. `ProcessSystem::dump` 내에서 출력할 때 Null character 이전까지만 출력하도록 수정. https://github.com/kaist-cp/rv6/pull/276#issuecomment-727167934
2. `Sleepablelock`이 holding 중이지 않을 때만 acquire 하고, holding 중일 때만 release 하도록 수정. https://github.com/kaist-cp/rv6/pull/276#issuecomment-730200985
- `consoleintr`에서 `Console lock`이 acquire 된 상황에서 `write_console_fmt`에서 `Console lock`을 이중으로 acquire 할 때 panic 하는 것이 bug의 원인이었습니다.
- `RawSpinlock`을 수정하는 것은 xv6의 intention을 바꾸는 작업이라고 생각하여 `Sleepablelock`에서만 일단 수정을 했습니다.
- `Spinlock`도 수정이 필요할까요?