### PR TITLE
[Minor issue of #271] Move disk to filesystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 os: linux
 dist: focal
+language: minimal
+branches:
+    only:
+        - riscv
+        - staging
+        - trying
+
 addons:
   apt:
     packages:
       - gcc-riscv64-linux-gnu
-      - qemu-system-misc=1:4.2-3ubuntu6
+      - qemu-system-misc
 install:
   - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
   - source $HOME/.cargo/env

--- a/README-rv6.md
+++ b/README-rv6.md
@@ -4,8 +4,7 @@
 
   ```
   # Ubuntu 20.04
-  # The latest qemu-system-misc(1:4.2-3ubuntu6.9) can't boot rv6, so please use older version (1:4.2-3ubuntu6)
-  sudo apt install gcc-riscv64-linux-gnu qemu-system-misc=1:4.2-3ubuntu6 gdb-multiarch
+  sudo apt install gcc-riscv64-linux-gnu qemu-system-misc gdb-multiarch
 
   rustup component add rust-src
   ```

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -117,15 +117,9 @@ impl Drop for Buf<'_> {
 
 impl Bcache {
     pub const fn zero() -> Self {
-        const fn bcache_entry(_: usize) -> MruEntry<BufEntry> {
-            MruEntry::new(BufEntry::zero())
-        }
-
         Spinlock::new(
             "BCACHE",
-            // TODO : Const variable should be used instead of the magic number.
-            // https://github.com/kaist-cp/rv6/issues/309
-            MruArena::new(array![x => bcache_entry(x); NBUF]),
+            MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF]),
         )
     }
 

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -97,7 +97,7 @@ impl Kernel {
         let mut p: *mut Proc = myproc();
         let mut data = &mut *(*p).data.get();
 
-        let tx = self.fs().begin_transaction();
+        let tx = self.file_system.begin_transaction();
         let ptr = ok_or!(path.namei(&tx), {
             return Err(());
         });

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -191,15 +191,9 @@ impl ArenaObject for File {
 
 impl FileTable {
     pub const fn zero() -> Self {
-        const fn ftable_entry(_: usize) -> ArrayEntry<File> {
-            ArrayEntry::new(File::zero())
-        }
-
         Spinlock::new(
             "FTABLE",
-            // TODO : Const variable should be used instead of the magic number.
-            // https://github.com/kaist-cp/rv6/issues/309
-            ArrayArena::new(array![x => ftable_entry(x); NFILE]),
+            ArrayArena::new(array![_ => ArrayEntry::new(File::zero()); NFILE]),
         )
     }
 

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -97,7 +97,7 @@ impl File {
         match &self.typ {
             FileType::Pipe { pipe } => pipe.read(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
-                let tx = kernel().fs().begin_transaction();
+                let tx = kernel().file_system.begin_transaction();
                 let ip = ip.deref().lock(&tx);
                 let curr_off = *off.get();
                 let ret = ip.read(addr, curr_off, n as u32);
@@ -139,7 +139,7 @@ impl File {
                 let mut bytes_written: usize = 0;
                 while bytes_written < n as usize {
                     let bytes_to_write = cmp::min(n as usize - bytes_written, max);
-                    let tx = kernel().fs().begin_transaction();
+                    let tx = kernel().file_system.begin_transaction();
                     let mut ip = ip.deref().lock(&tx);
                     let curr_off = *off.get();
                     let r = ip
@@ -180,7 +180,7 @@ impl ArenaObject for File {
             match typ {
                 FileType::Pipe { mut pipe } => unsafe { pipe.close(self.writable) },
                 FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
-                    let _tx = kernel().fs().begin_transaction();
+                    let _tx = kernel().file_system.begin_transaction();
                     drop(ip);
                 }
                 _ => (),

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -278,6 +278,7 @@ impl InodeGuard<'_> {
     /// that lives on disk.
     pub unsafe fn update(&self) {
         let mut bp = kernel()
+            .fs()
             .disk
             .read(self.dev, kernel().fs().superblock.iblock(self.inum));
         let mut dip: *mut Dinode = (bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
@@ -306,7 +307,10 @@ impl InodeGuard<'_> {
         }
 
         if self.deref_inner().addr_indirect != 0 {
-            let mut bp = kernel().disk.read(dev, self.deref_inner().addr_indirect);
+            let mut bp = kernel()
+                .fs()
+                .disk
+                .read(dev, self.deref_inner().addr_indirect);
             let a = bp.deref_mut_inner().data.as_mut_ptr() as *mut u32;
             for j in 0..NINDIRECT {
                 if *a.add(j) != 0 {
@@ -334,6 +338,7 @@ impl InodeGuard<'_> {
         let mut tot: u32 = 0;
         while tot < n {
             let mut bp = kernel()
+                .fs()
                 .disk
                 .read(self.dev, self.bmap((off as usize).wrapping_div(BSIZE)));
             let m = core::cmp::min(
@@ -365,7 +370,7 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let mut bp = kernel().disk.read(
+            let mut bp = kernel().fs().disk.read(
                 self.dev,
                 self.bmap_or_alloc((off as usize).wrapping_div(BSIZE)),
             );
@@ -434,7 +439,7 @@ impl InodeGuard<'_> {
             self.deref_inner_mut().addr_indirect = addr;
         }
 
-        let mut bp = kernel().disk.read(self.dev, addr);
+        let mut bp = kernel().fs().disk.read(self.dev, addr);
         let a: *mut u32 = bp.deref_mut_inner().data.as_mut_ptr() as *mut u32;
         unsafe {
             addr = *a.add(bn);
@@ -459,7 +464,7 @@ impl InodeGuard<'_> {
             let indirect = inner.addr_indirect;
             assert_ne!(indirect, 0, "bmap: out of range");
 
-            let bp = kernel().disk.read(self.dev, indirect);
+            let bp = kernel().fs().disk.read(self.dev, indirect);
             let data = bp.deref_inner().data.as_ptr() as *mut u32;
             let addr = unsafe { *data.add(bn) };
             assert_ne!(addr, 0, "bmap: out of range");
@@ -524,6 +529,7 @@ impl Inode {
         let mut guard = self.inner.lock();
         if !guard.valid {
             let mut bp = kernel()
+                .fs()
                 .disk
                 .read(self.dev, kernel().fs().superblock.iblock(self.inum));
             let dip: &mut Dinode = unsafe {
@@ -609,6 +615,7 @@ impl Itable {
     pub unsafe fn alloc_inode(&self, dev: u32, typ: i16, tx: &FsTransaction<'_>) -> RcInode<'_> {
         for inum in 1..kernel().fs().superblock.ninodes {
             let mut bp = kernel()
+                .fs()
                 .disk
                 .read(dev, kernel().fs().superblock.iblock(inum));
             let dip = (bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -580,15 +580,9 @@ impl Inode {
 
 impl Itable {
     pub const fn zero() -> Self {
-        const fn itable_entry(_: usize) -> ArrayEntry<Inode> {
-            ArrayEntry::new(Inode::zero())
-        }
-
         Spinlock::new(
             "ITABLE",
-            // TODO : Const variable should be used instead of the magic number.
-            // https://github.com/kaist-cp/rv6/issues/309
-            ArrayArena::new(array![x => itable_entry(x); NINODE]),
+            ArrayArena::new(array![_ => ArrayEntry::new(Inode::zero()); NINODE]),
         )
     }
 

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -80,7 +80,7 @@ use crate::{
     vm::{KVAddr, VAddr},
 };
 
-use super::{FileName, IPB, MAXFILE, NDIRECT, NINDIRECT};
+use super::{FileName, DISK, IPB, MAXFILE, NDIRECT, NINDIRECT};
 
 /// Directory is a file containing a sequence of Dirent structures.
 pub const DIRSIZ: usize = 14;
@@ -226,7 +226,7 @@ impl Drop for InodeGuard<'_> {
 // Directories
 impl InodeGuard<'_> {
     /// Write a new directory entry (name, inum) into the directory dp.
-    pub fn dirlink(&mut self, name: &FileName, inum: u32) -> Result<(), ()> {
+    pub unsafe fn dirlink(&mut self, name: &FileName, inum: u32) -> Result<(), ()> {
         let mut de: Dirent = Default::default();
 
         // Check that name is not present.
@@ -277,10 +277,7 @@ impl InodeGuard<'_> {
     /// Must be called after every change to an ip->xxx field
     /// that lives on disk.
     pub unsafe fn update(&self) {
-        let mut bp = kernel()
-            .fs()
-            .disk
-            .read(self.dev, kernel().fs().superblock.iblock(self.inum));
+        let mut bp = DISK.read(self.dev, kernel().fs().superblock.iblock(self.inum));
         let mut dip: *mut Dinode = (bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
             .add((self.inum as usize).wrapping_rem(IPB));
         let inner = self.deref_inner();
@@ -307,10 +304,7 @@ impl InodeGuard<'_> {
         }
 
         if self.deref_inner().addr_indirect != 0 {
-            let mut bp = kernel()
-                .fs()
-                .disk
-                .read(dev, self.deref_inner().addr_indirect);
+            let mut bp = DISK.read(dev, self.deref_inner().addr_indirect);
             let a = bp.deref_mut_inner().data.as_mut_ptr() as *mut u32;
             for j in 0..NINDIRECT {
                 if *a.add(j) != 0 {
@@ -337,10 +331,8 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let mut bp = kernel()
-                .fs()
-                .disk
-                .read(self.dev, self.bmap((off as usize).wrapping_div(BSIZE)));
+            let mut bp =
+                unsafe { DISK.read(self.dev, self.bmap((off as usize).wrapping_div(BSIZE))) };
             let m = core::cmp::min(
                 n.wrapping_sub(tot),
                 (BSIZE as u32).wrapping_sub(off.wrapping_rem(BSIZE as u32)),
@@ -370,10 +362,12 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let mut bp = kernel().fs().disk.read(
-                self.dev,
-                self.bmap_or_alloc((off as usize).wrapping_div(BSIZE)),
-            );
+            let mut bp = unsafe {
+                DISK.read(
+                    self.dev,
+                    self.bmap_or_alloc((off as usize).wrapping_div(BSIZE)),
+                )
+            };
             let m = core::cmp::min(
                 n.wrapping_sub(tot),
                 (BSIZE as u32).wrapping_sub(off.wrapping_rem(BSIZE as u32)),
@@ -439,7 +433,7 @@ impl InodeGuard<'_> {
             self.deref_inner_mut().addr_indirect = addr;
         }
 
-        let mut bp = kernel().fs().disk.read(self.dev, addr);
+        let mut bp = unsafe { DISK.read(self.dev, addr) };
         let a: *mut u32 = bp.deref_mut_inner().data.as_mut_ptr() as *mut u32;
         unsafe {
             addr = *a.add(bn);
@@ -464,7 +458,7 @@ impl InodeGuard<'_> {
             let indirect = inner.addr_indirect;
             assert_ne!(indirect, 0, "bmap: out of range");
 
-            let bp = kernel().fs().disk.read(self.dev, indirect);
+            let bp = unsafe { DISK.read(self.dev, indirect) };
             let data = bp.deref_inner().data.as_ptr() as *mut u32;
             let addr = unsafe { *data.add(bn) };
             assert_ne!(addr, 0, "bmap: out of range");
@@ -528,10 +522,7 @@ impl Inode {
     pub fn lock<'x>(&'x self, tx: &'x FsTransaction<'x>) -> InodeGuard<'x> {
         let mut guard = self.inner.lock();
         if !guard.valid {
-            let mut bp = kernel()
-                .fs()
-                .disk
-                .read(self.dev, kernel().fs().superblock.iblock(self.inum));
+            let mut bp = unsafe { DISK.read(self.dev, kernel().fs().superblock.iblock(self.inum)) };
             let dip: &mut Dinode = unsafe {
                 &mut *((bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
                     .add((self.inum as usize).wrapping_rem(IPB)))
@@ -614,10 +605,7 @@ impl Itable {
     /// Returns an unlocked but allocated and referenced inode.
     pub unsafe fn alloc_inode(&self, dev: u32, typ: i16, tx: &FsTransaction<'_>) -> RcInode<'_> {
         for inum in 1..kernel().fs().superblock.ninodes {
-            let mut bp = kernel()
-                .fs()
-                .disk
-                .read(dev, kernel().fs().superblock.iblock(inum));
+            let mut bp = DISK.read(dev, kernel().fs().superblock.iblock(inum));
             let dip = (bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
                 .add((inum as usize).wrapping_rem(IPB));
 

--- a/kernel-rs/src/fs/log.rs
+++ b/kernel-rs/src/fs/log.rs
@@ -30,6 +30,7 @@ use crate::{
     sleepablelock::Sleepablelock,
 };
 
+use super::DISK;
 pub struct Log {
     dev: u32,
     start: i32,
@@ -76,10 +77,7 @@ impl Log {
         for (tail, dbuf) in self.lh.drain(..).enumerate() {
             // Read log block.
 
-            let lbuf = kernel()
-                .fs()
-                .disk
-                .read(self.dev as u32, (self.start + tail as i32 + 1) as u32);
+            let lbuf = DISK.read(self.dev as u32, (self.start + tail as i32 + 1) as u32);
 
             // Read dst.
             let mut dbuf = dbuf.lock();
@@ -92,7 +90,7 @@ impl Log {
             );
 
             // Write dst to disk.
-            kernel().fs().disk.write(&mut dbuf);
+            DISK.write(&mut dbuf);
 
             if recovering {
                 mem::forget(dbuf);
@@ -102,7 +100,7 @@ impl Log {
 
     /// Read the log header from disk into the in-memory log header.
     unsafe fn read_head(&mut self) {
-        let mut buf = kernel().fs().disk.read(self.dev as u32, self.start as u32);
+        let mut buf = DISK.read(self.dev as u32, self.start as u32);
         let lh = buf.deref_mut_inner().data.as_mut_ptr() as *mut LogHeader;
         for b in &(*lh).block[0..(*lh).n as usize] {
             self.lh.push(
@@ -118,13 +116,13 @@ impl Log {
     /// This is the true point at which the
     /// current transaction commits.
     unsafe fn write_head(&mut self) {
-        let mut buf = kernel().fs().disk.read(self.dev as u32, self.start as u32);
+        let mut buf = DISK.read(self.dev as u32, self.start as u32);
         let mut hb = &mut *(buf.deref_mut_inner().data.as_mut_ptr() as *mut LogHeader);
         hb.n = self.lh.len() as u32;
         for (db, b) in izip!(&mut hb.block, &self.lh) {
             *db = (*b).blockno;
         }
-        kernel().fs().disk.write(&mut buf)
+        DISK.write(&mut buf)
     }
 
     unsafe fn recover_from_log(&mut self) {
@@ -186,13 +184,11 @@ impl Log {
     unsafe fn write_log(&mut self) {
         for (tail, from) in self.lh.iter().enumerate() {
             // Log block.
-            let mut to = kernel()
-                .fs()
-                .disk
+            let mut to = DISK
                 .read(self.dev as u32, (self.start + tail as i32 + 1) as u32);
 
             // Cache block.
-            let from = kernel().fs().disk.read(self.dev as u32, from.blockno);
+            let from = DISK.read(self.dev as u32, from.blockno);
 
             ptr::copy(
                 from.deref_inner().data.as_ptr(),
@@ -201,7 +197,7 @@ impl Log {
             );
 
             // Write the log.
-            kernel().fs().disk.write(&mut to)
+            DISK.write(&mut to)
         }
     }
 

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -13,14 +13,7 @@
 
 use core::{cmp, mem, ptr};
 
-use crate::{
-    bio::Buf,
-    kernel::kernel,
-    param::BSIZE,
-    sleepablelock::Sleepablelock,
-    stat::T_DIR,
-    virtio_disk::Disk,
-};
+use crate::{bio::Buf, kernel::{kernel, kernel_mut}, param::BSIZE, sleepablelock::Sleepablelock, stat::T_DIR, virtio_disk::{Disk, virtio_disk_init}};
 
 mod inode;
 mod log;
@@ -58,14 +51,11 @@ pub struct FsTransaction<'s> {
 }
 
 impl FileSystem {
-    // pub fn zero() -> Self {
-
-    // }
     pub fn new(dev: u32) -> Self {
-        // let mut disk = Sleepablelock::new("virtio_disk", Disk::zero());
-        let disk = Sleepablelock::new("virtio_disk", kernel().disk);
+        let mut disk = Sleepablelock::new("virtio_disk", Disk::zero());
+        // let disk = Sleepablelock::new("virtio_disk", unsafe{&DISK});
 
-        // unsafe { virtio_disk_init(&mut kernel_mut().virtqueue, disk.get_mut()) };
+        unsafe { virtio_disk_init(&mut kernel_mut().virtqueue, disk.get_mut()) };
         let superblock = unsafe { Superblock::new(&disk.read(dev, 1)) };
         let log = Sleepablelock::new(
             "LOG",

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -13,7 +13,14 @@
 
 use core::{cmp, mem, ptr};
 
-use crate::{bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, stat::T_DIR};
+use crate::{
+    bio::Buf,
+    kernel::kernel,
+    param::BSIZE,
+    sleepablelock::Sleepablelock,
+    stat::T_DIR,
+    virtio_disk::Disk,
+};
 
 mod inode;
 mod log;
@@ -41,6 +48,9 @@ pub struct FileSystem {
 
     /// TODO(rv6): document it
     log: Sleepablelock<Log>,
+
+    /// It may sleep until some Descriptors are freed.
+    pub disk: Sleepablelock<Disk>,
 }
 
 pub struct FsTransaction<'s> {
@@ -48,13 +58,25 @@ pub struct FsTransaction<'s> {
 }
 
 impl FileSystem {
+    // pub fn zero() -> Self {
+
+    // }
     pub fn new(dev: u32) -> Self {
-        let superblock = unsafe { Superblock::new(&kernel().disk.read(dev, 1)) };
+        // let mut disk = Sleepablelock::new("virtio_disk", Disk::zero());
+        let disk = Sleepablelock::new("virtio_disk", kernel().disk);
+
+        // unsafe { virtio_disk_init(&mut kernel_mut().virtqueue, disk.get_mut()) };
+        let superblock = unsafe { Superblock::new(&disk.read(dev, 1)) };
         let log = Sleepablelock::new(
             "LOG",
             Log::new(dev, superblock.logstart as i32, superblock.nlog as i32),
         );
-        Self { superblock, log }
+
+        Self {
+            superblock,
+            log,
+            disk,
+        }
     }
 
     /// Called for each FS system call.
@@ -83,7 +105,7 @@ impl FsTransaction<'_> {
     /// commit()/write_log() will do the disk write.
     ///
     /// write() replaces write(); a typical use is:
-    ///   bp = kernel().disk.read(...)
+    ///   bp = kernel().fs().disk.read(...)
     ///   modify bp->data[]
     ///   write(bp)
     unsafe fn write(&self, b: Buf<'static>) {
@@ -102,7 +124,7 @@ impl FsTransaction<'_> {
     /// Allocate a zeroed disk block.
     unsafe fn balloc(&self, dev: u32) -> u32 {
         for b in num_iter::range_step(0, self.fs.superblock.size, BPB) {
-            let mut bp = kernel().disk.read(dev, self.fs.superblock.bblock(b));
+            let mut bp = self.fs.disk.read(dev, self.fs.superblock.bblock(b));
             for bi in 0..cmp::min(BPB, self.fs.superblock.size - b) {
                 let m = 1 << (bi % 8);
                 if bp.deref_mut_inner().data[(bi / 8) as usize] & m == 0 {
@@ -120,7 +142,7 @@ impl FsTransaction<'_> {
 
     /// Free a disk block.
     unsafe fn bfree(&self, dev: u32, b: u32) {
-        let mut bp = kernel().disk.read(dev, self.fs.superblock.bblock(b));
+        let mut bp = self.fs.disk.read(dev, self.fs.superblock.bblock(b));
         let bi = b.wrapping_rem(BPB) as i32;
         let m = 1u8 << (bi % 8);
         assert_ne!(

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -19,7 +19,7 @@ use crate::{
     spinlock::Spinlock,
     trap::{trapinit, trapinithart},
     uart::Uart,
-    virtio_disk::{virtio_disk_init, Disk},
+    // virtio_disk::{virtio_disk_init, Disk},
     vm::{KVAddr, PageTable},
 };
 
@@ -70,10 +70,10 @@ pub struct Kernel {
     /// This is a global instead of allocated because it must be multiple contiguous pages, which
     /// `kernel().alloc()` doesn't support, and page aligned.
     // TODO(efenniht): I moved out pages from Disk. Did I changed semantics (pointer indirection?)
-    virtqueue: [RawPage; 2],
+    pub virtqueue: [RawPage; 2],
 
     /// It may sleep until some Descriptors are freed.
-    pub disk: Disk, //Sleepablelock<Disk>,
+    // pub disk: Disk, //Sleepablelock<Disk>,
 
     pub devsw: [Devsw; NDEV],
 
@@ -98,7 +98,7 @@ impl Kernel {
             cpus: [Cpu::new(); NCPU],
             bcache: Bcache::zero(),
             virtqueue: [RawPage::DEFAULT, RawPage::DEFAULT],
-            disk: Disk::zero(), //Sleepablelock::new("virtio_disk", Disk::zero()),
+            // disk: Disk::zero(), //Sleepablelock::new("virtio_disk", Disk::zero()),
             devsw: [Devsw {
                 read: None,
                 write: None,
@@ -246,7 +246,7 @@ pub unsafe fn kernel_main() -> ! {
         KERNEL.bcache.get_mut().init();
 
         // Emulated hard disk.
-        virtio_disk_init(&mut KERNEL.virtqueue, &mut KERNEL.disk); //KERNEL.disk.get_mut());
+        // virtio_disk_init(&mut KERNEL.virtqueue, &mut KERNEL.disk); //KERNEL.disk.get_mut());
 
         // First user process.
         KERNEL.procs.user_proc_init();

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -1,6 +1,5 @@
 use core::fmt::{self, Write};
 use core::sync::atomic::{spin_loop_hint, AtomicBool, Ordering};
-use spin::Once;
 
 use crate::{
     bio::Bcache,
@@ -19,7 +18,7 @@ use crate::{
     spinlock::Spinlock,
     trap::{trapinit, trapinithart},
     uart::Uart,
-    virtio_disk::virtio_disk_init1,
+    virtio_disk::virtio_disk_init,
     vm::{KVAddr, PageTable},
 };
 
@@ -76,7 +75,7 @@ pub struct Kernel {
 
     pub itable: Itable,
 
-    pub file_system: Once<FileSystem>,
+    pub file_system: FileSystem,
 }
 
 impl Kernel {
@@ -99,7 +98,7 @@ impl Kernel {
             }; NDEV],
             ftable: FileTable::zero(),
             itable: Itable::zero(),
-            file_system: Once::new(),
+            file_system: FileSystem::zero(),
         }
     }
 
@@ -158,16 +157,17 @@ impl Kernel {
         &self.cpus[id] as *const _ as *mut _
     }
 
-    pub fn fsinit(&self, dev: u32) {
-        self.file_system.call_once(|| FileSystem::new(dev));
-    }
-
-    pub fn fs(&self) -> &FileSystem {
-        if let Some(fs) = self.file_system.get() {
-            fs
-        } else {
-            unreachable!()
-        }
+    pub fn fsinit(&mut self, dev: u32) {
+        self.file_system
+            .superblock
+            .call_once(|| FileSystem::superblock_init(&self.file_system.disk, dev));
+        self.file_system.log.call_once(|| {
+            FileSystem::log_init(
+                self.file_system.superblock().logstart as i32,
+                self.file_system.superblock().nlog as i32,
+                dev,
+            )
+        });
     }
 }
 
@@ -240,7 +240,7 @@ pub unsafe fn kernel_main() -> ! {
         KERNEL.bcache.get_mut().init();
 
         // Emulated hard disk.
-        virtio_disk_init1(&mut KERNEL.virtqueue); //KERNEL.disk.get_mut());
+        virtio_disk_init(&mut KERNEL.virtqueue, KERNEL.file_system.disk.get_mut()); //KERNEL.disk.get_mut());
 
         // First user process.
         KERNEL.procs.user_proc_init();

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -27,10 +27,16 @@ use crate::{
 // TODO(rv6): remove pub from `pub static mut KERNEL`.
 pub static mut KERNEL: Kernel = Kernel::zero();
 
+// pub static mut DISK: Disk = Disk::zero();
+
 /// After intialized, the kernel is safe to immutably access.
 #[inline]
 pub fn kernel() -> &'static Kernel {
     unsafe { &KERNEL }
+}
+
+pub fn kernel_mut() -> &'static mut Kernel {
+    unsafe { &mut KERNEL }
 }
 
 pub struct Kernel {
@@ -67,7 +73,7 @@ pub struct Kernel {
     virtqueue: [RawPage; 2],
 
     /// It may sleep until some Descriptors are freed.
-    pub disk: Sleepablelock<Disk>,
+    pub disk: Disk, //Sleepablelock<Disk>,
 
     pub devsw: [Devsw; NDEV],
 
@@ -92,7 +98,7 @@ impl Kernel {
             cpus: [Cpu::new(); NCPU],
             bcache: Bcache::zero(),
             virtqueue: [RawPage::DEFAULT, RawPage::DEFAULT],
-            disk: Sleepablelock::new("virtio_disk", Disk::zero()),
+            disk: Disk::zero(), //Sleepablelock::new("virtio_disk", Disk::zero()),
             devsw: [Devsw {
                 read: None,
                 write: None,
@@ -240,7 +246,7 @@ pub unsafe fn kernel_main() -> ! {
         KERNEL.bcache.get_mut().init();
 
         // Emulated hard disk.
-        virtio_disk_init(&mut KERNEL.virtqueue, KERNEL.disk.get_mut());
+        virtio_disk_init(&mut KERNEL.virtqueue, &mut KERNEL.disk); //KERNEL.disk.get_mut());
 
         // First user process.
         KERNEL.procs.user_proc_init();

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -19,15 +19,13 @@ use crate::{
     spinlock::Spinlock,
     trap::{trapinit, trapinithart},
     uart::Uart,
-    // virtio_disk::{virtio_disk_init, Disk},
+    virtio_disk::virtio_disk_init1,
     vm::{KVAddr, PageTable},
 };
 
 /// The kernel.
 // TODO(rv6): remove pub from `pub static mut KERNEL`.
 pub static mut KERNEL: Kernel = Kernel::zero();
-
-// pub static mut DISK: Disk = Disk::zero();
 
 /// After intialized, the kernel is safe to immutably access.
 #[inline]
@@ -72,9 +70,6 @@ pub struct Kernel {
     // TODO(efenniht): I moved out pages from Disk. Did I changed semantics (pointer indirection?)
     pub virtqueue: [RawPage; 2],
 
-    /// It may sleep until some Descriptors are freed.
-    // pub disk: Disk, //Sleepablelock<Disk>,
-
     pub devsw: [Devsw; NDEV],
 
     pub ftable: FileTable,
@@ -98,7 +93,6 @@ impl Kernel {
             cpus: [Cpu::new(); NCPU],
             bcache: Bcache::zero(),
             virtqueue: [RawPage::DEFAULT, RawPage::DEFAULT],
-            // disk: Disk::zero(), //Sleepablelock::new("virtio_disk", Disk::zero()),
             devsw: [Devsw {
                 read: None,
                 write: None,
@@ -246,7 +240,7 @@ pub unsafe fn kernel_main() -> ! {
         KERNEL.bcache.get_mut().init();
 
         // Emulated hard disk.
-        // virtio_disk_init(&mut KERNEL.virtqueue, &mut KERNEL.disk); //KERNEL.disk.get_mut());
+        virtio_disk_init1(&mut KERNEL.virtqueue); //KERNEL.disk.get_mut());
 
         // First user process.
         KERNEL.procs.user_proc_init();

--- a/kernel-rs/src/plic.rs
+++ b/kernel-rs/src/plic.rs
@@ -21,14 +21,14 @@ pub unsafe fn plicinithart() {
 }
 
 /// ask the PLIC what interrupt we should serve.
-pub unsafe fn plic_claim() -> usize {
+pub unsafe fn plic_claim() -> u32 {
     let hart: usize = cpuid();
-    let irq: usize = *(plic_sclaim(hart) as *mut usize);
+    let irq: u32 = *(plic_sclaim(hart) as *mut u32);
     irq
 }
 
 /// tell the PLIC we've served this IRQ.
-pub unsafe fn plic_complete(irq: usize) {
+pub unsafe fn plic_complete(irq: u32) {
     let hart: usize = cpuid();
-    *(plic_sclaim(hart) as *mut usize) = irq;
+    *(plic_sclaim(hart) as *mut u32) = irq;
 }

--- a/kernel-rs/src/poweroff.rs
+++ b/kernel-rs/src/poweroff.rs
@@ -5,15 +5,15 @@ use core::ptr;
 ///
 /// This function uses SiFive Test Finalizer, which provides power management for QEMU virt device.
 pub fn machine_poweroff(exitcode: u16) -> ! {
-    const BASE_CODE: u64 = 0x3333;
-    let code = ((exitcode as u64) << 16) | BASE_CODE;
+    const BASE_CODE: u32 = 0x3333;
+    let code = ((exitcode as u32) << 16) | BASE_CODE;
     // SAFETY:
     // - FINISHER is identically mapped from physical address.
     // - FINISHER is for MMIO. Though this is not specified as document, see the implementation:
     // https://github.com/qemu/qemu/blob/stable-5.0/hw/riscv/virt.c#L60 and,
     // https://github.com/qemu/qemu/blob/stable-5.0/hw/riscv/sifive_test.c#L34
     unsafe {
-        ptr::write_volatile(memlayout::FINISHER as *mut u64, code);
+        ptr::write_volatile(memlayout::FINISHER as *mut u32, code);
     }
 
     unreachable!("Power off failed");

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -12,7 +12,7 @@ use core::{
 use crate::{
     file::RcFile,
     fs::{Path, RcInode},
-    kernel::{kernel, KERNEL},
+    kernel::{kernel, kernel_mut, KERNEL},
     memlayout::{kstack, TRAMPOLINE, TRAPFRAME},
     ok_or,
     page::Page,
@@ -466,7 +466,7 @@ impl ProcData {
         for file in &mut self.open_files {
             *file = None;
         }
-        let _tx = kernel().fs().begin_transaction();
+        let _tx = kernel().file_system.begin_transaction();
         self.cwd = None;
     }
 }
@@ -1024,7 +1024,7 @@ unsafe fn forkret() {
     // File system initialization must be run in the context of a
     // regular process (e.g., because it calls sleep), and thus cannot
     // be run from main().
-    kernel().fsinit(ROOTDEV);
+    kernel_mut().fsinit(ROOTDEV);
 
     usertrapret();
 }

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -60,8 +60,8 @@ impl<T> Sleepablelock<T> {
 }
 
 impl<T> SleepablelockGuard<'_, T> {
-    pub fn raw(&self) -> usize {
-        self.lock as *const _ as usize
+    pub fn raw(&self) -> *const RawSpinlock {
+        &self.lock.lock as *const _
     }
 
     pub fn sleep(&mut self) {

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -116,6 +116,28 @@ pub struct Spinlock<T> {
 
 unsafe impl<T: Send> Sync for Spinlock<T> {}
 
+pub struct SpinlockProtectedGuard<'s> {
+    lock: &'s RawSpinlock,
+    _marker: PhantomData<*const ()>,
+}
+
+// Do not implement Send; lock must be unlocked by the CPU that acquired it.
+unsafe impl<'s> Sync for SpinlockProtectedGuard<'s> {}
+
+/// Similar to `Spinlock<T>`, but instead of internally owning a `RawSpinlock`,
+/// this stores a `'static` reference to an external `RawSpinlock` that was provided by the caller.
+/// By making multiple `SpinlockProtected<T>`'s refer to a single `RawSpinlock`,
+/// you can make multiple data be protected by a single `RawSpinlock`, and hence,
+/// implement global locks.
+/// To dereference the inner data, you must use `SpinlockProtected<T>::get_mut`, instead of
+/// trying to dereference the `SpinlockProtectedGuard`.
+pub struct SpinlockProtected<T> {
+    lock: &'static RawSpinlock,
+    data: UnsafeCell<T>,
+}
+
+unsafe impl<T: Send> Sync for SpinlockProtected<T> {}
+
 impl<T> Spinlock<T> {
     pub const fn new(name: &'static str, data: T) -> Self {
         Self {
@@ -165,8 +187,8 @@ impl<T> Spinlock<T> {
 }
 
 impl<T> SpinlockGuard<'_, T> {
-    pub fn raw(&self) -> usize {
-        self.lock as *const _ as usize
+    pub fn raw(&self) -> *const RawSpinlock {
+        &self.lock.lock as *const _
     }
 
     pub fn reacquire_after<F, R>(&mut self, f: F) -> R
@@ -196,6 +218,60 @@ impl<T> Deref for SpinlockGuard<'_, T> {
 impl<T> DerefMut for SpinlockGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *self.lock.data.get() }
+    }
+}
+
+impl<T> SpinlockProtected<T> {
+    pub const fn new(raw_lock: &'static RawSpinlock, data: T) -> Self {
+        Self {
+            lock: raw_lock,
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock(&self) -> SpinlockProtectedGuard<'_> {
+        self.lock.acquire();
+
+        SpinlockProtectedGuard {
+            lock: self.lock,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns a mutable reference to the inner data, provided that the given
+    /// `guard: SpinlockProtectedGuard` was obtained from a `SpinlockProtected`
+    /// that refers to the same `RawSpinlock` with this `SpinlockProtected`.
+    ///
+    /// # Note
+    ///
+    /// In order to prevent references from leaking, the returned reference
+    /// cannot outlive the given `guard`.
+    ///
+    /// This method adds some small runtime cost, since we need to check that the given
+    /// `SpinlockProtectedGuard` was truely originated from a `SpinlockProtected`
+    /// that refers to the same `RawSpinlock`.
+    #[allow(clippy::mut_from_ref)]
+    pub fn get_mut<'s>(&self, guard: &'s SpinlockProtectedGuard<'s>) -> &'s mut T {
+        assert!(self.lock as *const _ == guard.lock as *const _);
+        unsafe { &mut *self.data.get() }
+    }
+
+    /// Check whether this cpu is holding the lock.
+    pub fn holding(&self) -> bool {
+        self.lock.holding()
+    }
+}
+
+impl SpinlockProtectedGuard<'_> {
+    /// Returns the inner `RawSpinlock`.
+    pub fn raw(&self) -> *const RawSpinlock {
+        self.lock as *const _
+    }
+}
+
+impl Drop for SpinlockProtectedGuard<'_> {
+    fn drop(&mut self) {
+        self.lock.release();
     }
 }
 

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -146,7 +146,7 @@ impl Kernel {
         let mut old: [u8; MAXPATH as usize] = [0; MAXPATH];
         let old = ok_or!(argstr(0, &mut old), return usize::MAX);
         let new = ok_or!(argstr(1, &mut new), return usize::MAX);
-        let tx = self.fs().begin_transaction();
+        let tx = self.file_system.begin_transaction();
         let ptr = ok_or!(Path::new(old).namei(&tx), return usize::MAX);
         let mut ip = ptr.lock(&tx);
         if ip.deref_inner().typ == T_DIR {
@@ -174,7 +174,7 @@ impl Kernel {
         let mut de: Dirent = Default::default();
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
-        let tx = self.fs().begin_transaction();
+        let tx = self.file_system.begin_transaction();
         let (ptr, name) = ok_or!(Path::new(path).nameiparent(&tx), return usize::MAX);
         let mut dp = ptr.lock(&tx);
 
@@ -215,7 +215,7 @@ impl Kernel {
         let omode = ok_or!(argint(1), return usize::MAX);
         let omode = FcntlFlags::from_bits_truncate(omode);
 
-        let tx = self.fs().begin_transaction();
+        let tx = self.file_system.begin_transaction();
 
         let (ip, (typ, major)) = if omode.contains(FcntlFlags::O_CREATE) {
             ok_or!(
@@ -271,7 +271,7 @@ impl Kernel {
 
     pub unsafe fn sys_mkdir(&self) -> usize {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
-        let tx = self.fs().begin_transaction();
+        let tx = self.file_system.begin_transaction();
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
         ok_or!(
             create(Path::new(path), T_DIR, 0, 0, &tx, |_| ()),
@@ -285,7 +285,7 @@ impl Kernel {
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
         let major = ok_or!(argint(1), return usize::MAX) as u16;
         let minor = ok_or!(argint(2), return usize::MAX) as u16;
-        let tx = self.fs().begin_transaction();
+        let tx = self.file_system.begin_transaction();
         let _ip = ok_or!(
             create(Path::new(path), T_DEVICE, major, minor, &tx, |_| ()),
             return usize::MAX
@@ -298,7 +298,7 @@ impl Kernel {
         let p: *mut Proc = myproc();
         let mut data = &mut *(*p).data.get();
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
-        let tx = self.fs().begin_transaction();
+        let tx = self.file_system.begin_transaction();
         let ptr = ok_or!(Path::new(path).namei(&tx), return usize::MAX);
         let ip = ptr.lock(&tx);
         if ip.deref_inner().typ != T_DIR {

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -209,7 +209,7 @@ pub unsafe fn devintr() -> i32 {
         if irq as usize == UART0_IRQ {
             kernel().uart.intr();
         } else if irq as usize == VIRTIO0_IRQ {
-            kernel().disk.lock().virtio_intr();
+            kernel().fs().disk.lock().virtio_intr();
         } else if irq != 0 {
             println!("unexpected interrupt irq={}\n", irq);
         }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -1,4 +1,5 @@
 use crate::{
+    fs::DISK,
     kernel::kernel,
     memlayout::{TRAMPOLINE, TRAPFRAME, UART0_IRQ, VIRTIO0_IRQ},
     plic::{plic_claim, plic_complete},
@@ -209,7 +210,7 @@ pub unsafe fn devintr() -> i32 {
         if irq as usize == UART0_IRQ {
             kernel().uart.intr();
         } else if irq as usize == VIRTIO0_IRQ {
-            kernel().fs().disk.lock().virtio_intr();
+            DISK.lock().virtio_intr();
         } else if irq != 0 {
             println!("unexpected interrupt irq={}\n", irq);
         }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -1,5 +1,4 @@
 use crate::{
-    fs::DISK,
     kernel::kernel,
     memlayout::{TRAMPOLINE, TRAPFRAME, UART0_IRQ, VIRTIO0_IRQ},
     plic::{plic_claim, plic_complete},
@@ -210,7 +209,7 @@ pub unsafe fn devintr() -> i32 {
         if irq as usize == UART0_IRQ {
             kernel().uart.intr();
         } else if irq as usize == VIRTIO0_IRQ {
-            DISK.lock().virtio_intr();
+            kernel().file_system.disk.lock().virtio_intr();
         } else if irq != 0 {
             println!("unexpected interrupt irq={}\n", irq);
         }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -204,14 +204,14 @@ pub unsafe fn devintr() -> i32 {
         // This is a supervisor external interrupt, via PLIC.
 
         // irq indicates which device interrupted.
-        let irq: usize = plic_claim();
+        let irq = plic_claim();
 
-        if irq == UART0_IRQ {
+        if irq as usize == UART0_IRQ {
             kernel().uart.intr();
-        } else if irq == VIRTIO0_IRQ {
+        } else if irq as usize == VIRTIO0_IRQ {
             kernel().disk.lock().virtio_intr();
         } else if irq != 0 {
-            println!("unexpected interrupt irq={:018p}\n", irq as *const u8);
+            println!("unexpected interrupt irq={}\n", irq);
         }
 
         // The PLIC allows each device to raise at most one

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -364,7 +364,7 @@ impl InflightInfo {
     }
 }
 
-pub unsafe fn virtio_disk_init1(virtqueue: &mut [RawPage; 2]) {
+pub unsafe fn virtio_disk_init(virtqueue: &mut [RawPage; 2], disk: &mut Disk) {
     let mut status: VirtIOStatus = VirtIOStatus::empty();
     assert!(
         MmioRegs::MagicValue.read() == 0x74726976
@@ -412,14 +412,6 @@ pub unsafe fn virtio_disk_init1(virtqueue: &mut [RawPage; 2]) {
     // avail = pages + 0x40 -- 2 * u16, then num * u16
     // used = pages + 4096 -- 2 * u16, then num * vRingUsedElem
 
-    // disk.desc = DescriptorPool::new(&mut virtqueue[0]);
-    // disk.avail = (virtqueue[0].as_mut_ptr() as *mut VirtqDesc).add(NUM) as _;
-    // disk.used = virtqueue[1].as_mut_ptr() as _;
-
-    // plic.c and trap.c arrange for interrupts from VIRTIO0_IRQ.
-}
-
-pub unsafe fn virtio_disk_init2(virtqueue: &mut [RawPage; 2], disk: &mut Disk) {
     disk.desc = DescriptorPool::new(&mut virtqueue[0]);
     disk.avail = (virtqueue[0].as_mut_ptr() as *mut VirtqDesc).add(NUM) as _;
     disk.used = virtqueue[1].as_mut_ptr() as _;

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -20,7 +20,7 @@ use core::ptr;
 use core::sync::atomic::{fence, Ordering};
 
 use arrayvec::ArrayVec;
-#[derive(Copy, Clone)] // 수정: fs disk때문에 추가한 부분
+
 pub struct Disk {
     desc: DescriptorPool,
     avail: *mut VirtqAvail,
@@ -38,7 +38,6 @@ pub struct Disk {
     ops: [VirtIOBlockOutHeader; NUM],
 }
 
-#[derive(Copy, Clone)]
 struct DescriptorPool {
     desc: *mut [VirtqDesc; NUM],
 

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -20,7 +20,7 @@ use core::ptr;
 use core::sync::atomic::{fence, Ordering};
 
 use arrayvec::ArrayVec;
-
+#[derive(Copy, Clone)] // 수정: fs disk때문에 추가한 부분
 pub struct Disk {
     desc: DescriptorPool,
     avail: *mut VirtqAvail,
@@ -38,6 +38,7 @@ pub struct Disk {
     ops: [VirtIOBlockOutHeader; NUM],
 }
 
+#[derive(Copy, Clone)]
 struct DescriptorPool {
     desc: *mut [VirtqDesc; NUM],
 

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -364,7 +364,7 @@ impl InflightInfo {
     }
 }
 
-pub unsafe fn virtio_disk_init(virtqueue: &mut [RawPage; 2], disk: &mut Disk) {
+pub unsafe fn virtio_disk_init1(virtqueue: &mut [RawPage; 2]) {
     let mut status: VirtIOStatus = VirtIOStatus::empty();
     assert!(
         MmioRegs::MagicValue.read() == 0x74726976
@@ -412,6 +412,14 @@ pub unsafe fn virtio_disk_init(virtqueue: &mut [RawPage; 2], disk: &mut Disk) {
     // avail = pages + 0x40 -- 2 * u16, then num * u16
     // used = pages + 4096 -- 2 * u16, then num * vRingUsedElem
 
+    // disk.desc = DescriptorPool::new(&mut virtqueue[0]);
+    // disk.avail = (virtqueue[0].as_mut_ptr() as *mut VirtqDesc).add(NUM) as _;
+    // disk.used = virtqueue[1].as_mut_ptr() as _;
+
+    // plic.c and trap.c arrange for interrupts from VIRTIO0_IRQ.
+}
+
+pub unsafe fn virtio_disk_init2(virtqueue: &mut [RawPage; 2], disk: &mut Disk) {
     disk.desc = DescriptorPool::new(&mut virtqueue[0]);
     disk.avail = (virtqueue[0].as_mut_ptr() as *mut VirtqDesc).add(NUM) as _;
     disk.used = virtqueue[1].as_mut_ptr() as _;


### PR DESCRIPTION
qemu-system error가 뜨는 상황입니다.
```
hart 1 starting
hart 2 starting
qemu-system-riscv64: virtio: bogus descriptor or out of resources
```

세 가지 방법을 시도해 보았는데 모두 위와 같은 에러가 뜹니다. 혹시 `bogus descriptor or out of resources` 에러에 대한 조언이 있을까요?

---
`Disk`에 Copy, Clone을 추가했습니다.

**Approach 1.**
kernel.rs에서
`pub static mut DISK: Disk = Disk::zero();` 정의
`virtio_disk_init(&mut KERNEL.virtqueue, &mut DISK);` 로 디스크 초기화
Mod.rs에서 
`let disk = unsafe {Sleepablelock::new("virtio_disk", DISK) };`
로 DISK를 받아옴
--> error

**Approach 2.**
kernel.rs에서
```
pub fn kernel_mut() -> &'static mut Kernel {
    unsafe { &mut KERNEL }
}
```
정의
Mod.rs에서
`let mut disk = Sleepablelock::new("virtio_disk", Disk::zero());`
`unsafe { virtio_disk_init(&mut kernel_mut().virtqueue, disk.get_mut()) };`
로 디스크 정의 및 초기화
--> error

**Approach 3.** 
`Kernel`의 `disk`를 `Sleepablelock<Disk>` 대신 `Disk`로 변경
Mod.rs에서
`let disk = Sleepablelock::new("virtio_disk", kernel().disk);`
로 fs에 추가
--> error

draft는 Approach 3코드입니다.