### PR TITLE
Remove dependency to superblock.rs (related to #271)

### DIFF
--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -85,6 +85,9 @@ use super::{FileName, IPB, MAXFILE, NDIRECT, NINDIRECT};
 /// Directory is a file containing a sequence of Dirent structures.
 pub const DIRSIZ: usize = 14;
 
+/// dinode size
+pub const DINODE_SIZE: usize = mem::size_of::<Dinode>();
+
 /// dirent size
 pub const DIRENT_SIZE: usize = mem::size_of::<Dirent>();
 

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -26,7 +26,9 @@ mod log;
 mod path;
 mod superblock;
 
-pub use inode::{Dinode, Dirent, Inode, InodeGuard, InodeInner, RcInode, DIRENT_SIZE, DIRSIZ};
+pub use inode::{
+    Dinode, Dirent, Inode, InodeGuard, InodeInner, RcInode, DINODE_SIZE, DIRENT_SIZE, DIRSIZ,
+};
 pub use log::Log;
 pub use path::{FileName, Path};
 pub use superblock::{Superblock, BPB, IPB};
@@ -53,7 +55,7 @@ pub struct FsTransaction<'s> {
 
 impl FileSystem {
     pub fn new(dev: u32) -> Self {
-        let superblock = unsafe { Superblock::new(&kernel().disk.read(dev, 1)) };
+        let superblock = unsafe { Superblock::new(dev) };
         let log = Sleepablelock::new(
             "LOG",
             Log::new(dev, superblock.logstart as i32, superblock.nlog as i32),

--- a/kernel-rs/src/fs/superblock.rs
+++ b/kernel-rs/src/fs/superblock.rs
@@ -1,8 +1,8 @@
-use core::{mem, ptr};
+use core::ptr;
 
-use crate::{bio::Buf, param::BSIZE};
+use crate::{kernel::kernel, param::BSIZE};
 
-use super::Dinode;
+use super::DINODE_SIZE;
 
 const FSMAGIC: u32 = 0x10203040;
 
@@ -40,14 +40,15 @@ pub struct Superblock {
 }
 
 /// Inodes per block.
-pub const IPB: usize = BSIZE.wrapping_div(mem::size_of::<Dinode>());
+pub const IPB: usize = BSIZE.wrapping_div(DINODE_SIZE);
 
 /// Bitmap bits per block
 pub const BPB: u32 = BSIZE.wrapping_mul(8) as u32;
 
 impl Superblock {
     /// Read the super block.
-    pub unsafe fn new(buf: &Buf) -> Self {
+    pub unsafe fn new(dev: u32) -> Self {
+        let buf = &kernel().disk.read(dev, 1);
         let result = ptr::read(buf.deref_inner().data.as_ptr() as *const Superblock);
         assert_eq!(result.magic, FSMAGIC, "invalid file system");
         result


### PR DESCRIPTION
#### dependency 제거를 위한 PR입니다. 

- related to #271
- `inode.rs`의 `Dinode`를 `superblock.rs`에서 사용
  - `pub const DINODE_SIZE: usize = mem::size_of::<Dinode>();`를 이용해 제거
- `bio.rs`의 `Buf`를 `superblock.rs`에서 사용
  - `Superblock::new(&Buf)`를 `Superblock::new(u32)`로 변경
  - xv6의 `readsb()`가 Buf가 아닌 dev number를 받는 점을 고려했습니다.
https://github.com/kaist-cp/rv6/blob/d28972066b059796b1ebb80afccd3407cdcb4c01/kernel/fs.c#L29-L38
- 이 PR이 머지될 경우의 dependency입니다.
![Imgur](https://imgur.com/z34HL98.png)