### PR TITLE
Remove tag (#306 이어서)

### DIFF
--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -13,7 +13,6 @@
 
 use crate::{
     arena::{Arena, ArenaObject, MruArena, MruEntry, Rc},
-    kernel::kernel,
     param::{BSIZE, NBUF},
     proc::WaitChannel,
     sleeplock::Sleeplock,
@@ -129,7 +128,7 @@ impl Bcache {
     }
 
     /// Return a unlocked buf with the contents of the indicated block.
-    pub fn buf(&self, dev: u32, blockno: u32) -> BufUnlocked<'_> {
+    pub fn get_buf(&self, dev: u32, blockno: u32) -> BufUnlocked<'_> {
         let inner = self
             .find_or_alloc(
                 |buf| buf.dev == dev && buf.blockno == blockno,
@@ -141,14 +140,14 @@ impl Bcache {
             )
             .expect("[BufGuard::new] no buffers");
 
-        unsafe { Rc::from_unchecked(&kernel().bcache, inner) }
+        unsafe { Rc::from_unchecked(self, inner) }
     }
 
     /// Retrieves BufUnlocked without increasing reference count.
     pub fn buf_unforget(&self, dev: u32, blockno: u32) -> Option<BufUnlocked<'_>> {
         let inner = self.unforget(|buf| buf.dev == dev && buf.blockno == blockno)?;
 
-        Some(unsafe { Rc::from_unchecked(&kernel().bcache, inner) })
+        Some(unsafe { Rc::from_unchecked(self, inner) })
     }
 }
 

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -123,6 +123,8 @@ impl Bcache {
 
         Spinlock::new(
             "BCACHE",
+            // TODO : Const variable should be used instead of the magic number.
+            // https://github.com/kaist-cp/rv6/issues/309
             MruArena::new(array_const_fn_init![bcache_entry; 30]),
         )
     }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -15,9 +15,17 @@ use core::{cell::UnsafeCell, cmp, convert::TryFrom, mem, ops::Deref, slice};
 
 pub enum FileType {
     None,
-    Pipe { pipe: AllocatedPipe },
-    Inode { ip: RcInode, off: UnsafeCell<u32> },
-    Device { ip: RcInode, major: u16 },
+    Pipe {
+        pipe: AllocatedPipe,
+    },
+    Inode {
+        ip: RcInode<'static>,
+        off: UnsafeCell<u32>,
+    },
+    Device {
+        ip: RcInode<'static>,
+        major: u16,
+    },
 }
 
 pub struct File {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -208,6 +208,6 @@ impl FileTable {
             *p = File::new(typ, readable, writable);
         })?;
 
-        Some(unsafe { Rc::from_unchecked(&kernel().ftable, inner) })
+        Some(unsafe { Rc::from_unchecked(self, inner) })
     }
 }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -197,6 +197,8 @@ impl FileTable {
 
         Spinlock::new(
             "FTABLE",
+            // TODO : Const variable should be used instead of the magic number.
+            // https://github.com/kaist-cp/rv6/issues/309
             ArrayArena::new(array_const_fn_init![ftable_entry; 100]),
         )
     }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -586,6 +586,8 @@ impl Itable {
 
         Spinlock::new(
             "ITABLE",
+            // TODO : Const variable should be used instead of the magic number.
+            // https://github.com/kaist-cp/rv6/issues/309
             ArrayArena::new(array_const_fn_init![itable_entry; 50]),
         )
     }

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -20,7 +20,9 @@ mod log;
 mod path;
 mod superblock;
 
