### PR TITLE
Inode::read requires neither mutation nor buf alloc.

### DIFF
--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -109,7 +109,7 @@ impl File {
             FileType::Pipe { pipe } => pipe.read(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
                 let tx = kernel().fs().begin_transaction();
-                let mut ip = ip.deref().lock(&tx);
+                let ip = ip.deref().lock(&tx);
                 let curr_off = *off.get();
                 let ret = ip.read(addr, curr_off, n as u32);
                 if let Ok(v) = ret {


### PR DESCRIPTION
#280 은 버그가 아님을 보이고, bmap 의 행동을 좀 더 명확하게 바꾼 PR입니다.

 - `Inode::read` 는 offset 과 amount 를 항상 파일 크기 이내가 되도록 사전 체크를 합니다.
 - 한편 `Inode` 의 API 는 파일 크기를 변경해야 하는 경우 항상 그 크기를 커버하는 버퍼를 할당하도록 되어 있습니다.
 - 따라서 `Inode::read` 가 부르는 `bmap` 은 그 내부에서 `balloc` 을 절대 부르지 않습니다.
 - 이를 코드를 보고 명확히 알 수 있도록 기존의 `bmap` 은 `bmap_or_alloc` 으로 이름을 바꾸고, `balloc` 을 호출하지 않는 `bmap` 을 따로 만들었습니다.
 - `Inode::read` 는 이제 `bmap` 을 호출하고, 그 경우에도 usertest 를 통과합니다.

Closes #280

