### PR TITLE
[Closes #328] Remove FsTransaction from InodeGuard

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -97,11 +97,11 @@ impl Kernel {
         let mut p: *mut Proc = myproc();
         let mut data = &mut *(*p).data.get();
 
-        let tx = self.file_system.begin_transaction();
-        let ptr = ok_or!(path.namei(&tx), {
+        let _tx = self.file_system.begin_transaction();
+        let ptr = ok_or!(path.namei(), {
             return Err(());
         });
-        let mut ip = ptr.lock(&tx);
+        let mut ip = ptr.lock();
 
         // Check ELF header
         let bytes_read = ip.read(

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -97,6 +97,12 @@ impl Kernel {
         let mut p: *mut Proc = myproc();
         let mut data = &mut *(*p).data.get();
 
+        // TODO(rv6)
+        // The method namei can drop inodes. If namei succeeds, its return
+        // value, ptr, will be dropped when this method returns. Deallocation
+        // of an inode may cause disk write operations, so we must begin a
+        // transaction here.
+        // https://github.com/kaist-cp/rv6/issues/290
         let _tx = self.file_system.begin_transaction();
         let ptr = ok_or!(path.namei(), {
             return Err(());

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -97,8 +97,7 @@ impl File {
         match &self.typ {
             FileType::Pipe { pipe } => pipe.read(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
-                let tx = kernel().file_system.begin_transaction();
-                let mut ip = ip.deref().lock(&tx);
+                let mut ip = ip.deref().lock();
                 let curr_off = *off.get();
                 let ret = ip.read(addr, curr_off, n as u32);
                 if let Ok(v) = ret {
@@ -140,13 +139,14 @@ impl File {
                 while bytes_written < n as usize {
                     let bytes_to_write = cmp::min(n as usize - bytes_written, max);
                     let tx = kernel().file_system.begin_transaction();
-                    let mut ip = ip.deref().lock(&tx);
+                    let mut ip = ip.deref().lock();
                     let curr_off = *off.get();
                     let r = ip
                         .write(
                             addr + bytes_written as usize,
                             curr_off,
                             bytes_to_write as u32,
+                            &tx,
                         )
                         .map(|v| {
                             *off.get() = curr_off.wrapping_add(v as u32);

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -180,6 +180,11 @@ impl ArenaObject for File {
             match typ {
                 FileType::Pipe { mut pipe } => unsafe { pipe.close(self.writable) },
                 FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
+                    // TODO(rv6)
+                    // The inode ip will be dropped by drop(ip). Deallocation
+                    // of an inode may cause disk write operations, so we must
+                    // begin a transaction here.
+                    // https://github.com/kaist-cp/rv6/issues/290
                     let _tx = kernel().file_system.begin_transaction();
                     drop(ip);
                 }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -523,7 +523,7 @@ impl ArenaObject for Inode {
 impl Inode {
     /// Lock the given inode.
     /// Reads the inode from disk if necessary.
-    pub fn lock<'x>(&'x self) -> InodeGuard<'x> {
+    pub fn lock(&self) -> InodeGuard<'_> {
         let mut guard = self.inner.lock();
         if !guard.valid {
             let mut bp = kernel().file_system.disk.read(

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -448,7 +448,7 @@ impl InodeGuard<'_> {
         if bn < NDIRECT {
             let mut addr = inner.addr_direct[bn];
             if addr == 0 {
-                addr = unsafe { tx_opt.unwrap().balloc(self.dev) };
+                addr = unsafe { tx_opt.expect("bmap: out of range").balloc(self.dev) };
                 self.deref_inner_mut().addr_direct[bn] = addr;
             }
             addr
@@ -458,7 +458,7 @@ impl InodeGuard<'_> {
 
             let mut indirect = inner.addr_indirect;
             if indirect == 0 {
-                indirect = unsafe { tx_opt.unwrap().balloc(self.dev) };
+                indirect = unsafe { tx_opt.expect("bmap: out of range").balloc(self.dev) };
                 self.deref_inner_mut().addr_indirect = indirect;
             }
 
@@ -467,7 +467,7 @@ impl InodeGuard<'_> {
             debug_assert_eq!(prefix.len(), 0, "bmap: Buf data unaligned");
             let mut addr = data[bn];
             if addr == 0 {
-                let tx = tx_opt.unwrap();
+                let tx = tx_opt.expect("bmap: out of range");
                 addr = unsafe { tx.balloc(self.dev) };
                 data[bn] = addr;
                 unsafe { tx.write(bp) };

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -466,6 +466,11 @@ impl ProcData {
         for file in &mut self.open_files {
             *file = None;
         }
+        // TODO(rv6)
+        // If self.cwd is not None, the inode inside self.cwd will be dropped
+        // by assigning None to self.cwd. Deallocation of an inode may cause
+        // disk write operations, so we must begin a transaction here.
+        // https://github.com/kaist-cp/rv6/issues/290
         let _tx = kernel().file_system.begin_transaction();
         self.cwd = None;
     }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -299,6 +299,12 @@ impl Kernel {
         let p: *mut Proc = myproc();
         let mut data = &mut *(*p).data.get();
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
+        // TODO(rv6)
+        // The method namei can drop inodes. If namei succeeds, its return
+        // value, ptr, will be dropped when this method returns. Deallocation
+        // of an inode may cause disk write operations, so we must begin a
+        // transaction here.
+        // https://github.com/kaist-cp/rv6/issues/290
         let _tx = self.file_system.begin_transaction();
         let ptr = ok_or!(Path::new(path).namei(), return usize::MAX);
         let ip = ptr.lock();


### PR DESCRIPTION
Closes #328

* `InodeGuard`의 `tx: &FsTransaction` 필드를 없애고 `InodeGuard`의 메서드 중 `FsTransaction`이 필요한 메서드만 명시적으로 `FsTransaction`을 인자로 받도록 수정했습니다.
* `exec.rs`의 `exec`와 `sysfile.rs`의 `sys_chdir`은 `FsTransaction`을 사용하지는 않지만 할당되어 있던 inode를 해제할 수 있기 때문에 `begin_transaction`을 호출합니다. 이는 기존 C 코드에서 `begin_op`를 호출하는 것에 합치합니다. 반면, `file.rs`의 `read`는 더 이상 `begin_transaction`을 호출하지 않으며 이 역시 기존 C 코드에서 `begin_op`를 호출하지 않는 것에 합치합니다.