### PR TITLE
[Closes #261] Merge mit pdos [8]

### DIFF
--- a/.gdbinit.tmpl-riscv
+++ b/.gdbinit.tmpl-riscv
@@ -3,3 +3,4 @@ set architecture riscv:rv64
 target remote 127.0.0.1:1234
 symbol-file kernel/kernel
 set disassemble-next-line auto
+set riscv use-compressed-breakpoints yes

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -211,6 +211,8 @@ pub unsafe fn consoleinit(devsw: &mut [Devsw; NDEV]) {
 
 /// User write()s to the console go here.
 unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
+    // TODO(@coolofficials) Remove below comment.
+    // consolewrite() does not need console.lock() -- can lead to sleep() with lock held.
     kernel().console.get_mut_unchecked().write(src, n)
 }
 

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -211,8 +211,7 @@ pub unsafe fn consoleinit(devsw: &mut [Devsw; NDEV]) {
 
 /// User write()s to the console go here.
 unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
-    let mut console = kernel().console.lock();
-    console.write(src, n)
+    kernel().console.get_mut_unchecked().write(src, n)
 }
 
 /// User read()s from the console go here.

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -164,6 +164,7 @@ impl File {
                             v
                         })?;
                     if r != bytes_to_write as usize {
+                        // error from InodeGuard::write
                         break;
                     }
                     bytes_written += r;

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 
 /// The kernel.
+// TODO(rv6): remove pub from `pub static mut KERNEL`.
 pub static mut KERNEL: Kernel = Kernel::zero();
 
 /// After intialized, the kernel is safe to immutably access.

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// The kernel.
-static mut KERNEL: Kernel = Kernel::zero();
+pub static mut KERNEL: Kernel = Kernel::zero();
 
 /// After intialized, the kernel is safe to immutably access.
 #[inline]
