### PR TITLE
Fix: access PLIC in 32-bit.

### DIFF
--- a/README-rv6.md
+++ b/README-rv6.md
@@ -4,8 +4,7 @@
 
   ```
   # Ubuntu 20.04
-  # The latest qemu-system-misc(1:4.2-3ubuntu6.9) can't boot rv6, so please use older version (1:4.2-3ubuntu6)
-  sudo apt install gcc-riscv64-linux-gnu qemu-system-misc=1:4.2-3ubuntu6 gdb-multiarch
+  sudo apt install gcc-riscv64-linux-gnu qemu-system-misc gdb-multiarch
 
   rustup component add rust-src
   ```

--- a/kernel-rs/src/plic.rs
+++ b/kernel-rs/src/plic.rs
@@ -21,14 +21,14 @@ pub unsafe fn plicinithart() {
 }
 
 /// ask the PLIC what interrupt we should serve.
-pub unsafe fn plic_claim() -> usize {
+pub unsafe fn plic_claim() -> u32 {
     let hart: usize = cpuid();
-    let irq: usize = *(plic_sclaim(hart) as *mut usize);
+    let irq: u32 = *(plic_sclaim(hart) as *mut u32);
     irq
 }
 
 /// tell the PLIC we've served this IRQ.
-pub unsafe fn plic_complete(irq: usize) {
+pub unsafe fn plic_complete(irq: u32) {
     let hart: usize = cpuid();
-    *(plic_sclaim(hart) as *mut usize) = irq;
+    *(plic_sclaim(hart) as *mut u32) = irq;
 }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -204,14 +204,14 @@ pub unsafe fn devintr() -> i32 {
         // This is a supervisor external interrupt, via PLIC.
 
         // irq indicates which device interrupted.
-        let irq: usize = plic_claim();
+        let irq = plic_claim();
 
-        if irq == UART0_IRQ {
+        if irq as usize == UART0_IRQ {
             kernel().uart.intr();
-        } else if irq == VIRTIO0_IRQ {
+        } else if irq as usize == VIRTIO0_IRQ {
             kernel().disk.lock().virtio_intr();
         } else if irq != 0 {
-            println!("unexpected interrupt irq={:018p}\n", irq as *const u8);
+            println!("unexpected interrupt irq={}\n", irq);
         }
 
         // The PLIC allows each device to raise at most one


### PR DESCRIPTION
#160 의 root cause를 해결합니다: PLIC MMIO 를 접근할 때 32bit 단위로 접근하도록 수정합니다. 이제 qemu의 최신 버전에서도 정상적으로 작동합니다.

[PLIC spec](https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc) 과 xv6 구현 모두 해당 영역을 32bit 단위로 접근합니다. Rust로 옮기면서 해당 버그가 introduce 된 것 같습니다.