### PR TITLE
[Closes #300] GlobalSpinlock: Acquire global lock "wait_lock" before accessing parent field

### DIFF
--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -117,15 +117,9 @@ impl Drop for Buf<'_> {
 
 impl Bcache {
     pub const fn zero() -> Self {
-        const fn bcache_entry(_: usize) -> MruEntry<BufEntry> {
-            MruEntry::new(BufEntry::zero())
-        }
-
         Spinlock::new(
             "BCACHE",
-            // TODO : Const variable should be used instead of the magic number.
-            // https://github.com/kaist-cp/rv6/issues/309
-            MruArena::new(array![x => bcache_entry(x); NBUF]),
+            MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF]),
         )
     }
 

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -191,15 +191,9 @@ impl ArenaObject for File {
 
 impl FileTable {
     pub const fn zero() -> Self {
-        const fn ftable_entry(_: usize) -> ArrayEntry<File> {
-            ArrayEntry::new(File::zero())
-        }
-
         Spinlock::new(
             "FTABLE",
-            // TODO : Const variable should be used instead of the magic number.
-            // https://github.com/kaist-cp/rv6/issues/309
-            ArrayArena::new(array![x => ftable_entry(x); NFILE]),
+            ArrayArena::new(array![_ => ArrayEntry::new(File::zero()); NFILE]),
         )
     }
 

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -580,15 +580,9 @@ impl Inode {
 
 impl Itable {
     pub const fn zero() -> Self {
-        const fn itable_entry(_: usize) -> ArrayEntry<Inode> {
-            ArrayEntry::new(Inode::zero())
-        }
-
         Spinlock::new(
             "ITABLE",
-            // TODO : Const variable should be used instead of the magic number.
-            // https://github.com/kaist-cp/rv6/issues/309
-            ArrayArena::new(array![x => itable_entry(x); NINODE]),
+            ArrayArena::new(array![_ => ArrayEntry::new(Inode::zero()); NINODE]),
         )
     }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -527,17 +527,11 @@ pub struct ProcessSystem {
     wait_lock: RawSpinlock,
 }
 
-const fn proc_entry(_: usize) -> Proc {
-    Proc::zero()
-}
-
 impl ProcessSystem {
     pub const fn zero() -> Self {
         Self {
             nextpid: AtomicI32::new(1),
-            // TODO : Const variable should be used instead of the magic number.
-            // https://github.com/kaist-cp/rv6/issues/309
-            process_pool: array![x => proc_entry(x); NPROC],
+            process_pool: array![_ => Proc::zero(); NPROC],
             initial_proc: ptr::null_mut(),
             wait_lock: RawSpinlock::new("wait_lock"),
         }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -847,7 +847,9 @@ pub unsafe fn proc_mapstacks(page_table: &mut PageTable<KVAddr>) {
 #[allow(clippy::ref_in_deref)]
 pub unsafe fn procinit(procs: &'static mut ProcessSystem) {
     for (i, p) in procs.process_pool.iter_mut().enumerate() {
-        p.parent.as_mut_ptr().write(GlobalSpinlock::new(&procs.wait_lock, ptr::null_mut()));
+        p.parent
+            .as_mut_ptr()
+            .write(GlobalSpinlock::new(&procs.wait_lock, ptr::null_mut()));
         (&mut *(*p).data.get()).kstack = kstack(i);
     }
 }

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -60,8 +60,8 @@ impl<T> Sleepablelock<T> {
 }
 
 impl<T> SleepablelockGuard<'_, T> {
-    pub fn raw(&self) -> usize {
-        self.lock as *const _ as usize
+    pub fn raw(&self) -> *const RawSpinlock {
+        &self.lock.lock as *const _
     }
 
     pub fn sleep(&mut self) {

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -227,10 +227,6 @@ impl<T> SpinlockProtected<T> {
         }
     }
 
-    pub fn into_inner(self) -> T {
-        self.data.into_inner()
-    }
-
     pub fn lock(&self) -> SpinlockProtectedGuard<'_, T> {
         self.lock.acquire();
 
@@ -243,8 +239,15 @@ impl<T> SpinlockProtected<T> {
     /// Returns a mutable reference to the inner data, provided that the given
     /// `guard: SpinlockProtectedGuard` was obtained from a `SpinlockProtected`
     /// that refers to the same `RawSpinlock` with this `SpinlockProtected`.
-    /// Note that in order to prevent references from leaking, the returned reference
+    ///
+    /// # Note
+    ///
+    /// In order to prevent references from leaking, the returned reference
     /// cannot outlive the given `guard`.
+    ///
+    /// This adds some small runtime cost, since we need to check that the given
+    /// `SpinlockProtectedGuard` was truely originated from a `SpinlockProtected`
+    /// that refers to the same `RawSpinlock`.
     #[allow(clippy::mut_from_ref)]
     pub fn get_mut<'s>(&self, guard: &'s SpinlockProtectedGuard<'s, T>) -> &'s mut T {
         assert!(self.lock as *const _ == guard.lock.lock as *const _);

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -117,7 +117,7 @@ pub struct Spinlock<T> {
 unsafe impl<T: Send> Sync for Spinlock<T> {}
 
 pub struct GlobalSpinlockGuard<'s, T> {
-    lock: &'s GlobalSpinlock<'s, T>,
+    lock: &'s GlobalSpinlock<T>,
     _marker: PhantomData<*const ()>,
 }
 
@@ -125,12 +125,12 @@ pub struct GlobalSpinlockGuard<'s, T> {
 unsafe impl<'s, T: Sync> Sync for GlobalSpinlockGuard<'s, T> {}
 
 /// A struct for wrapping data that is protected by a global `RawSpinlock`.
-pub struct GlobalSpinlock<'s, T> {
-    lock: &'s RawSpinlock,
+pub struct GlobalSpinlock<T> {
+    lock: &'static RawSpinlock,
     data: UnsafeCell<T>,
 }
 
-unsafe impl<'s, T: Send> Sync for GlobalSpinlock<'s, T> {}
+unsafe impl<T: Send> Sync for GlobalSpinlock<T> {}
 
 impl<T> Spinlock<T> {
     pub const fn new(name: &'static str, data: T) -> Self {
@@ -215,10 +215,10 @@ impl<T> DerefMut for SpinlockGuard<'_, T> {
     }
 }
 
-impl<'s, T> GlobalSpinlock<'s, T> {
+impl<T> GlobalSpinlock<T> {
     /// Creates a new `GlobalSpinlock` that protects `data` with a
     /// global `RawSpinlock` type.
-    pub const fn new(global_raw_lock: &'s RawSpinlock, data: T) -> Self {
+    pub const fn new(global_raw_lock: &'static RawSpinlock, data: T) -> Self {
         Self {
             lock: global_raw_lock,
             data: UnsafeCell::new(data),

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -116,19 +116,21 @@ pub struct Spinlock<T> {
 
 unsafe impl<T: Send> Sync for Spinlock<T> {}
 
-pub struct SpinlockProtectedGuard<'s, T> {
-    lock: &'s SpinlockProtected<T>,
+pub struct SpinlockProtectedGuard<'s> {
+    lock: &'s RawSpinlock,
     _marker: PhantomData<*const ()>,
 }
 
 // Do not implement Send; lock must be unlocked by the CPU that acquired it.
-unsafe impl<'s, T: Sync> Sync for SpinlockProtectedGuard<'s, T> {}
+unsafe impl<'s> Sync for SpinlockProtectedGuard<'s> {}
 
 /// Similar to `Spinlock<T>`, but instead of internally owning a `RawSpinlock`,
 /// this stores a `'static` reference to an external `RawSpinlock` that was provided by the caller.
 /// By making multiple `SpinlockProtected<T>`'s refer to a single `RawSpinlock`,
 /// you can make multiple data be protected by a single `RawSpinlock`, and hence,
 /// implement global locks.
+/// To dereference the inner data, you must use `SpinlockProtected<T>::get_mut`, instead of
+/// trying to dereference the `SpinlockProtectedGuard`.
 pub struct SpinlockProtected<T> {
     lock: &'static RawSpinlock,
     data: UnsafeCell<T>,
@@ -227,11 +229,11 @@ impl<T> SpinlockProtected<T> {
         }
     }
 
-    pub fn lock(&self) -> SpinlockProtectedGuard<'_, T> {
+    pub fn lock(&self) -> SpinlockProtectedGuard<'_> {
         self.lock.acquire();
 
         SpinlockProtectedGuard {
-            lock: self,
+            lock: self.lock,
             _marker: PhantomData,
         }
     }
@@ -245,12 +247,12 @@ impl<T> SpinlockProtected<T> {
     /// In order to prevent references from leaking, the returned reference
     /// cannot outlive the given `guard`.
     ///
-    /// This adds some small runtime cost, since we need to check that the given
+    /// This method adds some small runtime cost, since we need to check that the given
     /// `SpinlockProtectedGuard` was truely originated from a `SpinlockProtected`
     /// that refers to the same `RawSpinlock`.
     #[allow(clippy::mut_from_ref)]
-    pub fn get_mut<'s>(&self, guard: &'s SpinlockProtectedGuard<'s, T>) -> &'s mut T {
-        assert!(self.lock as *const _ == guard.lock.lock as *const _);
+    pub fn get_mut<'s>(&self, guard: &'s SpinlockProtectedGuard<'s>) -> &'s mut T {
+        assert!(self.lock as *const _ == guard.lock as *const _);
         unsafe { &mut *self.data.get() }
     }
 
@@ -260,29 +262,16 @@ impl<T> SpinlockProtected<T> {
     }
 }
 
-impl<T> SpinlockProtectedGuard<'_, T> {
+impl SpinlockProtectedGuard<'_> {
     /// Returns the inner `RawSpinlock`.
     pub fn raw(&self) -> *const RawSpinlock {
-        self.lock.lock as *const _
+        self.lock as *const _
     }
 }
 
-impl<T> Drop for SpinlockProtectedGuard<'_, T> {
+impl Drop for SpinlockProtectedGuard<'_> {
     fn drop(&mut self) {
-        self.lock.lock.release();
-    }
-}
-
-impl<T> Deref for SpinlockProtectedGuard<'_, T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.lock.data.get() }
-    }
-}
-
-impl<T> DerefMut for SpinlockProtectedGuard<'_, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.lock.data.get() }
+        self.lock.release();
     }
 }
 


### PR DESCRIPTION
* Closes https://github.com/kaist-cp/rv6/issues/300
* 현재 @anemoneflower 님께서 이미 procGuard관련 refactoring을 하시는걸로 알고 있어서, 최대한 겹치지 않게 parent field 관련된 부분만 한번 시험적으로 변경해봤습니다.

# 변경사항
* parent field만을 위한 type 및 API를 만들려다가, 최대한 깔끔하게 하기 위해서 **Spinlock과 매우 비슷한 GlobalSpinlock을 만들었습니다.**
* GlobalSpinlock은 Spinlock과 거의 비슷하나(거의 대부분의 코드를 복사 붙여넣었습니다), 유일한 차이점은 Spinlock은 Spinlock 하나당 RawSpinlock하나를 own하지만, **GlobalSpinlock은 RawSpinlock을 own하지 않고 외부의 global한 RawSpinlock을 가르키는 raw pointer를 갖습니다.**
* **GlobalSpinlockGuard**를 얻기 위해서는 **GlobalSpinlock::lock()** 를 하거나, 동일한 RawSpinlock을 이용하는 다른 GlobalSpinlock으로부터 이미 획득한 GlobalSpinlockGuard를 이용하여 **GlobalSpinlock::lock_with_guard()** 를 하면 됩니다. (spinlock.rs 참고). 굳이 atomic instruction을 다시할 필요가 없도록 하기 위해 이런 API를 추가했습니다.
* ProcInfo의 **parent field**를 Proc안으로 옮긴 후, access하기 위해서는 먼저 **GlobalSpinlock**를 거쳐가야 하도록 바꿨습니다.
* 다만, ProcInfo의 lock을 acquire한 상태에서 wait_lock을 확보하려고 하면 순서가 잘못되었으므로 deadlock이 생길 수 있는 것 같은데, 이걸 방지하는 코드는 아직 없습니다.

# 추가 변경/확인사항
* **proc.rs의 sleep, sleep_sleepable 함수에 버그가 있어서 수정했습니다.** 기존에는 ***const SleepableLock-> usize -> *const RawSpinlock**의 순서로 잘못된 형변환을 합니다. 수정후에는 raw() 함수가 곧바로 ***const RawSpinlock**을 리턴합니다. 어차피 Spinlock/SleepableLock의 가장 첫번째 field가 **lock: RawSpinlock**이여서 지금까지 오류는 안 일어난 것 같습니다.
* Spinlock::reacquire_after()는 arena.rs의 reacquire_after에서만 쓰이는데, 정작 arena.rs의 reacquire_after는 아무데서도 사용되지 않습니다. 일단 놔뒀습니다만, 불필요하다면 지우는 것도 좋을 것 같습니다.
* Spinlock::raw()는 어디에서도 사용되지 않습니다.
* array! macro는 array_const_fn_init과 달리, function pointer가 아니라 그냥 closure도 사용 가능하므로, 불필요한 코드를 삭제했습니다.