### PR TITLE
[#258 test] Refactor myproc() using procGuard

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -61,7 +61,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if (*myproc()).killed() {
+                if (*myproc().unwrap()).killed() {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -6,7 +6,7 @@ use crate::{
     kernel::kernel,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
     pipe::AllocatedPipe,
-    proc::{myproc, Proc},
+    proc::{myproc},
     spinlock::Spinlock,
     stat::Stat,
     vm::UVAddr,
@@ -70,12 +70,13 @@ impl File {
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
     pub unsafe fn stat(&self, addr: UVAddr) -> Result<(), ()> {
-        let p: *mut Proc = myproc();
+        let mut p = myproc().unwrap();
 
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
-                (*(*p).data.get()).pagetable.copyout(
+                // (*(*p).data.get())
+                p.deref_mut_data().pagetable.copyout(
                     addr,
                     slice::from_raw_parts_mut(
                         &mut st as *mut Stat as *mut u8,

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -146,7 +146,9 @@ impl Path {
         let mut ptr = if self.is_absolute() {
             Self::root()
         } else {
-            (*(*myproc()).data.get()).cwd.clone().unwrap()
+            let mut g = myproc().unwrap();
+            g.deref_mut_data().cwd.clone().unwrap()
+            // (*(*myproc()).data.get()).cwd.clone().unwrap()
         };
 
         let mut path = self;

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -164,11 +164,11 @@ pub enum PipeError {
 impl PipeInner {
     unsafe fn try_write(&mut self, addr: UVAddr, n: usize) -> Result<usize, PipeError> {
         let mut ch = [0 as u8];
-        let proc = myproc();
+        let mut proc = myproc().unwrap();
         if !self.readopen || (*proc).killed() {
             return Err(PipeError::InvalidStatus);
         }
-        let data = &mut *(*proc).data.get();
+        let data = proc.deref_mut_data();//&mut *(*proc).data.get();
         for i in 0..n {
             if self.nwrite == self.nread.wrapping_add(PIPESIZE as u32) {
                 //DOC: pipewrite-full
@@ -184,8 +184,9 @@ impl PipeInner {
     }
 
     unsafe fn try_read(&mut self, addr: UVAddr, n: usize) -> Result<usize, PipeError> {
-        let proc = myproc();
-        let data = &mut *(*proc).data.get();
+        let mut proc = myproc().unwrap();
+        // let data = &mut *(*proc).data.get();
+        let data = proc.deref_mut_data();
 
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -27,7 +27,7 @@ impl RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
-        *guard = unsafe { (*myproc()).pid() };
+        *guard = unsafe { (*myproc().unwrap()).pid() };
     }
 
     pub fn release(&self) {
@@ -38,7 +38,7 @@ impl RawSleeplock {
 
     pub fn holding(&self) -> bool {
         let guard = self.locked.lock();
-        *guard == unsafe { (*myproc()).pid() }
+        *guard == unsafe { (*myproc().unwrap()).pid() }
     }
 }
 

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -13,7 +13,7 @@ impl Kernel {
     }
 
     pub unsafe fn sys_getpid(&self) -> usize {
-        (*myproc()).pid() as _
+        (*myproc().unwrap()).pid() as _
     }
 
     pub unsafe fn sys_fork(&self) -> usize {
@@ -27,7 +27,8 @@ impl Kernel {
 
     pub unsafe fn sys_sbrk(&self) -> usize {
         let n = ok_or!(argint(0), return usize::MAX);
-        let addr: i32 = (*(*myproc()).data.get()).sz as i32;
+        // let addr: i32 = (*(*myproc()).data.get()).sz as i32;
+        let addr: i32 = myproc().unwrap().deref_mut_data().sz as i32;
         if resizeproc(n) < 0 {
             return usize::MAX;
         }
@@ -39,7 +40,7 @@ impl Kernel {
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
-            if (*myproc()).killed() {
+            if (*myproc().unwrap()).killed() {
                 return usize::MAX;
             }
             ticks.sleep();

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -123,16 +123,18 @@ impl VAddr for UVAddr {
     }
 
     unsafe fn copyin(dst: &mut [u8], src: Self) -> Result<(), ()> {
-        let p = myproc();
-        (*(*p).data.get())
+        let mut p = myproc().unwrap();
+        p.deref_mut_data()
+        // (*(*p).data.get())
             .pagetable
             .copyin(dst, src)
             .map_or(Err(()), |_v| Ok(()))
     }
 
     unsafe fn copyout(dst: Self, src: &[u8]) -> Result<(), ()> {
-        let p = myproc();
-        (*(*p).data.get())
+        let mut p = myproc().unwrap();
+        // (*(*p).data.get())
+        p.deref_mut_data()
             .pagetable
             .copyout(dst, src)
             .map_or(Err(()), |_v| Ok(()))


### PR DESCRIPTION
현재 있는 `procGuard`와 #258에서 만드려고 하는 `procExcutionGuard`의 기능이 중복되는 것 같아 `procGuard`를 사용해서 `procData`에 safe하게 접근하는 방향으로 refactoring을 시도했습니다.
- `myproc()`에서 `Result<ProcGuard, ()>` 를 리턴하도록 수정했습니다.

   
이 방향으로 refactoring을 진행하려면 다음 내용을 고민해야 합니다.
- `myproc()`에서 `ProcGuard`를 리턴하는 것이 맞는 방향인지, 새로운 guard가 필요한지,
- `myproc()`에서 return하는 `ProcGuard`가 info에 lock을 걸어주는 것이 맞는 방향인지

---

- #258 리팩토링을 위해 시도했던 코드입니다. 나중에 참고하기 위해 draft를 남깁니다.
- 에러가 남아있어서 동작하지는 않습니다. (추가로 `unwrap()`등 수정해야 할 부분이 많이 존재합니다.)