-pub use inode::{Dinode, Dirent, Inode, InodeGuard, InodeInner, RcInode, DIRENT_SIZE, DIRSIZ};
+pub use inode::{
+    Dinode, Dirent, Inode, InodeGuard, InodeInner, Itable, RcInode, DIRENT_SIZE, DIRSIZ,
+};
 pub use log::Log;
 pub use path::{FileName, Path};
 pub use superblock::{Superblock, BPB, IPB};

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -92,7 +92,7 @@ impl FsTransaction<'_> {
 
     /// Zero a block.
     unsafe fn bzero(&self, dev: u32, bno: u32) {
-        let mut buf = kernel().bcache.buf(dev, bno).lock();
+        let mut buf = kernel().bcache.get_buf(dev, bno).lock();
         ptr::write_bytes(buf.deref_mut_inner().data.as_mut_ptr(), 0, BSIZE);
         buf.deref_mut_inner().valid = true;
         self.write(buf);

--- a/kernel-rs/src/fs/superblock.rs
+++ b/kernel-rs/src/fs/superblock.rs
@@ -47,7 +47,7 @@ pub const BPB: u32 = BSIZE.wrapping_mul(8) as u32;
 
 impl Superblock {
     /// Read the super block.
-    pub unsafe fn new(buf: &Buf) -> Self {
+    pub unsafe fn new(buf: &Buf<'static>) -> Self {
         let result = ptr::read(buf.deref_inner().data.as_ptr() as *const Superblock);
         assert_eq!(result.magic, FSMAGIC, "invalid file system");
         result

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -535,6 +535,8 @@ impl ProcessSystem {
     pub const fn zero() -> Self {
         Self {
             nextpid: AtomicI32::new(1),
+            // TODO : Const variable should be used instead of the magic number.
+            // https://github.com/kaist-cp/rv6/issues/309
             process_pool: array_const_fn_init![proc_entry; 64],
             initial_proc: ptr::null_mut(),
             wait_lock: RawSpinlock::new("wait_lock"),

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -313,7 +313,7 @@ pub struct ProcData {
     pub open_files: [Option<RcFile<'static>>; NOFILE],
 
     /// Current directory.
-    pub cwd: Option<RcInode>,
+    pub cwd: Option<RcInode<'static>>,
 }
 
 /// Per-process state.

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -310,7 +310,7 @@ pub struct ProcData {
     context: Context,
 
     /// Open files.
-    pub open_files: [Option<RcFile>; NOFILE],
+    pub open_files: [Option<RcFile<'static>>; NOFILE],
 
     /// Current directory.
     pub cwd: Option<RcInode>,

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -73,7 +73,7 @@ pub unsafe fn argstr(n: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
 }
 
 impl Kernel {
-    pub unsafe fn syscall(&self) {
+    pub unsafe fn syscall(&'static self) {
         let p: *mut Proc = myproc();
         let mut data = &mut *(*p).data.get();
         let num: i32 = (*data.trapframe).a7 as i32;

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -63,7 +63,7 @@ unsafe fn create<F, T>(
     minor: u16,
     tx: &FsTransaction<'_>,
     f: F,
-) -> Result<(RcInode, T), ()>
+) -> Result<(RcInode<'static>, T), ()>
 where
     F: FnOnce(&mut InodeGuard<'_>) -> T,
 {

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -7,8 +7,8 @@
 use crate::{
     fcntl::FcntlFlags,
     file::{FileType, RcFile},
-    fs::{Dirent, FileName, FsTransaction, Inode, InodeGuard, Path, RcInode, DIRENT_SIZE},
-    kernel::Kernel,
+    fs::{Dirent, FileName, FsTransaction, InodeGuard, Path, RcInode, DIRENT_SIZE},
+    kernel::{kernel, Kernel},
     ok_or,
     page::Page,
     param::{MAXARG, MAXPATH, NDEV, NOFILE},
@@ -79,7 +79,7 @@ where
         }
         return Err(());
     }
-    let ptr2 = Inode::alloc(dp.dev, typ, tx);
+    let ptr2 = kernel().itable.alloc_inode(dp.dev, typ, tx);
     let mut ip = ptr2.lock(tx);
     ip.deref_inner_mut().major = major;
     ip.deref_inner_mut().minor = minor;

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -212,7 +212,7 @@ impl Sleepablelock<Disk> {
     /// Return a locked Buf with the `latest` contents of the indicated block.
     /// If buf.valid is true, we don't need to access Disk.
     pub fn read(&self, dev: u32, blockno: u32) -> Buf<'static> {
-        let mut buf = kernel().bcache.buf(dev, blockno).lock();
+        let mut buf = kernel().bcache.get_buf(dev, blockno).lock();
         if !buf.deref_inner().valid {
             unsafe {
                 Disk::virtio_rw(&mut self.lock(), &mut buf, false);


### PR DESCRIPTION
#### PR #306 리뷰 반영했습니다. CI 통과후 리뷰 요청 드리겠습니다.

- #306 이어서
  - 지저분한 tag가 있었는데 모두 없앴습니다.
  - kernel()을 되도록 적게 사용하자는 제안과 관련이 있습니다. kernel()이 사용되는 지점을 점점 더 상위 레벨로 올려서 나중에는 없에버리는게 목표입니다.
- array_const_fn_init에서는 magic number만 사용 가능해서, 일부 리뷰는 반영하지 못했습니다. #309 이슈 생성했고, 코멘트로도 적어두었습니다.
- 나머지 리뷰는 모두 반영하였습니다.