### PR TITLE
Update README-rv6.md : specify qemu version and erase cargo-xbuild

### DIFF
--- a/README-rv6.md
+++ b/README-rv6.md
@@ -4,13 +4,10 @@
 
   ```
   # Ubuntu 20.04
-  sudo apt install gcc-riscv64-linux-gnu qemu-system-misc gdb-multiarch
+  # The latest qemu-system-misc(1:4.2-3ubuntu6.9) can't boot rv6, so please use older version (1:4.2-3ubuntu6)
+  sudo apt install gcc-riscv64-linux-gnu qemu-system-misc=1:4.2-3ubuntu6 gdb-multiarch
 
   rustup component add rust-src
-  
-  # Older nightly needs cargo-xbuild version 0.5.35.
-  cargo install cargo-xbuild --version 0.5.35
-  [https://github.com/kaist-cp/rv6/issues/162]
   ```
 
 - Compile rv6.


### PR DESCRIPTION
- Specify qemu version 
  - 2020/11/26 기준 우분투 20.04에서 qemu-system-misc 1:4.2-3ubuntu6 보다 더 최신 버전인 6.9, 6.6에서는 부팅이 여전히 되지 않습니다. 계속 6을 사용해야 할 것 같습니다.
  - #160 에서 해결했지만, 문서에 적혀있지 않아 추가했습니다.
- Erase cargo-xbuild
  - https://github.com/kaist-cp/rv6/commit/de88805673d2886ca81b39602870df7ad83ea205 이후로 cargo xbuild는 사용되지 않아 지웠습니다.