### PR TITLE
[Closes #324] Fix SpinlockProtected::get_mut()'s signature

### DIFF
--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -251,7 +251,7 @@ impl<T> SpinlockProtected<T> {
     /// `SpinlockProtectedGuard` was truely originated from a `SpinlockProtected`
     /// that refers to the same `RawSpinlock`.
     /// TODO: This runtime cost can be removed by using a trait, such as `pub trait SpinlockID {}`.
-    pub fn get_mut<'a: 'a, 'b>(&'a self, guard: &'b mut SpinlockProtectedGuard<'a>) -> &'b mut T {
+    pub fn get_mut<'a: 'b, 'b>(&'a self, guard: &'b mut SpinlockProtectedGuard<'a>) -> &'b mut T {
         assert!(self.lock as *const _ == guard.lock as *const _);
         unsafe { &mut *self.data.get() }
     }

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -250,6 +250,7 @@ impl<T> SpinlockProtected<T> {
     /// This method adds some small runtime cost, since we need to check that the given
     /// `SpinlockProtectedGuard` was truely originated from a `SpinlockProtected`
     /// that refers to the same `RawSpinlock`.
+    /// TODO: This runtime cost can be removed by using a trait, such as `pub trait SpinlockID {}`.
     pub fn get_mut<'a: 'a, 'b>(&'a self, guard: &'b mut SpinlockProtectedGuard<'a>) -> &'b mut T {
         assert!(self.lock as *const _ == guard.lock as *const _);
         unsafe { &mut *self.data.get() }

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -250,8 +250,7 @@ impl<T> SpinlockProtected<T> {
     /// This method adds some small runtime cost, since we need to check that the given
     /// `SpinlockProtectedGuard` was truely originated from a `SpinlockProtected`
     /// that refers to the same `RawSpinlock`.
-    #[allow(clippy::mut_from_ref)]
-    pub fn get_mut<'s>(&self, guard: &'s SpinlockProtectedGuard<'s>) -> &'s mut T {
+    pub fn get_mut<'a: 'a, 'b>(&'a self, guard: &'b mut SpinlockProtectedGuard<'a>) -> &'b mut T {
         assert!(self.lock as *const _ == guard.lock as *const _);
         unsafe { &mut *self.data.get() }
     }


### PR DESCRIPTION
* Closes https://github.com/kaist-cp/rv6/issues/324
* `SpinlockProtected::get_mut()`의 signature를 바꿨습니다. 이제 guard는 &mut 입니다. (교수님 말씀처럼 &self를 &mut self로 바꾸려면 `ProcessSystem`이나 `Kernel`을 &mut로 borrow해야되는 부분들이 생기는 것 같아, guard를 &mut로 바꿨습니다.)

https://github.com/kaist-cp/rv6/blob/7ecf1595d09c76786a290d11038dca129b6f7ce1/kernel-rs/src/spinlock.rs#L253-L257

* 더 이상 아래의 두 코드는 compile되지 않습니다.
```rust
static LOCK: RawSpinlock = RawSpinlock::new("test");

fn test() {
    let v = SpinlockProtected::<i32>::new(&LOCK, 0);
    let mut guard = v.lock();
    
    let w_mut = {
        let w = SpinlockProtected::<i32>::new(&LOCK, 1);
        w.get_mut(&mut guard)
    };

    *w_mut = 2;
}
```
Error: w does not live long enough
```rust
static LOCK: RawSpinlock = RawSpinlock::new("test");

fn test() {
    let v = SpinlockProtected::<i32>::new(&LOCK, 0);
    let mut guard = v.lock();

    let w1 = v.get_mut(&mut guard);
    let w2 = v.get_mut(&mut guard);

    *w1 = 10;
    *w2 = 20;
}
```
Error:  cannot borrow as mutable more than once
* lifetime관련해서 삽질하느라 조금 늦었습니다. 다만, 제가 lifetime에 대해서 그렇게 익숙하지가 않아서 그런데, 혹시 오류가 없는 지 확인해 주실 수 있으신가요? (`SpinlockProtected::get_mut()`만 확인해주시면 될 것 같습니다.) @efenniht @jeehoonkang 그리고 다음부터는 좀 더 조심하겠습니다.