### PR TITLE
Update CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 os: linux
 dist: focal
+language: minimal
+branches:
+    only:
+        - riscv
+        - staging
+        - trying
+
 addons:
   apt:
     packages:
       - gcc-riscv64-linux-gnu
-      - qemu-system-misc=1:4.2-3ubuntu6
+      - qemu-system-misc
 install:
   - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
   - source $HOME/.cargo/env

--- a/kernel-rs/src/poweroff.rs
+++ b/kernel-rs/src/poweroff.rs
@@ -5,15 +5,15 @@ use core::ptr;
 ///
 /// This function uses SiFive Test Finalizer, which provides power management for QEMU virt device.
 pub fn machine_poweroff(exitcode: u16) -> ! {
-    const BASE_CODE: u64 = 0x3333;
-    let code = ((exitcode as u64) << 16) | BASE_CODE;
+    const BASE_CODE: u32 = 0x3333;
+    let code = ((exitcode as u32) << 16) | BASE_CODE;
     // SAFETY:
     // - FINISHER is identically mapped from physical address.
     // - FINISHER is for MMIO. Though this is not specified as document, see the implementation:
     // https://github.com/qemu/qemu/blob/stable-5.0/hw/riscv/virt.c#L60 and,
     // https://github.com/qemu/qemu/blob/stable-5.0/hw/riscv/sifive_test.c#L34
     unsafe {
-        ptr::write_volatile(memlayout::FINISHER as *mut u64, code);
+        ptr::write_volatile(memlayout::FINISHER as *mut u32, code);
     }
 
     unreachable!("Power off failed");


### PR DESCRIPTION
CI 설정을 업데이트합니다.
 - bors 가 생성하는 `staging.tmp` 브랜치에 대한 CI 를 스킵합니다. (이것 때문에 많은 PR 이 성공하는데도 실패로 표기되었습니다)
 - #320 에 따라 테스트에 사용하는 qemu 버전을 최신을 사용하도록 합니다.
 - language 를 minimal로 설정합니다. 설정하지 않은 경우 기본으로 ruby 를 사용하더군요.
 - `poweroff.rs` 도 32bit 크기로 접근하도록 수정했습니다.