### PR TITLE
[Closes #295] Replace freeproc(), proc_freepagetable() with ProcGuard::drop(), PageTable<UVAddr>::drop()

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -121,9 +121,7 @@ impl Kernel {
 
         let pt = PageTable::<UVAddr>::new(data.trapframe).ok_or(())?;
 
-        let mut ptable_guard = scopeguard::guard((pt, sz), |(mut pt, _)| {
-            pt.drop();
-        });
+        let mut ptable_guard = scopeguard::guard((pt, sz), |(_, _)| {});
 
         let (pt, sz) = &mut *ptable_guard;
         // Load program into memory.
@@ -236,7 +234,7 @@ impl Kernel {
             );
 
             // Commit to the user image.
-            let mut oldpagetable = mem::replace(&mut data.pagetable, pt);
+            data.pagetable = pt;
             data.sz = sz;
 
             // initial program counter = main
@@ -244,7 +242,6 @@ impl Kernel {
 
             // initial stack pointer
             (*data.trapframe).sp = sp;
-            oldpagetable.drop();
 
             // this ends up in a0, the first argument to main(argc, argv)
             return Ok(argc);

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -90,7 +90,7 @@ impl ProgHdr {
 
 impl Kernel {
     pub unsafe fn exec(&self, path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
-        let sz: usize = 0;
+        let mut sz: usize;
         let mut ustack = [0usize; MAXARG + 1];
         let mut elf: ElfHdr = Default::default();
         let mut ph: ProgHdr = Default::default();
@@ -119,13 +119,10 @@ impl Kernel {
             return Err(());
         }
 
-        let pt = PageTable::<UVAddr>::new(data.trapframe).ok_or(())?;
+        let mut pt = PageTable::<UVAddr>::new(data.trapframe).ok_or(())?;
 
-        let mut ptable_guard = scopeguard::guard((pt, sz), |(_, _)| {});
-
-        let (pt, sz) = &mut *ptable_guard;
         // Load program into memory.
-        *sz = 0;
+        sz = 0;
         for i in 0..elf.phnum as usize {
             let off = elf.phoff.wrapping_add(i * mem::size_of::<ProgHdr>());
 
@@ -144,13 +141,13 @@ impl Kernel {
                 if ph.vaddr.wrapping_add(ph.memsz) < ph.vaddr {
                     return Err(());
                 }
-                let sz1 = pt.alloc(*sz, ph.vaddr.wrapping_add(ph.memsz))?;
-                *sz = sz1;
+                let sz1 = pt.alloc(sz, ph.vaddr.wrapping_add(ph.memsz))?;
+                sz = sz1;
                 if ph.vaddr.wrapping_rem(PGSIZE) != 0 {
                     return Err(());
                 }
                 loadseg(
-                    pt,
+                    &mut pt,
                     UVAddr::new(ph.vaddr),
                     &mut ip,
                     ph.off as u32,
@@ -164,12 +161,12 @@ impl Kernel {
 
         // Allocate two pages at the next page boundary.
         // Use the second as the user stack.
-        *sz = sz.wrapping_add(PGSIZE).wrapping_sub(1) & !PGSIZE.wrapping_sub(1);
+        sz = sz.wrapping_add(PGSIZE).wrapping_sub(1) & !PGSIZE.wrapping_sub(1);
 
-        let sz1 = pt.alloc(*sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)))?;
-        *sz = sz1;
+        let sz1 = pt.alloc(sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)))?;
+        sz = sz1;
         pt.clear(UVAddr::new(sz.wrapping_sub(2usize.wrapping_mul(PGSIZE))));
-        let mut sp: usize = *sz;
+        let mut sp: usize = sz;
         let stackbase: usize = sp.wrapping_sub(PGSIZE);
 
         // Push argument strings, prepare rest of stack in ustack.
@@ -212,7 +209,6 @@ impl Kernel {
                 )
                 .is_ok()
         {
-            let (pt, sz) = scopeguard::ScopeGuard::into_inner(ptable_guard);
             // arguments to user main(argc, argv)
             // argc is returned via the system call return
             // value, which goes in a0.

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -90,7 +90,6 @@ impl ProgHdr {
 
 impl Kernel {
     pub unsafe fn exec(&self, path: &Path, argv: &[*mut u8]) -> Result<usize, ()> {
-        let mut sz: usize;
         let mut ustack = [0usize; MAXARG + 1];
         let mut elf: ElfHdr = Default::default();
         let mut ph: ProgHdr = Default::default();
@@ -122,7 +121,7 @@ impl Kernel {
         let mut pt = PageTable::<UVAddr>::new(data.trapframe).ok_or(())?;
 
         // Load program into memory.
-        sz = 0;
+        let mut sz = 0;
         for i in 0..elf.phnum as usize {
             let off = elf.phoff.wrapping_add(i * mem::size_of::<ProgHdr>());
 

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -141,8 +141,7 @@ impl Kernel {
                 if ph.vaddr.wrapping_add(ph.memsz) < ph.vaddr {
                     return Err(());
                 }
-                let sz1 = pt.alloc(sz, ph.vaddr.wrapping_add(ph.memsz))?;
-                sz = sz1;
+                sz = pt.alloc(sz, ph.vaddr.wrapping_add(ph.memsz))?;
                 if ph.vaddr.wrapping_rem(PGSIZE) != 0 {
                     return Err(());
                 }
@@ -162,9 +161,7 @@ impl Kernel {
         // Allocate two pages at the next page boundary.
         // Use the second as the user stack.
         sz = sz.wrapping_add(PGSIZE).wrapping_sub(1) & !PGSIZE.wrapping_sub(1);
-
-        let sz1 = pt.alloc(sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)))?;
-        sz = sz1;
+        sz = pt.alloc(sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)))?;
         pt.clear(UVAddr::new(sz.wrapping_sub(2usize.wrapping_mul(PGSIZE))));
         let mut sp: usize = sz;
         let stackbase: usize = sp.wrapping_sub(PGSIZE);

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -125,7 +125,7 @@ impl Kernel {
 
     /// Allocate one 4096-byte page of physical memory.
     /// Returns a pointer that the kernel can use.
-    /// Returns 0 if the memory cannot be allocated.
+    /// Returns None if the memory cannot be allocated.
     pub fn alloc(&self) -> Option<Page> {
         let mut page = kernel().kmem.lock().alloc()?;
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -395,9 +395,6 @@ impl ProcGuard {
             kernel().free(Page::from_usize(data.trapframe as _));
         }
         data.trapframe = ptr::null_mut();
-        let mut page_table = PageTable::zero();
-        mem::swap(&mut data.pagetable, &mut page_table);
-        page_table.drop();
         data.pagetable = PageTable::zero();
         data.sz = 0;
 
@@ -422,8 +419,7 @@ impl Drop for ProcGuard {
             if self.deref_info().state == Procstate::USED && (*self.data.get()).sz == 0 {
                 self.freeproc(None);
             }
-            let proc = &*self.ptr;
-            proc.info.unlock();
+            (*self.ptr).info.unlock();
         }
     }
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -207,7 +207,8 @@ pub enum Procstate {
     RUNNABLE,
     SLEEPING,
     UNUSED,
-    USED,
+    WIP1,
+    WIP2,
 }
 
 pub struct WaitChannel {
@@ -379,11 +380,44 @@ impl ProcGuard {
         );
         (*kernel().mycpu()).interrupt_enabled = interrupt_enabled;
     }
+
+    /// Frees a `Proc` structure and the data hanging from it, including user pages.
+    /// Must provide a `ProcGuard`, and optionally, you can also provide a `SpinlockProtectedGuard`
+    /// if you also want to clear `p`'s parent field into `ptr::null_mut()`.
+    ///
+    /// # Note
+    ///
+    /// If a `SpinlockProtectedGuard` was not provided, `p`'s parent field is not modified.
+    /// Note that this is because accessing a parent field without a `SpinlockProtectedGuard` is illegal.
+    unsafe fn freeproc(&mut self, parent_guard: Option<SpinlockProtectedGuard<'_>>) {
+        let mut data = &mut *self.data.get();
+        if !data.trapframe.is_null() {
+            kernel().free(Page::from_usize(data.trapframe as _));
+        }
+        data.trapframe = ptr::null_mut();
+        let mut page_table = PageTable::zero();
+        mem::swap(&mut data.pagetable, &mut page_table);
+        proc_freepagetable(page_table, data.sz);
+        data.pagetable = PageTable::zero();
+        data.sz = 0;
+        if let Some(mut guard) = parent_guard {
+            *(*self).parent.assume_init_mut().get_mut(&mut guard) = ptr::null_mut();
+        }
+        self.deref_mut_info().pid = 0;
+        (*self).name[0] = 0;
+        self.deref_mut_info().waitchannel = ptr::null();
+        self.killed = AtomicBool::new(false);
+        self.deref_mut_info().xstate = 0;
+        self.deref_mut_info().state = Procstate::UNUSED;
+    }
 }
 
 impl Drop for ProcGuard {
     fn drop(&mut self) {
         unsafe {
+            if self.deref_info().state == Procstate::WIP1 {
+                self.freeproc(None);
+            }
             let proc = &*self.ptr;
             proc.info.unlock();
         }
@@ -439,7 +473,8 @@ impl Context {
 impl Procstate {
     fn to_str(&self) -> &'static str {
         match self {
-            Procstate::USED => "used",
+            Procstate::WIP1 => "work in progress: step 1",
+            Procstate::WIP2 => "work in progress: step 2",
             Procstate::UNUSED => "unused",
             Procstate::SLEEPING => "sleep ",
             Procstate::RUNNABLE => "runble",
@@ -565,18 +600,16 @@ impl ProcessSystem {
             if guard.deref_info().state == Procstate::UNUSED {
                 let data = &mut *guard.data.get();
                 guard.deref_mut_info().pid = self.allocpid();
-                guard.deref_mut_info().state = Procstate::USED;
+                guard.deref_mut_info().state = Procstate::WIP1;
 
                 // Allocate a trapframe page.
                 let page = some_or!(kernel().alloc(), {
-                    freeproc(guard, None);
                     return Err(());
                 });
                 data.trapframe = page.into_usize() as *mut Trapframe;
 
                 // An empty user page table.
                 data.pagetable = some_or!(PageTable::<UVAddr>::new(data.trapframe), {
-                    freeproc(guard, None);
                     return Err(());
                 });
 
@@ -684,7 +717,6 @@ impl ProcessSystem {
             .copy(&mut npdata.pagetable, pdata.sz)
             .is_err()
         {
-            freeproc(np, None);
             return -1;
         }
         npdata.sz = pdata.sz;
@@ -711,12 +743,20 @@ impl ProcessSystem {
 
         let pid = np.deref_mut_info().pid;
 
+        // Change the process's state to WIP2, so that the destructor doesn't
+        // free the process.
+        np.deref_mut_info().state = Procstate::WIP2;
+
+        // Now drop the guard before we acquire the `wait_lock`.
+        // This is because the lock order must be `wait_lock` -> `Proc::info`.
         let child = np.raw();
         drop(np);
 
+        // Acquire the `wait_lock`, and write the parent field.
         let mut parent_guard = (*child).parent.assume_init_ref().lock();
         *(*child).parent.assume_init_ref().get_mut(&mut parent_guard) = p;
 
+        // Set the process's state to RUNNABLE.
         let mut np = (*child).lock();
         np.deref_mut_info().state = Procstate::RUNNABLE;
 
@@ -737,6 +777,7 @@ impl ProcessSystem {
             let mut havekids = false;
             for np in &self.process_pool {
                 if *np.parent.assume_init_ref().get_mut(&mut parent_guard) == p {
+                    // Found a child.
                     // Make sure the child isn't still in exit() or swtch().
                     let mut np = np.lock();
 
@@ -759,7 +800,8 @@ impl ProcessSystem {
                             drop(np);
                             return -1;
                         }
-                        freeproc(np, Some(parent_guard));
+                        // Reap the zombie child process.
+                        np.freeproc(Some(parent_guard));
                         return pid;
                     }
                 }
@@ -861,36 +903,6 @@ pub unsafe fn myproc() -> *mut Proc {
     let p = (*c).proc;
     pop_off();
     p
-}
-
-/// Frees a `Proc` structure and the data hanging from it, including user pages.
-/// Must provide a `ProcGuard`, and optionally, you can also provide a `SpinlockProtectedGuard`
-/// if you also want to clear `p`'s parent field into `ptr::null_mut()`.
-///
-/// # Note
-///
-/// If a `SpinlockProtectedGuard` was not provided, `p`'s parent field is not modified.
-/// Note that this is because accessing a parent field without a `SpinlockProtectedGuard` is illegal.
-unsafe fn freeproc(mut p: ProcGuard, parent_guard: Option<SpinlockProtectedGuard<'_>>) {
-    let mut data = &mut *p.data.get();
-    if !data.trapframe.is_null() {
-        kernel().free(Page::from_usize(data.trapframe as _));
-    }
-    data.trapframe = ptr::null_mut();
-    let mut page_table = PageTable::zero();
-    mem::swap(&mut data.pagetable, &mut page_table);
-    proc_freepagetable(page_table, data.sz);
-    data.pagetable = PageTable::zero();
-    data.sz = 0;
-    if let Some(mut guard) = parent_guard {
-        *(*p).parent.assume_init_mut().get_mut(&mut guard) = ptr::null_mut();
-    }
-    p.deref_mut_info().pid = 0;
-    (*p).name[0] = 0;
-    p.deref_mut_info().waitchannel = ptr::null();
-    p.killed = AtomicBool::new(false);
-    p.deref_mut_info().xstate = 0;
-    p.deref_mut_info().state = Procstate::UNUSED;
 }
 
 /// Free a process's page table, and free the

--- a/kernel-rs/src/riscv.rs
+++ b/kernel-rs/src/riscv.rs
@@ -380,7 +380,7 @@ pub const fn pte_flags(pte: PteT) -> usize {
 pub const PXMASK: usize = 0x1ff;
 
 #[inline]
-fn pxshift(level: usize) -> usize {
+pub fn pxshift(level: usize) -> usize {
     PGSHIFT + 9 * level
 }
 


### PR DESCRIPTION
* Closes https://github.com/kaist-cp/rv6/issues/295

1번
* **이제 `freeproc()`을 직접 call해야되는 경우는 `ProcessSystem::wait()`에서 `ZOMBIE` 상태의 child process을 reap하고 싶을 때 뿐입니다.** 그 외에는 `Process`의 `state`가 `STARTING1`인 경우, `ProcGuard::drop()`할때 알아서 call됩니다.
* `freeproc()`은 이제 `ProcGuard`의 method 중 하나입니다.
* 추가로, `STARTING1`과 `STARTING2`라는 새로운 state를 추가했습니다. 굳이 2개나 추가한 이유는 `ProcessSystem::fork()`때문입니다. (아래 코드의 주석 참고. 아주 잠깐동안 `ProcGuard`이 drop되는 부분이 있습니다.).
	* `ProcessSystem::fork()`을 시작하자마자 `wait_lock`을 acquire하도록 변경한다면 굳이 2개일 필요가 없어지지만, 이러면 critical section의 길이가 길어지고 xv6이랑 약간 달라지는 것 같아 일단은 놔뒀습니다.

2번
* **proc_freepagetable을 `PageTable<UVAddr>::drop()`로 대체**했고, 지저분한 부분들을 조금 정리했습니다.(proc_freepagetable은 더 이상 사용되진 않지만 일단 놔뒀습니다.)
* 이를 위해, `PageTable`에 `num_usr_pages`라는 field를 추가했습니다. (`ProcData::sz`는 그대로 놔뒀습니다.)
* 다만, **`Drop` trait을 추가했다는 뜻이 아니라 그냥 `drop()`라는 함수를 추가했다는 뜻입니다.**
	* `Drop` trait을 추가하면 좋을텐데, 현재 Rust에서는 특정 generic type만을 위한 Drop을 만들수가 없어서 이렇게까지 밖에 하지 못했습니다. 혹시 다른 방법이 있으면 말씀해주시면 감사하겠습니다. @jeehoonkang @efenniht 
	* 차라리 PageTable<UVAddr>만을 위한 새로운 wrapper을 만들까요?