@@ -245,7 +245,7 @@ pub unsafe fn kernel_main() -> ! {
         kernel().page_table.kvminithart();
 
         // Process system.
-        procinit(&mut KERNEL.procs, &mut KERNEL.page_table);
+        procinit(&mut KERNEL.procs);
 
         // Trap vectors.
         trapinit();

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -73,7 +73,7 @@ pub struct Kernel {
 
     pub ftable: Spinlock<ArrayArena<File, NFILE>>,
 
-    pub icache: Spinlock<ArrayArena<Inode, NINODE>>,
+    pub itable: Spinlock<ArrayArena<Inode, NINODE>>,
 
     pub file_system: Once<FileSystem>,
 }
@@ -88,7 +88,7 @@ const fn ftable_entry(_: usize) -> ArrayEntry<File> {
     ArrayEntry::new(File::zero())
 }
 
-const fn icache_entry(_: usize) -> ArrayEntry<Inode> {
+const fn itable_entry(_: usize) -> ArrayEntry<Inode> {
     ArrayEntry::new(Inode::zero())
 }
 
@@ -118,9 +118,9 @@ impl Kernel {
                 "FTABLE",
                 ArrayArena::new(array_const_fn_init![ftable_entry; 100]),
             ),
-            icache: Spinlock::new(
-                "ICACHE",
-                ArrayArena::new(array_const_fn_init![icache_entry; 50]),
+            itable: Spinlock::new(
+                "ITABLE",
+                ArrayArena::new(array_const_fn_init![itable_entry; 50]),
             ),
             file_system: Once::new(),
         }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -161,13 +161,13 @@ impl PipeInner {
     unsafe fn try_write(&mut self, addr: UVAddr, n: usize) -> Result<usize, PipeError> {
         let mut ch = [0 as u8];
         let proc = myproc();
+        if !self.readopen || (*proc).killed() {
+            return Err(PipeError::InvalidStatus);
+        }
         let data = &mut *(*proc).data.get();
         for i in 0..n {
             if self.nwrite == self.nread.wrapping_add(PIPESIZE as u32) {
                 //DOC: pipewrite-full
-                if !self.readopen || (*proc).killed() {
-                    return Err(PipeError::InvalidStatus);
-                }
                 return Ok(i);
             }
             if data.pagetable.copyin(&mut ch, addr + i).is_err() {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -737,6 +737,8 @@ impl ProcessSystem {
                                 )
                                 .is_err()
                         {
+                            drop(np);
+                            self.proc_tree_lock.release();
                             return -1;
                         }
                         freeproc(np);

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -60,14 +60,12 @@ consolewrite(int user_src, uint64 src, int n)
 {
   int i;
 
-  acquire(&cons.lock);
   for(i = 0; i < n; i++){
     char c;
     if(either_copyin(&c, user_src, src+i, 1) == -1)
       break;
     uartputc(c);
   }
-  release(&cons.lock);
 
   return i;
 }

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -86,6 +86,7 @@ int             cpuid(void);
 void            exit(int);
 int             fork(void);
 int             growproc(int);
+void            proc_mapstacks(pagetable_t);
 pagetable_t     proc_pagetable(struct proc *);
 void            proc_freepagetable(pagetable_t, uint64);
 int             kill(int);
@@ -156,7 +157,7 @@ int             uartgetc(void);
 // vm.c
 void            kvminit(void);
 void            kvminithart(void);
-void            kvmmap(uint64, uint64, uint64, int);
+void            kvmmap(pagetable_t, uint64, uint64, uint64, int);
 int             mappages(pagetable_t, uint64, uint64, uint64, int);
 pagetable_t     uvmcreate(void);
 void            uvminit(pagetable_t, uchar *, uint);

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -166,10 +166,10 @@ filewrite(struct file *f, uint64 addr, int n)
       iunlock(f->ip);
       end_op();
 
-      if(r < 0)
+      if(r != n1){
+        // error from writei
         break;
-      if(r != n1)
-        panic("short filewrite");
+      }
       i += r;
     }
     ret = (i == n ? n : -1);

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -480,6 +480,9 @@ readi(struct inode *ip, int user_dst, uint64 dst, uint off, uint n)
 // Caller must hold ip->lock.
 // If user_src==1, then src is a user virtual address;
 // otherwise, src is a kernel address.
+// Returns the number of bytes successfully written.
+// If the return value is less than the requested n,
+// there was an error of some kind.
 int
 writei(struct inode *ip, int user_src, uint64 src, uint off, uint n)
 {
@@ -496,23 +499,21 @@ writei(struct inode *ip, int user_src, uint64 src, uint off, uint n)
     m = min(n - tot, BSIZE - off%BSIZE);
     if(either_copyin(bp->data + (off % BSIZE), user_src, src, m) == -1) {
       brelse(bp);
-      n = -1;
       break;
     }
     log_write(bp);
     brelse(bp);
   }
 
-  if(n > 0){
-    if(off > ip->size)
-      ip->size = off;
-    // write the i-node back to disk even if the size didn't change
-    // because the loop above might have called bmap() and added a new
-    // block to ip->addrs[].
-    iupdate(ip);
-  }
+  if(off > ip->size)
+    ip->size = off;
 
-  return n;
+  // write the i-node back to disk even if the size didn't change
+  // because the loop above might have called bmap() and added a new
+  // block to ip->addrs[].
+  iupdate(ip);
+
+  return tot;
 }
 
 // Directories

--- a/kernel/log.c
+++ b/kernel/log.c
@@ -216,12 +216,12 @@ log_write(struct buf *b)
 {
   int i;
 
+  acquire(&log.lock);
   if (log.lh.n >= LOGSIZE || log.lh.n >= log.size - 1)
     panic("too big a transaction");
   if (log.outstanding < 1)
     panic("log_write outside of trans");
 
-  acquire(&log.lock);
   for (i = 0; i < log.lh.n; i++) {
     if (log.lh.block[i] == b->blockno)   // log absorbtion
       break;

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -76,26 +76,29 @@ pipeclose(struct pipe *pi, int writable)
 int
 pipewrite(struct pipe *pi, uint64 addr, int n)
 {
-  int i;
-  char ch;
+  int i = 0;
   struct proc *pr = myproc();
 
   acquire(&pi->lock);
-  for(i = 0; i < n; i++){
-    while(pi->nwrite == pi->nread + PIPESIZE){  //DOC: pipewrite-full
-      if(pi->readopen == 0 || pr->killed){
-        release(&pi->lock);
-        return -1;
-      }
+  while(i < n){
+    if(pi->readopen == 0 || pr->killed){
+      release(&pi->lock);
+      return -1;
+    }
+    if(pi->nwrite == pi->nread + PIPESIZE){ //DOC: pipewrite-full
       wakeup(&pi->nread);
       sleep(&pi->nwrite, &pi->lock);
+    } else {
+      char ch;
+      if(copyin(pr->pagetable, &ch, addr + i, 1) == -1)
+        break;
+      pi->data[pi->nwrite++ % PIPESIZE] = ch;
+      i++;
     }
-    if(copyin(pr->pagetable, &ch, addr + i, 1) == -1)
-      break;
-    pi->data[pi->nwrite++ % PIPESIZE] = ch;
   }
   wakeup(&pi->nread);
   release(&pi->lock);
+
   return i;
 }
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -21,6 +21,23 @@ static void freeproc(struct proc *p);
 
 extern char trampoline[]; // trampoline.S
 
+
+// Allocate a page for each process's kernel stack.
+// Map it high in memory, followed by an invalid
+// guard page.
+void
+proc_mapstacks(pagetable_t kpgtbl) {
+  struct proc *p;
+  
+  for(p = proc; p < &proc[NPROC]; p++) {
+    char *pa = kalloc();
+    if(pa == 0)
+      panic("kalloc");
+    uint64 va = KSTACK((int) (p - proc));
+    kvmmap(kpgtbl, va, (uint64)pa, PGSIZE, PTE_R | PTE_W);
+  }
+}
+
 // initialize the proc table at boot time.
 void
 procinit(void)
@@ -30,18 +47,8 @@ procinit(void)
   initlock(&pid_lock, "nextpid");
   for(p = proc; p < &proc[NPROC]; p++) {
       initlock(&p->lock, "proc");
-
-      // Allocate a page for the process's kernel stack.
-      // Map it high in memory, followed by an invalid
-      // guard page.
-      char *pa = kalloc();
-      if(pa == 0)
-        panic("kalloc");
-      uint64 va = KSTACK((int) (p - proc));
-      kvmmap(va, (uint64)pa, PGSIZE, PTE_R | PTE_W);
-      p->kstack = va;
+      p->kstack = KSTACK((int) (p - proc));
   }
-  kvminithart();
 }
 
 // Must be called with interrupts disabled,

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -16,11 +16,14 @@ int nextpid = 1;
 struct spinlock pid_lock;
 
 extern void forkret(void);
-static void wakeup1(struct proc *chan);
 static void freeproc(struct proc *p);
 
 extern char trampoline[]; // trampoline.S
 
+// protects parent/child relationships.
+// must be held when using p->parent.
+// must be acquired before any p->lock.
+struct spinlock proc_tree_lock;
 
 // Allocate a page for each process's kernel stack.
 // Map it high in memory, followed by an invalid
@@ -45,6 +48,7 @@ procinit(void)
   struct proc *p;
   
   initlock(&pid_lock, "nextpid");
+  initlock(&proc_tree_lock, "proc_tree");
   for(p = proc; p < &proc[NPROC]; p++) {
       initlock(&p->lock, "proc");
       p->kstack = KSTACK((int) (p - proc));
@@ -113,6 +117,7 @@ allocproc(void)
 
 found:
   p->pid = allocpid();
+  p->state = USED;
 
   // Allocate a trapframe page.
   if((p->trapframe = (struct trapframe *)kalloc()) == 0){
@@ -283,8 +288,6 @@ fork(void)
   }
   np->sz = p->sz;
 
-  np->parent = p;
-
   // copy saved user registers.
   *(np->trapframe) = *(p->trapframe);
 
@@ -301,35 +304,30 @@ fork(void)
 
   pid = np->pid;
 
-  np->state = RUNNABLE;
+  release(&np->lock);
 
+  acquire(&proc_tree_lock);
+  np->parent = p;
+  release(&proc_tree_lock);
+
+  acquire(&np->lock);
+  np->state = RUNNABLE;
   release(&np->lock);
 
   return pid;
 }
 
 // Pass p's abandoned children to init.
-// Caller must hold p->lock.
+// Caller must hold proc_tree_lock.
 void
 reparent(struct proc *p)
 {
   struct proc *pp;
 
   for(pp = proc; pp < &proc[NPROC]; pp++){
-    // this code uses pp->parent without holding pp->lock.
-    // acquiring the lock first could cause a deadlock
-    // if pp or a child of pp were also in exit()
-    // and about to try to lock p.
     if(pp->parent == p){
-      // pp->parent can't change between the check and the acquire()
-      // because only the parent changes it, and we're the parent.
-      acquire(&pp->lock);
       pp->parent = initproc;
-      // we should wake up init here, but that would require
-      // initproc->lock, which would be a deadlock, since we hold
-      // the lock on one of init's children (pp). this is why
-      // exit() always wakes init (before acquiring any locks).
-      release(&pp->lock);
+      wakeup(initproc);
     }
   }
 }
@@ -359,41 +357,20 @@ exit(int status)
   end_op();
   p->cwd = 0;
 
-  // we might re-parent a child to init. we can't be precise about
-  // waking up init, since we can't acquire its lock once we've
-  // acquired any other proc lock. so wake up init whether that's
-  // necessary or not. init may miss this wakeup, but that seems
-  // harmless.
-  acquire(&initproc->lock);
-  wakeup1(initproc);
-  release(&initproc->lock);
-
-  // grab a copy of p->parent, to ensure that we unlock the same
-  // parent we locked. in case our parent gives us away to init while
-  // we're waiting for the parent lock. we may then race with an
-  // exiting parent, but the result will be a harmless spurious wakeup
-  // to a dead or wrong process; proc structs are never re-allocated
-  // as anything else.
-  acquire(&p->lock);
-  struct proc *original_parent = p->parent;
-  release(&p->lock);
+  acquire(&proc_tree_lock);
   
-  // we need the parent's lock in order to wake it up from wait().
-  // the parent-then-child rule says we have to lock it first.
-  acquire(&original_parent->lock);
-
   acquire(&p->lock);
 
   // Give any children to init.
   reparent(p);
 
   // Parent might be sleeping in wait().
-  wakeup1(original_parent);
+  wakeup(p->parent);
 
   p->xstate = status;
   p->state = ZOMBIE;
 
-  release(&original_parent->lock);
+  release(&proc_tree_lock);
 
   // Jump into the scheduler, never to return.
   sched();
@@ -409,20 +386,13 @@ wait(uint64 addr)
   int havekids, pid;
   struct proc *p = myproc();
 
-  // hold p->lock for the whole time to avoid lost
-  // wakeups from a child's exit().
-  acquire(&p->lock);
+  acquire(&proc_tree_lock);
 
   for(;;){
     // Scan through table looking for exited children.
     havekids = 0;
     for(np = proc; np < &proc[NPROC]; np++){
-      // this code uses np->parent without holding np->lock.
-      // acquiring the lock first would cause a deadlock,
-      // since np might be an ancestor, and we already hold p->lock.
       if(np->parent == p){
-        // np->parent can't change between the check and the acquire()
-        // because only the parent changes it, and we're the parent.
         acquire(&np->lock);
         havekids = 1;
         if(np->state == ZOMBIE){
@@ -436,7 +406,7 @@ wait(uint64 addr)
           }
           freeproc(np);
           release(&np->lock);
-          release(&p->lock);
+          release(&proc_tree_lock);
           return pid;
         }
         release(&np->lock);
@@ -445,12 +415,12 @@ wait(uint64 addr)
 
     // No point waiting if we don't have any children.
     if(!havekids || p->killed){
-      release(&p->lock);
+      release(&proc_tree_lock);
       return -1;
     }
     
     // Wait for a child to exit.
-    sleep(p, &p->lock);  //DOC: wait-sleep
+    sleep(p, &proc_tree_lock);  //DOC: wait-sleep
   }
 }
 
@@ -563,10 +533,9 @@ sleep(void *chan, struct spinlock *lk)
   // guaranteed that we won't miss any wakeup
   // (wakeup locks p->lock),
   // so it's okay to release lk.
-  if(lk != &p->lock){  //DOC: sleeplock0
-    acquire(&p->lock);  //DOC: sleeplock1
-    release(lk);
-  }
+
+  acquire(&p->lock);  //DOC: sleeplock1
+  release(lk);
 
   // Go to sleep.
   p->chan = chan;
@@ -578,10 +547,8 @@ sleep(void *chan, struct spinlock *lk)
   p->chan = 0;
 
   // Reacquire original lock.
-  if(lk != &p->lock){
-    release(&p->lock);
-    acquire(lk);
-  }
+  release(&p->lock);
+  acquire(lk);
 }
 
 // Wake up all processes sleeping on chan.
@@ -592,23 +559,13 @@ wakeup(void *chan)
   struct proc *p;
 
   for(p = proc; p < &proc[NPROC]; p++) {
-    acquire(&p->lock);
-    if(p->state == SLEEPING && p->chan == chan) {
-      p->state = RUNNABLE;
+    if(p != myproc()){
+      acquire(&p->lock);
+      if(p->state == SLEEPING && p->chan == chan) {
+        p->state = RUNNABLE;
+      }
+      release(&p->lock);
     }
-    release(&p->lock);
-  }
-}
-
-// Wake up p if it is sleeping in wait(); used by exit().
-// Caller must hold p->lock.
-static void
-wakeup1(struct proc *p)
-{
-  if(!holding(&p->lock))
-    panic("wakeup1");
-  if(p->chan == p && p->state == SLEEPING) {
-    p->state = RUNNABLE;
   }
 }
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -116,6 +116,7 @@ found:
 
   // Allocate a trapframe page.
   if((p->trapframe = (struct trapframe *)kalloc()) == 0){
+    freeproc(p);
     release(&p->lock);
     return 0;
   }

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -401,7 +401,7 @@ wait(uint64 addr)
           if(addr != 0 && copyout(p->pagetable, addr, (char *)&np->xstate,
                                   sizeof(np->xstate)) < 0) {
             release(&np->lock);
-            release(&p->lock);
+            release(&proc_tree_lock);
             return -1;
           }
           freeproc(np);

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -80,7 +80,7 @@ struct trapframe {
   /* 280 */ uint64 t6;
 };
 
-enum procstate { UNUSED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
+enum procstate { UNUSED, USED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
 
 // Per-process state
 struct proc {

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -88,11 +88,13 @@ struct proc {
 
   // p->lock must be held when using these:
   enum procstate state;        // Process state
-  struct proc *parent;         // Parent process
   void *chan;                  // If non-zero, sleeping on chan
   int killed;                  // If non-zero, have been killed
   int xstate;                  // Exit status to be returned to parent's wait
   int pid;                     // Process ID
+
+  // proc_tree_lock must be held when using this:
+  struct proc *parent;         // Parent process
 
   // these are private to the process, so p->lock need not be held.
   uint64 kstack;               // Virtual address of kernel stack

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -15,33 +15,45 @@ extern char etext[];  // kernel.ld sets this to end of kernel code.
 
 extern char trampoline[]; // trampoline.S
 
-/*
- * create a direct-map page table for the kernel.
- */
-void
-kvminit()
+// Make a direct-map page table for the kernel.
+pagetable_t
+kvmmake(void)
 {
-  kernel_pagetable = (pagetable_t) kalloc();
-  memset(kernel_pagetable, 0, PGSIZE);
+  pagetable_t kpgtbl;
+
+  kpgtbl = (pagetable_t) kalloc();
+  memset(kpgtbl, 0, PGSIZE);
 
   // uart registers
-  kvmmap(UART0, UART0, PGSIZE, PTE_R | PTE_W);
+  kvmmap(kpgtbl, UART0, UART0, PGSIZE, PTE_R | PTE_W);
 
   // virtio mmio disk interface
-  kvmmap(VIRTIO0, VIRTIO0, PGSIZE, PTE_R | PTE_W);
+  kvmmap(kpgtbl, VIRTIO0, VIRTIO0, PGSIZE, PTE_R | PTE_W);
 
   // PLIC
-  kvmmap(PLIC, PLIC, 0x400000, PTE_R | PTE_W);
+  kvmmap(kpgtbl, PLIC, PLIC, 0x400000, PTE_R | PTE_W);
 
   // map kernel text executable and read-only.
-  kvmmap(KERNBASE, KERNBASE, (uint64)etext-KERNBASE, PTE_R | PTE_X);
+  kvmmap(kpgtbl, KERNBASE, KERNBASE, (uint64)etext-KERNBASE, PTE_R | PTE_X);
 
   // map kernel data and the physical RAM we'll make use of.
-  kvmmap((uint64)etext, (uint64)etext, PHYSTOP-(uint64)etext, PTE_R | PTE_W);
+  kvmmap(kpgtbl, (uint64)etext, (uint64)etext, PHYSTOP-(uint64)etext, PTE_R | PTE_W);
 
   // map the trampoline for trap entry/exit to
   // the highest virtual address in the kernel.
-  kvmmap(TRAMPOLINE, (uint64)trampoline, PGSIZE, PTE_R | PTE_X);
+  kvmmap(kpgtbl, TRAMPOLINE, (uint64)trampoline, PGSIZE, PTE_R | PTE_X);
+
+  // map kernel stacks
+  proc_mapstacks(kpgtbl);
+  
+  return kpgtbl;
+}
+
+// Initialize the one kernel_pagetable
+void
+kvminit(void)
+{
+  kernel_pagetable = kvmmake();
 }
 
 // Switch h/w page table register to the kernel's page table,
@@ -112,9 +124,9 @@ walkaddr(pagetable_t pagetable, uint64 va)
 // only used when booting.
 // does not flush TLB or enable paging.
 void
-kvmmap(uint64 va, uint64 pa, uint64 sz, int perm)
+kvmmap(pagetable_t kpgtbl, uint64 va, uint64 pa, uint64 sz, int perm)
 {
-  if(mappages(kernel_pagetable, va, sz, pa, perm) != 0)
+  if(mappages(kpgtbl, va, sz, pa, perm) != 0)
     panic("kvmmap");
 }
 

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -77,7 +77,7 @@ kvminithart()
 //   21..29 -- 9 bits of level-1 index.
 //   12..20 -- 9 bits of level-0 index.
 //    0..11 -- 12 bits of byte offset within the page.
-static pte_t *
+pte_t *
 walk(pagetable_t pagetable, uint64 va, int alloc)
 {
   if(va >= MAXVA)

--- a/user/grind.c
+++ b/user/grind.c
@@ -277,14 +277,15 @@ go(int which_child)
       close(aa[0]);
       close(aa[1]);
       close(bb[1]);
-      char buf[3] = { 0, 0, 0 };
+      char buf[4] = { 0, 0, 0, 0 };
       read(bb[0], buf+0, 1);
       read(bb[0], buf+1, 1);
+      read(bb[0], buf+2, 1);
       close(bb[0]);
       int st1, st2;
       wait(&st1);
       wait(&st2);
-      if(st1 != 0 || st2 != 0 || strcmp(buf, "hi") != 0){
+      if(st1 != 0 || st2 != 0 || strcmp(buf, "hi\n") != 0){
         printf("grind: exec pipeline failed %d %d \"%s\"\n", st1, st2, buf);
         exit(1);
       }

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -779,6 +779,36 @@ pipe1(char *s)
   }
 }
 
+
+// test if child is killed (status = -1)
+void
+killstatus(char *s)
+{
+  int xst;
+  
+  for(int i = 0; i < 100; i++){
+    int pid1 = fork();
+    if(pid1 < 0){
+      printf("%s: fork failed\n", s);
+      exit(1);
+    }
+    if(pid1 == 0){
+      for (int j = 0; j < 1000; j++) {
+        getpid();
+      }
+      exit(0);
+    }
+    sleep(1);
+    kill(pid1);
+    wait(&xst);
+    if(xst != -1) {
+       printf("%s: status should be -1\n", s);
+       exit(1);
+    }
+  }
+  exit(0);
+}
+
 // meant to be run w/ at most two CPUs
 void
 preempt(char *s)
@@ -2786,6 +2816,7 @@ main(int argc, char *argv[])
     {iputtest, "iput"},
     {mem, "mem"},
     {pipe1, "pipe1"},
+    {killstatus, "killstatus"},
     {preempt, "preempt"},
     {exitwait, "exitwait"},
     {rmdot, "rmdot"},

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -793,7 +793,7 @@ killstatus(char *s)
       exit(1);
     }
     if(pid1 == 0){
-      for (int j = 0; j < 1000; j++) {
+      while(1) {
         getpid();
       }
       exit(0);


### PR DESCRIPTION
#### 12/4 기준 가장 최근 커밋까지 반영했습니다. CI 통과 + 내용 정리 + Rust 코드에 반영되었는지 확인 후 리뷰 요청 드리겠습니다.

- closes #261 

**2020/10/8**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/806580d6423274e7b38329362f64a549e04ddbab : set riscv use-compressed-breakpoints yes
  - `.gdbinit.tmpl-riscv` 변경 : Rust는 해당 사항 없음

**2020/10/15**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/c64aa44d7b5167f5b061b1e2fdf94d240a98b2bb : kvmmake() makes a complete kernel page table, matching Figure 3.3
  - `proc.c::procinit()`에서는 각 proc의 `kstack`만 빼고, 이외의 내용을 `proc.c::proc_mapstacks()`에서 담당 -> rv6는 https://github.com/kaist-cp/rv6/commit/fd20c80d7483d4fc1a2c1bd88a7710b29ab82eef 에서 비슷한 역할의 `palloc()`을 만들어 놓았었습니다.
    - 함수명을 바꿨습니다. (`palloc()` -> `proc_mapstacks()`)
    - `impl ProcData` 밖으로 빼내고, 불필요한 인자 `i`를 없앴습니다.
  - `vm.c::kvmmap()`의 첫 인자를 uint64에서 pagetable_t로 변경 -> rv6에서는 이미 `kvmmap()`이 `impl PageTable<KVAddr>` 안에 있어서, 적용할 내용이 없습니다.
  - void를 리턴하는 `vm.c::kvminit()`을 pagetable_t를 리턴하는 `vm.c::kvmmake()`로 바꾸고 + 새로 만든 `vm.c::kvminit()`에서는 `kernel_pagetable = kvmmake()`를 실행합니다.
    - **rv6에서는 `kvmmake()`가 `PageTable<KVAddr>`이 아닌 void를 리턴하는 것이 좋다고 판단했습니다.** 
      - `Kernel::zero()`에서 `page_table: PageTable::zero()`를 이미 실행하기 때문에, `kvmmake()`가 `PageTable<KVAddr>`을 리턴하려면 `PageTable::zero() `를 또 실행해야 할 것 같습니다. 이것이 비효율적이라고 판단했습니다.
      - `kvmmake`가 void를 리턴하면서, `kvminit()`은 (무의미하게?) `self.kvmmake()`만을 실행하게 되었습니다. 우선 xv6의 의도를 어느 정도 지키고자 `kvminit(), kvmmake()` 모두 만들었습니다.
- [X] https://github.com/mit-pdos/xv6-riscv/commit/93378618df7f71464f72284ccc699948c699d683 : Fix minor typos
  - `vm.c::walk()`가 static이 아니도록 변경 : Rust는 해당 사항 없음
- [X] https://github.com/mit-pdos/xv6-riscv/commit/21cfc978096c3ffa2fdd3bde4e698482a5dff6c3 : set riscv use-compressed-breakpoints yes
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/d4cecb269f2acc61cc1adc11fec2aa690b9c553b : kvmmake() makes a complete kernel page table, matching Figure 3.3
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/05a7db1a0a20187760d8a78ff7badfa4cc7e3314 : Fix minor typos
  - merge commit : 이전 커밋 반영시 이미 반영 완료

**2020/10/20**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/286b2f3c3306a621c415e8c7ce67bc2a6501998a : consolewrite does not need cons.lock -- can lead to sleep() with lock…
  - `console.c::consolewrite()`에서 `cons.lock`을 잡지 않습니다.
    - 우선은 `console.rs::consolewrite()`에서 `get_mut_unchecked()`를 사용하는 것으로 수정했습니다.
    - `Console::write()`의 내용을 `consolewrite()`로 옮겨오기만 하면 xv6의 이 커밋을 반영한 것이지만, #298 에서 다루면 어떨까요?
    - 시원님의 요청으로 임시 코멘트 작성했습니다. https://github.com/kaist-cp/rv6/pull/301/commits/96a961cec2517e6f12114a8f0452d9f5b45d25f9
- [X] https://github.com/mit-pdos/xv6-riscv/commit/55ad99f7293fc6d639a30d36820a770ee71a6cae : Merge branch 'riscv' of g.csail.mit.edu:xv6-dev into riscv
  - merge commit : 이전 커밋 반영시 이미 반영 완료 (10/15 첫 커밋)
- [X] https://github.com/mit-pdos/xv6-riscv/commit/4df1a265cb994ce9cbf9e7dce88b79b1dd7cc5dd : fix uart.c to work with UART_TX_BUF_SIZE == 1
  - `uart.c`의 `uart_tx_r, uart_tx_w`를 int에서 uint64로 변경 + 기타 연산 자잘한 수정 -> `uart.rs`에 반영 완료

**2020/10/22**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/147855e5219e91886e71e796fd51fbc6b1a056d2 : test for closed pipe or killed on every char, not just if pipe full
  - `pipe.c::pipewrite()` 리팩토링 -> #206 에서 했던 내용과 비슷한 방향이어서 큰 수정이 필요 없었습니다.

**2020/10/23**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/d7c0a1b7a703f7366942092f9cf421b6cd111a36 : hopefully make writei more correct
  - `file.c::filewrite()` : panic 없애고 주석 변경 -> `file.rs::write()`에 panic은 이미 없었고, 주석만 변경했습니다.
  - `fs.c::writei()` : `either_copyin()`이 -1을 리턴해도 `writei()`가 -1을 리턴하지 않게 바뀌었습니다. -> `inode.rs::write()`에 적용했습니다.

**2020/11/2**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/af570f582cafe3326116f202ab26d81fe95d320a : free proc if kalloc fails
  - `proc.c::allocproc()` 내에서 `kalloc()`이 실패한 경우에도 `freeproc()` 실행 -> `proc.rs::alloc()`에 적용했습니다.

**2020/11/4**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/8d4fbc6e2a4c8373453f2e1380bb8c6ca8d334c0 : Frans' proc_lock.
  - 이 커밋 전에는 proc의 parent를 proc.lock 쥐지 않은 상태에서도 접근가능 했었습니다.
  - 이 커밋에서는 **임의의 proc의 parent/child relationship 변경을 보호하기 위한 global lock `proc_tree_lock`을 만들었습니다.**
    - 이로 인해 임의의 `proc`의 parent 필드 수정 시에는 `proc_tree_lock`을 꼭 획득해야 합니다.
    - parent를 제외한 proc의 필드 수정 시에는 이전처럼 `proc.lock`을 획득해야 합니다.
    - `proc_tree_lock` 및 `reparent` 관련 디테일 : `reparent()`에서 proc의 parent를 initproc으로 바꾼 뒤, `initproc`을 wake up 시켜야 합니다.
    - 이 커밋 반영 이전
      - `reparent()` 실행 시 `initproc`의 child 중 하나인 `proc`의 lock을 쥔 상태로 실행됩니다. 이 때 `initproc`을 wake up 시키기 위해서 `initproc`의 lock을 쥐려 하면 deadlock이 발생할 수 있습니다. 따라서 `exit()`에서 항상 `initproc`을 wake up 하는 방식이었습니다.
    - 이 커밋 반영 이후
      - `reparent()`에서 바로 `initproc`을 wake up 시킵니다.  - 위 내용들을 `proc.rs`에 반영했습니다. 이 내용을 더 잘 추상화하는 것은 #300 에서 이어서 논의하기로 해서 `proc_tree_lock`은 `RawSpinlock`으로 만들었습니다.
- [X] https://github.com/mit-pdos/xv6-riscv/commit/7dea4b93c82354d5a24e8882860af5a1d92282e6 : oops
  - `proc.c:wait()`에서 `copyout()`이 실패한 경우 -1을 리턴하기 전 `proc_tree_lock`를 release하기
  - lock release하는 순서를 xv6와 통일하기 위해 `drop(np)`도 추가했습니다.

**2020/11/5**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/13dccb0380d3c694083095040fadd03bfe4f598c : consolewrite does not need cons.lock -- can lead to sleep() with lock…
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/329935eca8484d7f1d34c1d43b16c495d861ad75 : fix uart.c to work with UART_TX_BUF_SIZE == 1
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/e1bb4c74346bc439e8c0cd93750f90bb82c537c8 : test for closed pipe or killed on every char, not just if pipe full
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/5e392531c07966fd8a6bee50e3e357c553fb2a2f : hopefully make writei more correct
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/b48ea5d2209bb9addf43687739245734038b991e : free proc if kalloc fails
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/2875069973d3e0ca4a70f6e7648a92b14cf08ab6 : Frans' proc_lock.
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/47323c97cf6bcf5e238c518762ba048e8795f57d : oops
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/bc943c230960c414fd43b93317c3825f1a99c611 : don't over-lock in exit()
  - `proc.c:exit()` 내 `p.lock.acquire()` 위치 변경 -> `proc.rs:exit_current()`에 적용 완료
    - `proc.c:reparent()` 실행 시 `proc.lock`을 쥐지 않아도 되기 때문에, `ProcessSystem::reparent()`의 인자 `p`를 `&mut ProcGuard`에서 `*mut Proc`으로 변경하였습니다.
  - `proc.c, proc.h` 주석 + new line 추가  -> `proc.rs`에 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/774288e05a5891a4de0a165e2a65665714f6ca34 : proc_tree_lock -> wait_lock
  - `proc.c` 변수명 변경 ( `proc_tree_lock` -> `wait_lock` ) 및 주석 변경 -> `proc.rs`에 적용 완료

**2020/11/6**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/b63d3506e9fbe7db1cd117db746fb58b7712ab4f : Be principled: acquire lock first
  - `log.c:log_write()` 시작하자마자 `log.lock`을 쥐도록 변경 : rv6의 `FsTransaction::write()`에 이미 그렇게 구현되어 있어서 해당 사항 없음
- [X] https://github.com/mit-pdos/xv6-riscv/commit/d7b308fe81b9fdee1f6060f847b37a252214266a : kill/status test
  - `usertests.c`에 killstatus test 추가 : Rust는 해당 사항 없음
- [X] https://github.com/mit-pdos/xv6-riscv/commit/9599a8e616dc5a1aa6b0c3b7c0c6ed9ffdf5e67a : x
  - `usertests.c` 수정 : Rust는 해당 사항 없음
- [X] https://github.com/mit-pdos/xv6-riscv/commit/ba8d9f4808bd2c59df42a6615920a22e3735c359 : don't over-lock in exit()
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/38084bcea84e79f5fff9ce8c7f91c077fc1eacd3 : proc_tree_lock -> wait_lock
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/b4c2851bb347d5243a4498fdd9e1f0c9a23e6498 : Be principled: acquire lock first
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/ef97f65025b3704a90fbde79ef3ce3a38bcb6899 : kill/status test
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/60b63b9d077f2c9d722e8572e5e78379cfaef796 : x
  - merge commit : 이전 커밋 반영시 이미 반영 완료
- [X] https://github.com/mit-pdos/xv6-riscv/commit/231c08dc5e5e39a6fafda832e6935beb38ef3887 : Merge remote-tracking branch 'refs/remotes/origin/riscv' into riscv
  - merge commit : 이전 커밋 반영시 이미 반영 완료

**2020/11/20**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/6e3f75c2aa670bc0d47928cd48408b81e5bd758d : suppress an incorrect error message in grind
  - `user/grind.c` 수정 : Rust는 해당 사항 없음

**2020/11/24**
- [X] https://github.com/mit-pdos/xv6-riscv/commit/077323a8f0b3440fcc3d082096a2d83fe5461d70 : Rename icache to itable
  - `icache`를 `itable`로 이름 변경 : 아래 설명 참고
```
The inode cache isn't really a cache. The main purpose of it is toallow for synchronization (locking individual inodes), providing
long-lived references to inodes, and ensuring that there is only inode
in memory.
```