### PR TITLE
[#closes 243] Procdump debug & Refactor console struct.

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -220,19 +220,19 @@ pub unsafe fn consoleinit(devsw: &mut [Devsw; NDEV]) {
     kernel().console.uart.init();
 
     // Connect read and write system calls
-    // to terminalread and terminalwrite.
+    // to consoleread and consolewrite.
     devsw[CONSOLE_IN_DEVSW] = Devsw {
         read: Some(consoleread),
         write: Some(consolewrite),
     };
 }
 
-/// User write()s to the terminal go here.
+/// User write()s to the console go here.
 unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
     kernel().console.terminalwrite(src, n)
 }
 
-/// User read()s from the terminal go here.
+/// User read()s from the console go here.
 /// Copy (up to) a whole input line to dst.
 /// User_dist indicates whether dst is a user
 /// or kernel address.
@@ -243,7 +243,7 @@ unsafe fn consoleread(dst: UVAddr, n: i32) -> i32 {
 /// The console input interrupt handler.
 /// uartintr() calls this for input character.
 /// Do erase/kill processing, append to CONS.buf,
-/// wake up terminalread() if a whole line has arrived.
+/// wake up consoleread() if a whole line has arrived.
 pub unsafe fn consoleintr(cin: i32) {
     kernel().console.terminalintr(cin);
 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -16,7 +16,7 @@ const CONSOLE_IN_DEVSW: usize = 1;
 const INPUT_BUF: usize = 128;
 
 /// The integrated interface for console device.
-/// Managing every communications between real-world users and system.
+/// Managing every communication between real-world users and system.
 pub struct Console {
     /// An interface for user programs.
     /// I/O interactions between users and processes are done by this interface.

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -30,7 +30,7 @@ pub struct Console {
 
     /// A console's uart interface which guarantees uniqueness.
     /// Interaction with UART Registers should always held by this interface.
-    uart: Uart,
+    pub uart: Uart,
 }
 
 impl Console {
@@ -51,10 +51,6 @@ impl Console {
             read: Some(consoleread),
             write: Some(consolewrite),
         };
-    }
-
-    pub fn uartintr(&self) {
-        self.uart.intr()
     }
 
     /// Send one character to the uart.

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -50,7 +50,7 @@ impl Console {
         };
     }
 
-    unsafe fn terminalwrite(&self, src: UVAddr, n: i32) -> i32 {
+    unsafe fn write(&self, src: UVAddr, n: i32) -> i32 {
         self.terminal.lock();
         for i in 0..n {
             let mut c = [0 as u8];
@@ -62,7 +62,7 @@ impl Console {
         n
     }
 
-    unsafe fn terminalread(&self, mut dst: UVAddr, mut n: i32) -> i32 {
+    unsafe fn read(&self, mut dst: UVAddr, mut n: i32) -> i32 {
         let mut terminal = self.terminal.lock();
         let target = n as u32;
         while n > 0 {
@@ -104,7 +104,7 @@ impl Console {
         target.wrapping_sub(n as u32) as i32
     }
 
-    fn terminalintr(&self, mut cin: i32) {
+    fn intr(&self, mut cin: i32) {
         let mut terminal = self.terminal.lock();
         match cin {
             // Print process list.
@@ -230,7 +230,7 @@ pub fn consoleinit(devsw: &mut [Devsw; NDEV]) {
 
 /// User write()s to the console go here.
 unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
-    kernel().console.terminalwrite(src, n)
+    kernel().console.write(src, n)
 }
 
 /// User read()s from the console go here.
@@ -238,7 +238,7 @@ unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
 /// User_dist indicates whether dst is a user
 /// or kernel address.
 unsafe fn consoleread(dst: UVAddr, n: i32) -> i32 {
-    kernel().console.terminalread(dst, n)
+    kernel().console.read(dst, n)
 }
 
 /// The console input interrupt handler.
@@ -246,5 +246,5 @@ unsafe fn consoleread(dst: UVAddr, n: i32) -> i32 {
 /// Do erase/kill processing, append to CONS.buf,
 /// wake up consoleread() if a whole line has arrived.
 pub fn consoleintr(cin: i32) {
-    kernel().console.terminalintr(cin);
+    kernel().console.intr(cin);
 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -15,9 +15,15 @@ const CONSOLE_IN_DEVSW: usize = 1;
 /// Size of console input buffer.
 const INPUT_BUF: usize = 128;
 
+/// The integrated interface for console device.
 pub struct Console {
+    /// An interface for user programs. I/O interactions for processes are done by this interface. 
     terminal: Sleepablelock<Terminal>,
+
+    /// A struct for println! macro. Lock to avoid interleaving concurrent println! macros.
     pub printer: Spinlock<Printer>,
+
+    /// A console's uart interface which guarantees uniqueness. Interaction with UART Registers should always held by this interface.
     uart: Uart,
 }
 

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -174,9 +174,9 @@ impl SleepablelockGuard<'_, Terminal> {
     fn intr(&mut self, mut cin: i32) {
         match cin {
             // Print process list.
-            m if m == ctrl('P') => unsafe {
+            m if m == ctrl('P') => {
                 kernel().procs.dump();
-            },
+            }
 
             // Kill line.
             m if m == ctrl('U') => {

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -197,13 +197,11 @@ impl Terminal {
 }
 
 /// A printer formats UTF-8 bytes.
-pub struct Printer {
-    _padding: u8,
-}
+pub struct Printer {}
 
 impl Printer {
     pub const fn new() -> Self {
-        Self { _padding: 0 }
+        Self {}
     }
 }
 

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -132,6 +132,7 @@ impl Console {
                     self.putc(BACKSPACE);
                 }
             }
+
             _ => {
                 if cin != 0 && terminal.e.wrapping_sub(terminal.r) < INPUT_BUF as u32 {
                     cin = if cin == '\r' as i32 { '\n' as i32 } else { cin };

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -215,17 +215,17 @@ const fn ctrl(x: char) -> i32 {
     x as i32 - '@' as i32
 }
 
-pub unsafe fn terminalinit(devsw: &mut [Devsw; NDEV]) {
+pub unsafe fn consoleinit(devsw: &mut [Devsw; NDEV]) {
     // Connect read and write system calls
     // to terminalread and terminalwrite.
     devsw[CONSOLE_IN_DEVSW] = Devsw {
-        read: Some(terminalread),
-        write: Some(terminalwrite),
+        read: Some(consoleread),
+        write: Some(consolewrite),
     };
 }
 
 /// User write()s to the terminal go here.
-unsafe fn terminalwrite(src: UVAddr, n: i32) -> i32 {
+unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
     kernel().console.terminalwrite(src, n)
 }
 
@@ -233,7 +233,7 @@ unsafe fn terminalwrite(src: UVAddr, n: i32) -> i32 {
 /// Copy (up to) a whole input line to dst.
 /// User_dist indicates whether dst is a user
 /// or kernel address.
-unsafe fn terminalread(dst: UVAddr, n: i32) -> i32 {
+unsafe fn consoleread(dst: UVAddr, n: i32) -> i32 {
     kernel().console.terminalread(dst, n)
 }
 
@@ -241,6 +241,6 @@ unsafe fn terminalread(dst: UVAddr, n: i32) -> i32 {
 /// uartintr() calls this for input character.
 /// Do erase/kill processing, append to CONS.buf,
 /// wake up terminalread() if a whole line has arrived.
-pub unsafe fn terminalintr(cin: i32) {
+pub unsafe fn consoleintr(cin: i32) {
     kernel().console.terminalintr(cin);
 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -16,7 +16,7 @@ const CONSOLE_IN_DEVSW: usize = 1;
 const INPUT_BUF: usize = 128;
 
 /// The integrated interface for console device.
-/// Managing every graphic interactions with real-world users and system.
+/// Managing every graphic interactions between real-world users and system.
 pub struct Console {
     /// An interface for user programs.
     /// I/O interactions between users and processes are done by this interface.

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -104,13 +104,13 @@ impl Console {
         target.wrapping_sub(n as u32) as i32
     }
 
-    unsafe fn terminalintr(&self, mut cin: i32) {
+    fn terminalintr(&self, mut cin: i32) {
         let mut terminal = self.terminal.lock();
         match cin {
             // Print process list.
-            m if m == ctrl('P') => {
+            m if m == ctrl('P') => unsafe {
                 kernel().procs.dump();
-            }
+            },
 
             // Kill line.
             m if m == ctrl('U') => {

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -16,9 +16,10 @@ const CONSOLE_IN_DEVSW: usize = 1;
 const INPUT_BUF: usize = 128;
 
 /// The integrated interface for console device.
+/// Managing every graphic interactions with real-world users and system.
 pub struct Console {
     /// An interface for user programs.
-    /// I/O interactions for processes are done by this interface.
+    /// I/O interactions between users and processes are done by this interface.
     terminal: Sleepablelock<Terminal>,
 
     /// A struct for println! macro.

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -1,6 +1,6 @@
 use crate::{
     file::Devsw,
-    kernel::kernel,
+    kernel::{kernel, KERNEL},
     param::NDEV,
     proc::myproc,
     sleepablelock::Sleepablelock,
@@ -69,8 +69,7 @@ impl Console {
         };
     }
 
-    unsafe fn write(&self, src: UVAddr, n: i32) -> i32 {
-        self.terminal.lock();
+    unsafe fn write(&mut self, src: UVAddr, n: i32) -> i32 {
         for i in 0..n {
             let mut c = [0 as u8];
             if VAddr::copyin(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
@@ -242,7 +241,7 @@ const fn ctrl(x: char) -> i32 {
 
 /// User write()s to the console go here.
 unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
-    kernel().console.write(src, n)
+    KERNEL.console.write(src, n)
 }
 
 /// User read()s from the console go here.

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -158,15 +158,6 @@ impl Console {
     }
 }
 
-impl Write for Printer {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        for c in s.bytes() {
-            kernel().console.putc(c as _);
-        }
-        Ok(())
-    }
-}
-
 pub struct Terminal {
     buf: [u8; INPUT_BUF],
 
@@ -201,6 +192,15 @@ impl Printer {
     }
 }
 
+impl Write for Printer {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.bytes() {
+            kernel().console.putc(c as _);
+        }
+        Ok(())
+    }
+}
+
 /// Console input and output, to the uart.
 /// Reads are line at a time.
 /// Implements special input characters:
@@ -216,7 +216,7 @@ const fn ctrl(x: char) -> i32 {
     x as i32 - '@' as i32
 }
 
-pub unsafe fn consoleinit(devsw: &mut [Devsw; NDEV]) {
+pub fn consoleinit(devsw: &mut [Devsw; NDEV]) {
     kernel().console.uart.init();
 
     // Connect read and write system calls
@@ -244,6 +244,6 @@ unsafe fn consoleread(dst: UVAddr, n: i32) -> i32 {
 /// uartintr() calls this for input character.
 /// Do erase/kill processing, append to CONS.buf,
 /// wake up consoleread() if a whole line has arrived.
-pub unsafe fn consoleintr(cin: i32) {
+pub fn consoleintr(cin: i32) {
     kernel().console.terminalintr(cin);
 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -20,6 +20,8 @@ const INPUT_BUF: usize = 128;
 pub struct Console {
     /// An interface for user programs.
     /// I/O interactions between users and processes are done by this interface.
+    /// Inputs: User commands.
+    /// Outputs: Graphic(text) results.
     terminal: Sleepablelock<Terminal>,
 
     /// A struct for println! macro.
@@ -169,6 +171,7 @@ impl Console {
     }
 }
 
+/// Accept user commands and show result texts.
 pub struct Terminal {
     buf: [u8; INPUT_BUF],
 
@@ -193,6 +196,7 @@ impl Terminal {
     }
 }
 
+/// A printer formats UTF-8 bytes.
 pub struct Printer {
     _padding: u8,
 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -216,6 +216,8 @@ const fn ctrl(x: char) -> i32 {
 }
 
 pub unsafe fn consoleinit(devsw: &mut [Devsw; NDEV]) {
+    kernel().console.uart.init();
+
     // Connect read and write system calls
     // to terminalread and terminalwrite.
     devsw[CONSOLE_IN_DEVSW] = Devsw {

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -3,7 +3,7 @@ use crate::{
     kernel::kernel,
     param::NDEV,
     proc::myproc,
-    sleepablelock::Sleepablelock,
+    sleepablelock::{Sleepablelock, SleepablelockGuard},
     spinlock::Spinlock,
     uart::Uart,
     utils::spin_loop,
@@ -42,6 +42,17 @@ impl Console {
         }
     }
 
+    pub fn init(&mut self, devsw: &mut [Devsw; NDEV]) {
+        self.uart.init();
+
+        // Connect read and write system calls
+        // to consoleread and consolewrite.
+        devsw[CONSOLE_IN_DEVSW] = Devsw {
+            read: Some(consoleread),
+            write: Some(consolewrite),
+        };
+    }
+
     pub fn uartintr(&self) {
         self.uart.intr()
     }
@@ -63,111 +74,22 @@ impl Console {
     }
 
     unsafe fn write(&self, src: UVAddr, n: i32) -> i32 {
-        self.terminal.lock();
-        for i in 0..n {
-            let mut c = [0 as u8];
-            if VAddr::copyin(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
-                return i;
-            }
-            self.uart.putc(c[0] as i32);
-        }
-        n
+        let terminal = self.terminal.lock();
+        terminal.write(src, n)
     }
 
-    unsafe fn read(&self, mut dst: UVAddr, mut n: i32) -> i32 {
+    unsafe fn read(&self, dst: UVAddr, n: i32) -> i32 {
         let mut terminal = self.terminal.lock();
-        let target = n as u32;
-        while n > 0 {
-            // Wait until interrupt handler has put some
-            // input into CONS.buffer.
-            while terminal.r == terminal.w {
-                if (*myproc()).killed() {
-                    return -1;
-                }
-                terminal.sleep();
-            }
-            let fresh0 = terminal.r;
-            terminal.r = terminal.r.wrapping_add(1);
-            let cin = terminal.buf[fresh0.wrapping_rem(INPUT_BUF as u32) as usize] as i32;
-
-            // end-of-file
-            if cin == ctrl('D') {
-                if (n as u32) < target {
-                    // Save ^D for next time, to make sure
-                    // caller gets a 0-byte result.
-                    terminal.r = terminal.r.wrapping_sub(1)
-                }
-                break;
-            } else {
-                // Copy the input byte to the user-space buffer.
-                let cbuf = [cin as u8];
-                if UVAddr::copyout(dst, &cbuf).is_err() {
-                    break;
-                }
-                dst = dst + 1;
-                n -= 1;
-                if cin == '\n' as i32 {
-                    // A whole line has arrived, return to
-                    // the user-level read().
-                    break;
-                }
-            }
-        }
-        target.wrapping_sub(n as u32) as i32
+        terminal.read(dst, n)
     }
 
-    fn intr(&self, mut cin: i32) {
+    /// The console input interrupt handler.
+    /// uartintr() calls this for input character.
+    /// Do erase/kill processing, append to TERMINAL.buf,
+    /// wake up consoleread() if a whole line has arrived.
+    pub fn intr(&self, cin: i32) {
         let mut terminal = self.terminal.lock();
-        match cin {
-            // Print process list.
-            m if m == ctrl('P') => unsafe {
-                kernel().procs.dump();
-            },
-
-            // Kill line.
-            m if m == ctrl('U') => {
-                while terminal.e != terminal.w
-                    && terminal.buf
-                        [terminal.e.wrapping_sub(1).wrapping_rem(INPUT_BUF as u32) as usize]
-                        as i32
-                        != '\n' as i32
-                {
-                    terminal.e = terminal.e.wrapping_sub(1);
-                    self.putc(BACKSPACE);
-                }
-            }
-
-            // Backspace
-            m if m == ctrl('H') | '\x7f' as i32 => {
-                if terminal.e != terminal.w {
-                    terminal.e = terminal.e.wrapping_sub(1);
-                    self.putc(BACKSPACE);
-                }
-            }
-
-            _ => {
-                if cin != 0 && terminal.e.wrapping_sub(terminal.r) < INPUT_BUF as u32 {
-                    cin = if cin == '\r' as i32 { '\n' as i32 } else { cin };
-
-                    // Echo back to the user.
-                    self.putc(cin);
-
-                    // Store for consumption by consoleread().
-                    let fresh1 = terminal.e;
-                    terminal.e = terminal.e.wrapping_add(1);
-                    terminal.buf[fresh1.wrapping_rem(INPUT_BUF as u32) as usize] = cin as u8;
-                    if cin == '\n' as i32
-                        || cin == ctrl('D')
-                        || terminal.e == terminal.r.wrapping_add(INPUT_BUF as u32)
-                    {
-                        // Wake up consoleread() if a whole line (or end-of-file)
-                        // has arrived.
-                        terminal.w = terminal.e;
-                        terminal.wakeup();
-                    }
-                }
-            }
-        }
+        terminal.intr(cin);
     }
 }
 
@@ -192,6 +114,112 @@ impl Terminal {
             r: 0,
             w: 0,
             e: 0,
+        }
+    }
+}
+
+impl SleepablelockGuard<'_, Terminal> {
+    unsafe fn write(&self, src: UVAddr, n: i32) -> i32 {
+        for i in 0..n {
+            let mut c = [0 as u8];
+            if VAddr::copyin(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
+                return i;
+            }
+            kernel().console.uart.putc(c[0] as i32);
+        }
+        n
+    }
+
+    unsafe fn read(&mut self, mut dst: UVAddr, mut n: i32) -> i32 {
+        let target = n as u32;
+        while n > 0 {
+            // Wait until interrupt handler has put some
+            // input into CONS.buffer.
+            while self.r == self.w {
+                if (*myproc()).killed() {
+                    return -1;
+                }
+                self.sleep();
+            }
+            let fresh0 = self.r;
+            self.r = self.r.wrapping_add(1);
+            let cin = self.buf[fresh0.wrapping_rem(INPUT_BUF as u32) as usize] as i32;
+
+            // end-of-file
+            if cin == ctrl('D') {
+                if (n as u32) < target {
+                    // Save ^D for next time, to make sure
+                    // caller gets a 0-byte result.
+                    self.r = self.r.wrapping_sub(1)
+                }
+                break;
+            } else {
+                // Copy the input byte to the user-space buffer.
+                let cbuf = [cin as u8];
+                if UVAddr::copyout(dst, &cbuf).is_err() {
+                    break;
+                }
+                dst = dst + 1;
+                n -= 1;
+                if cin == '\n' as i32 {
+                    // A whole line has arrived, return to
+                    // the user-level read().
+                    break;
+                }
+            }
+        }
+        target.wrapping_sub(n as u32) as i32
+    }
+
+    fn intr(&mut self, mut cin: i32) {
+        match cin {
+            // Print process list.
+            m if m == ctrl('P') => unsafe {
+                kernel().procs.dump();
+            },
+
+            // Kill line.
+            m if m == ctrl('U') => {
+                while self.e != self.w
+                    && self.buf[self.e.wrapping_sub(1).wrapping_rem(INPUT_BUF as u32) as usize]
+                        as i32
+                        != '\n' as i32
+                {
+                    self.e = self.e.wrapping_sub(1);
+                    kernel().console.uart.putc(BACKSPACE);
+                }
+            }
+
+            // Backspace
+            m if m == ctrl('H') | '\x7f' as i32 => {
+                if self.e != self.w {
+                    self.e = self.e.wrapping_sub(1);
+                    kernel().console.uart.putc(BACKSPACE);
+                }
+            }
+
+            _ => {
+                if cin != 0 && self.e.wrapping_sub(self.r) < INPUT_BUF as u32 {
+                    cin = if cin == '\r' as i32 { '\n' as i32 } else { cin };
+
+                    // Echo back to the user.
+                    kernel().console.uart.putc(cin);
+
+                    // Store for consumption by consoleread().
+                    let fresh1 = self.e;
+                    self.e = self.e.wrapping_add(1);
+                    self.buf[fresh1.wrapping_rem(INPUT_BUF as u32) as usize] = cin as u8;
+                    if cin == '\n' as i32
+                        || cin == ctrl('D')
+                        || self.e == self.r.wrapping_add(INPUT_BUF as u32)
+                    {
+                        // Wake up consoleread() if a whole line (or end-of-file)
+                        // has arrived.
+                        self.w = self.e;
+                        self.wakeup();
+                    }
+                }
+            }
         }
     }
 }
@@ -229,17 +257,6 @@ const fn ctrl(x: char) -> i32 {
     x as i32 - '@' as i32
 }
 
-pub fn consoleinit(devsw: &mut [Devsw; NDEV]) {
-    kernel().console.uart.init();
-
-    // Connect read and write system calls
-    // to consoleread and consolewrite.
-    devsw[CONSOLE_IN_DEVSW] = Devsw {
-        read: Some(consoleread),
-        write: Some(consolewrite),
-    };
-}
-
 /// User write()s to the console go here.
 unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
     kernel().console.write(src, n)
@@ -251,12 +268,4 @@ unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
 /// or kernel address.
 unsafe fn consoleread(dst: UVAddr, n: i32) -> i32 {
     kernel().console.read(dst, n)
-}
-
-/// The console input interrupt handler.
-/// uartintr() calls this for input character.
-/// Do erase/kill processing, append to CONS.buf,
-/// wake up consoleread() if a whole line has arrived.
-pub fn consoleintr(cin: i32) {
-    kernel().console.intr(cin);
 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -16,7 +16,7 @@ const CONSOLE_IN_DEVSW: usize = 1;
 const INPUT_BUF: usize = 128;
 
 /// The integrated interface for console device.
-/// Managing every graphic interactions between real-world users and system.
+/// Managing every communications between real-world users and system.
 pub struct Console {
     /// An interface for user programs.
     /// I/O interactions between users and processes are done by this interface.

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -17,13 +17,16 @@ const INPUT_BUF: usize = 128;
 
 /// The integrated interface for console device.
 pub struct Console {
-    /// An interface for user programs. I/O interactions for processes are done by this interface. 
+    /// An interface for user programs.
+    /// I/O interactions for processes are done by this interface.
     terminal: Sleepablelock<Terminal>,
 
-    /// A struct for println! macro. Lock to avoid interleaving concurrent println! macros.
+    /// A struct for println! macro.
+    /// Lock to avoid interleaving concurrent println! macros.
     pub printer: Spinlock<Printer>,
 
-    /// A console's uart interface which guarantees uniqueness. Interaction with UART Registers should always held by this interface.
+    /// A console's uart interface which guarantees uniqueness.
+    /// Interaction with UART Registers should always held by this interface.
     uart: Uart,
 }
 

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -19,7 +19,6 @@ use crate::{
     sleepablelock::Sleepablelock,
     spinlock::Spinlock,
     trap::{trapinit, trapinithart},
-    uart::Uart,
     virtio_disk::{virtio_disk_init, Disk},
     vm::{KVAddr, PageTable},
 };
@@ -220,7 +219,6 @@ pub unsafe fn kernel_main() -> ! {
         // Initialize the kernel.
 
         // Console.
-        Uart::init();
         consoleinit(&mut KERNEL.devsw);
 
         println!();

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -5,7 +5,7 @@ use spin::Once;
 use crate::{
     arena::{ArrayArena, ArrayEntry, MruArena, MruEntry},
     bio::BufEntry,
-    console::{terminalinit, Console},
+    console::{consoleinit, Console},
     file::{Devsw, File},
     fs::{FileSystem, Inode},
     kalloc::{end, kinit, Kmem},
@@ -221,7 +221,7 @@ pub unsafe fn kernel_main() -> ! {
 
         // Console.
         Uart::init();
-        terminalinit(&mut KERNEL.devsw);
+        consoleinit(&mut KERNEL.devsw);
 
         println!();
         println!("rv6 kernel is booting");

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// The kernel.
-static mut KERNEL: Kernel = Kernel::zero();
+pub static mut KERNEL: Kernel = Kernel::zero();
 
 /// After intialized, the kernel is safe to immutably access.
 #[inline]

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -153,8 +153,8 @@ impl Kernel {
         Some(page)
     }
 
-    /// Prints the given formatted string with the Console.
-    pub fn console_write_fmt(&self, args: fmt::Arguments<'_>) -> fmt::Result {
+    /// Prints the given formatted string with the Printer.
+    pub fn printer_write_fmt(&self, args: fmt::Arguments<'_>) -> fmt::Result {
         if self.is_panicked() {
             unsafe { self.console.printer.get_mut_unchecked().write_fmt(args) }
         } else {

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -154,7 +154,7 @@ impl Kernel {
     }
 
     /// Prints the given formatted string with the Printer.
-    pub fn console_write_fmt(&self, args: fmt::Arguments<'_>) -> fmt::Result {
+    pub fn printer_write_fmt(&self, args: fmt::Arguments<'_>) -> fmt::Result {
         if self.is_panicked() {
             unsafe { self.console.printer.get_mut_unchecked().write_fmt(args) }
         } else {
@@ -189,7 +189,7 @@ impl Kernel {
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {
-        $crate::kernel::kernel().console_write_fmt(format_args!($($arg)*)).unwrap();
+        $crate::kernel::kernel().printer_write_fmt(format_args!($($arg)*)).unwrap();
     };
 }
 

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -5,7 +5,7 @@ use spin::Once;
 use crate::{
     arena::{ArrayArena, ArrayEntry, MruArena, MruEntry},
     bio::BufEntry,
-    console::{consoleinit, Console},
+    console::Console,
     file::{Devsw, File},
     fs::{FileSystem, Inode},
     kalloc::{end, kinit, Kmem},
@@ -219,7 +219,7 @@ pub unsafe fn kernel_main() -> ! {
         // Initialize the kernel.
 
         // Console.
-        consoleinit(&mut KERNEL.devsw);
+        KERNEL.console.init(&mut KERNEL.devsw);
 
         println!();
         println!("rv6 kernel is booting");

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -154,7 +154,7 @@ impl Kernel {
     }
 
     /// Prints the given formatted string with the Printer.
-    pub fn printer_write_fmt(&self, args: fmt::Arguments<'_>) -> fmt::Result {
+    pub fn console_write_fmt(&self, args: fmt::Arguments<'_>) -> fmt::Result {
         if self.is_panicked() {
             unsafe { self.console.printer.get_mut_unchecked().write_fmt(args) }
         } else {

--- a/kernel-rs/src/param.rs
+++ b/kernel-rs/src/param.rs
@@ -1,39 +1,42 @@
-/// maximum number of processes
+/// Maximum number of processes.
 pub const NPROC: usize = 64;
 
-/// maximum number of CPUs
+/// Maximum number of CPUs.
 pub const NCPU: usize = 8;
 
-/// open files per process
+/// Open files per process.
 pub const NOFILE: usize = 16;
 
-/// open files per system
+/// Open files per system.
 pub const NFILE: usize = 100;
 
-/// maximum number of active i-nodes
+/// Maximum number of active i-nodes.
 pub const NINODE: usize = 50;
 
-/// maximum major device number
+/// Maximum major device number.
 pub const NDEV: usize = 10;
 
-/// device number of file system root disk
+/// Device number of file system root disk.
 pub const ROOTDEV: i32 = 1;
 
-/// max exec arguments
+/// Max exec arguments.
 pub const MAXARG: usize = 32;
 
-/// max # of blocks any FS op writes
-/// Will be handled in #31
+/// Max # of blocks any FS op writes.
+/// Will be handled in #31.
 pub const MAXOPBLOCKS: usize = 10;
 
-/// max data blocks in on-disk log
+/// Max data blocks in on-disk log.
 pub const LOGSIZE: usize = MAXOPBLOCKS * 3;
 
-/// size of disk block cache
+/// Size of disk block cache.
 pub const NBUF: usize = MAXOPBLOCKS * 3;
 
-/// size of file system in blocks
+/// Size of file system in blocks.
 pub const FSSIZE: usize = 1000;
 
-/// maximum file path name
+/// Maximum file path name.
 pub const MAXPATH: usize = 128;
+
+/// Maximum length of process name.
+pub const MAXPROCNAME: usize = 16;

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -830,7 +830,7 @@ impl ProcessSystem {
     /// Print a process listing to console.  For debugging.
     /// Runs when user types ^P on console.
     /// No lock to avoid wedging a stuck machine further.
-    pub unsafe fn dump(&self) {
+    pub fn dump(&self) {
         println!();
         for p in &self.process_pool {
             // For null character recognization.
@@ -841,14 +841,16 @@ impl ProcessSystem {
                 name[count] = p.name[count];
                 count += 1;
             }
-            let info = p.info.get_mut_unchecked();
-            if info.state != Procstate::UNUSED {
-                println!(
-                    "{} {} {}",
-                    info.pid,
-                    Procstate::to_str(&info.state),
-                    str::from_utf8(&name).unwrap_or("???")
-                );
+            unsafe {
+                let info = p.info.get_mut_unchecked();
+                if info.state != Procstate::UNUSED {
+                    println!(
+                        "{} {} {}",
+                        info.pid,
+                        Procstate::to_str(&info.state),
+                        str::from_utf8(&name).unwrap_or("???")
+                    );
+                }
             }
         }
     }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -852,6 +852,7 @@ impl ProcessSystem {
     }
 }
 
+/// Initialize the proc table at boot time.
 pub unsafe fn procinit(procs: &mut ProcessSystem, page_table: &mut PageTable<KVAddr>) {
     for (i, p) in procs.process_pool.iter_mut().enumerate() {
         (*p.data.get()).palloc(page_table, i);
@@ -899,8 +900,8 @@ unsafe fn freeproc(mut p: ProcGuard) {
     p.deref_mut_info().state = Procstate::UNUSED;
 }
 
-/// Create a page table for a given process,
-/// with no user pages, but with trampoline pages.
+/// Create a user page table for a given process,
+/// with no user memory, but with trampoline pages.
 pub unsafe fn proc_pagetable(p: *mut Proc) -> PageTable<UVAddr> {
     // An empty page table.
     let mut pagetable = PageTable::<UVAddr>::zero();

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -304,7 +304,7 @@ pub struct ProcData {
     /// Size of process memory (bytes).
     pub sz: usize,
 
-    /// Page table.
+    /// User Page table.
     pub pagetable: PageTable<UVAddr>,
 
     /// Data page for trampoline.S.
@@ -833,6 +833,8 @@ impl ProcessSystem {
     pub unsafe fn dump(&self) {
         println!();
         for p in &self.process_pool {
+            // For null character recognization.
+            // str::from_utf8 cannot recognize interior null characters.
             let mut name = [0; MAXPROCNAME];
             let mut count = 0;
             while p.name[count] != 0 && count < MAXPROCNAME {

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -207,7 +207,7 @@ pub unsafe fn devintr() -> i32 {
         let irq: usize = plic_claim();
 
         if irq == UART0_IRQ {
-            kernel().console.get_mut_unchecked().uartintr();
+            kernel().console.uartintr();
         } else if irq == VIRTIO0_IRQ {
             kernel().disk.lock().virtio_intr();
         } else if irq != 0 {

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -207,7 +207,7 @@ pub unsafe fn devintr() -> i32 {
         let irq: usize = plic_claim();
 
         if irq == UART0_IRQ {
-            kernel().console.uartintr();
+            kernel().console.uart.intr();
         } else if irq == VIRTIO0_IRQ {
             kernel().disk.lock().virtio_intr();
         } else if irq != 0 {

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -99,6 +99,7 @@ pub struct Uart {
     pub tx_lock: Sleepablelock<UartTX>,
 }
 
+/// An interface for interacting with UART registers(UartCtrlRegs). Read and write bytes from UART registers.
 impl Uart {
     pub const fn new() -> Self {
         Self {
@@ -137,10 +138,10 @@ impl Uart {
         IER.write(UartRegBits::IERTxEnable.bits() | UartRegBits::IERRxEnable.bits());
     }
 
-    /// add a character to the output buffer and tell the
+    /// Add a character to the output buffer and tell the
     /// UART to start sending if it isn't already.
-    /// blocks if the output buffer is full.
-    /// because it may block, it can't be called
+    /// Blocks if the output buffer is full.
+    /// Because it may block, it can't be called
     /// from interrupts; it's only suitable for use
     /// by write().
     pub fn putc(&self, c: i32) {

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -230,9 +230,7 @@ impl Uart {
             if c == -1 {
                 break;
             }
-            unsafe {
-                consoleintr(c);
-            }
+            consoleintr(c);
         }
 
         // send buffered characters.

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -1,7 +1,7 @@
 //! low-level driver routines for 16550a UART.
 use crate::memlayout::UART0;
 use crate::{
-    console::terminalintr,
+    console::consoleintr,
     sleepablelock::{Sleepablelock, SleepablelockGuard},
     spinlock::{pop_off, push_off},
 };
@@ -231,7 +231,7 @@ impl Uart {
                 break;
             }
             unsafe {
-                terminalintr(c);
+                consoleintr(c);
             }
         }
 

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -99,7 +99,8 @@ pub struct Uart {
     pub tx_lock: Sleepablelock<UartTX>,
 }
 
-/// An interface for interacting with UART registers(UartCtrlRegs). Read and write bytes from UART registers.
+/// An interface for interacting with UART registers(UartCtrlRegs).
+/// Read and write bytes from UART registers.
 impl Uart {
     pub const fn new() -> Self {
         Self {

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -1,7 +1,7 @@
 //! low-level driver routines for 16550a UART.
 use crate::memlayout::UART0;
 use crate::{
-    console::consoleintr,
+    console::terminalintr,
     sleepablelock::{Sleepablelock, SleepablelockGuard},
     spinlock::{pop_off, push_off},
 };
@@ -164,7 +164,7 @@ impl Uart {
     /// use interrupts, for use by kernel printf() and
     /// to echo characters. it spins waiting for the uart's
     /// output register to be empty.
-    pub fn putc_sync(c: i32) {
+    pub fn putc_sync(&self, c: i32) {
         unsafe {
             push_off();
         }
@@ -231,7 +231,7 @@ impl Uart {
                 break;
             }
             unsafe {
-                consoleintr(c);
+                terminalintr(c);
             }
         }
 

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -113,7 +113,7 @@ impl Uart {
         }
     }
 
-    pub fn init() {
+    pub fn init(&self) {
         // Disable interrupts.
         IER.write(0x00);
 


### PR DESCRIPTION
구현 상 아직 논의가 필요한 부분이 있지만, 리뷰 부탁드립니다.
#276 의 논의가 너무 길어지고 #281 이후 resolve 하기 힘든 conflict가 많이 생겨서 새롭게 PR을 작성했습니다.

1. `Processsystem::dump` 출력 시 null character recognizing 문제 해결.
  - while loop을 이용한 해결방법이 현재 발견한 최선입니다.
  - magic number 16을 `MAXPROCNAME`으로 정의했습니다.


2. 지난 주 팀 미팅에서 논의한대로 `Console / Printer / Uart`의 Ownership을 정돈했습니다.
  - 다음과 같이 `struct Console`을 변경했습니다.
```
struct Console {
    terminal: Sleepablelock<Terminal>,
    printer: Spinlock<Printer>,
    uart: Uart,
}
```
  - 기존의 `struct Console`를 `struct Terminal`이라는 임시 이름으로 변경했습니다.
  - 역할이 다르기 때문에 `struct Printer`와 `struct Terminal(구 Console)`을 분리해야합니다.
    - `Terminal`은 user program의 input output logging, `Printer`는 `println!` 매크로를 위해 존재합니다.
    - xv6에서 `pr.lock`과 `cons.lock`은 항상 따로 잡힙니다.
  - `Uart`가 하나만 존재하게 하는 ownership 정리가 필요합니다.