### PR TITLE
[#293] bmap_inner: common part of bmap and bmap_or_alloc

### DIFF
--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -98,7 +98,7 @@ impl File {
             FileType::Pipe { pipe } => pipe.read(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
                 let tx = kernel().file_system.begin_transaction();
-                let ip = ip.deref().lock(&tx);
+                let mut ip = ip.deref().lock(&tx);
                 let curr_off = *off.get();
                 let ret = ip.read(addr, curr_off, n as u32);
                 if let Ok(v) = ret {


### PR DESCRIPTION
* `bmap`과 `bmap_or_alloc`을 공통으로 처리하기 위해 `bmap`의 첫 인자를 `&self`에서 다시 `&mut self`로 바꾸었습니다. 이에 따라 `read`또한 `&mut self`를 받습니다.
* #293 에서는 Cursor 사용을 제안했지만, 그렇게 하면 cursor가 `InodeGuard`를 참조하면서 동시에 그 내부를 mutable하게 참조할 수 있어야 해서 cursor를 사용하는 대신 `bmap_inner`라는 메서드를 만들고 `bmap`과 `bmap_or_alloc`이 모두 `bmap_inner`를 호출하게 변경했습니다.
* #292 이전의 코드는 `read`가 immutable하다는 것과 buf를 새로 할당하지 않는다는 것 모두를 나타낼 수 없었고, #292 를 통해 둘 모두를 표현하게 되었습니다. 이 PR은 `read`가 immutable함을 표현하지는 못하지만 buf를 새로 할당하지 않는다는 것을 명시적으로 드러내는 것은 유지합니다. 이로써 코드가 조금 짧아지기는 했으나 이 수정이 좋은 방향인지는 모르겠습니다.