### PR TITLE
[closes #332] split sys_* functions into fetch part and helper function

### DIFF
--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -203,11 +203,18 @@ impl FileTable {
     }
 
     /// Allocate a file structure.
-    pub fn alloc_file(&self, typ: FileType, readable: bool, writable: bool) -> Result<RcFile<'_>, ()> {
+    pub fn alloc_file(
+        &self,
+        typ: FileType,
+        readable: bool,
+        writable: bool,
+    ) -> Result<RcFile<'_>, ()> {
         // TODO: idiomatic initialization.
-        let inner = self.alloc(|p| {
-            *p = File::new(typ, readable, writable);
-        }).ok_or(())?;
+        let inner = self
+            .alloc(|p| {
+                *p = File::new(typ, readable, writable);
+            })
+            .ok_or(())?;
 
         Ok(unsafe { Rc::from_unchecked(self, inner) })
     }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -203,12 +203,12 @@ impl FileTable {
     }
 
     /// Allocate a file structure.
-    pub fn alloc_file(&self, typ: FileType, readable: bool, writable: bool) -> Option<RcFile<'_>> {
+    pub fn alloc_file(&self, typ: FileType, readable: bool, writable: bool) -> Result<RcFile<'_>, ()> {
         // TODO: idiomatic initialization.
         let inner = self.alloc(|p| {
             *p = File::new(typ, readable, writable);
-        })?;
+        }).ok_or(())?;
 
-        Some(unsafe { Rc::from_unchecked(self, inner) })
+        Ok(unsafe { Rc::from_unchecked(self, inner) })
     }
 }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -455,7 +455,7 @@ impl InodeGuard<'_> {
         // Write the i-node back to disk even if the size didn't change
         // because the loop above might have called bmap() and added a new
         // block to self->addrs[].
-        // TODO(rv6): Need to check the safety of InodeGuard::update
+        // TODO(rv6): Need to check the safety of InodeGuard::update()
         unsafe {
             self.update(tx);
         }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -455,6 +455,7 @@ impl InodeGuard<'_> {
         // Write the i-node back to disk even if the size didn't change
         // because the loop above might have called bmap() and added a new
         // block to self->addrs[].
+        // TODO(rv6): Need to check the safety of InodeGuard::update
         unsafe {
             self.update(tx);
         }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -512,7 +512,7 @@ impl InodeGuard<'_> {
     }
 
     /// Is the directory dp empty except for "." and ".." ?
-    pub unsafe fn isdirempty(&mut self) -> bool {
+    pub fn isdirempty(&mut self) -> bool {
         let mut de: Dirent = Default::default();
         for off in (2 * DIRENT_SIZE as u32..self.deref_inner().size).step_by(DIRENT_SIZE) {
             let bytes_read = self.read(

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -681,7 +681,6 @@ impl Itable {
                 .file_system
                 .disk
                 .read(dev, kernel().file_system.superblock().iblock(inum));
-            // TODO: unsafe block
             let dip = (bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
                 .add((inum as usize).wrapping_rem(IPB));
 

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -681,6 +681,7 @@ impl Itable {
                 .file_system
                 .disk
                 .read(dev, kernel().file_system.superblock().iblock(inum));
+            // TODO: unsafe block
             let dip = (bp.deref_mut_inner().data.as_mut_ptr() as *mut Dinode)
                 .add((inum as usize).wrapping_rem(IPB));
 

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -512,7 +512,7 @@ impl InodeGuard<'_> {
     }
 
     /// Is the directory dp empty except for "." and ".." ?
-    pub fn isdirempty(&mut self) -> bool {
+    pub fn is_dir_empty(&mut self) -> bool {
         let mut de: Dirent = Default::default();
         for off in (2 * DIRENT_SIZE as u32..self.deref_inner().size).step_by(DIRENT_SIZE) {
             let bytes_read = self.read(
@@ -520,7 +520,7 @@ impl InodeGuard<'_> {
                 off as u32,
                 DIRENT_SIZE as u32,
             );
-            assert_eq!(bytes_read, Ok(DIRENT_SIZE), "isdirempty: readi");
+            assert_eq!(bytes_read, Ok(DIRENT_SIZE), "is_dir_empty: readi");
             if de.inum != 0 {
                 return false;
             }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -455,7 +455,6 @@ impl InodeGuard<'_> {
         // Write the i-node back to disk even if the size didn't change
         // because the loop above might have called bmap() and added a new
         // block to self->addrs[].
-        // TODO(rv6): Need to check the safety of InodeGuard::update()
         unsafe {
             self.update(tx);
         }

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -139,7 +139,7 @@ impl Path {
         let mut ptr = if self.is_absolute() {
             Self::root()
         } else {
-            // TODO(rv6): accessing proc.data shoud be safe after refactoring myproc()
+            // TODO(rv6): accessing proc.data should be safe after refactoring myproc()
             unsafe { (*(*myproc()).data.get()).cwd.clone().unwrap() }
         };
 

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -140,7 +140,7 @@ impl Path {
             Self::root()
         } else {
             // TODO(rv6): accessing proc.data shoud be safe after refactoring myproc()
-            unsafe{(*(*myproc()).data.get()).cwd.clone().unwrap()}
+            unsafe { (*(*myproc()).data.get()).cwd.clone().unwrap() }
         };
 
         let mut path = self;

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -1,4 +1,12 @@
-use crate::{file::{FileType, RcFile}, kernel::kernel, ok_or, page::Page, proc::{myproc, WaitChannel}, spinlock::Spinlock, vm::UVAddr};
+use crate::{
+    file::{FileType, RcFile},
+    kernel::kernel,
+    ok_or,
+    page::Page,
+    proc::{myproc, WaitChannel},
+    spinlock::Spinlock,
+    vm::UVAddr,
+};
 use core::ops::Deref;
 
 const PIPESIZE: usize = 512;
@@ -125,14 +133,24 @@ impl AllocatedPipe {
             read_waitchannel: WaitChannel::new(),
             write_waitchannel: WaitChannel::new(),
         };
-        let f0 = ok_or!(kernel()
-            .ftable
-            .alloc_file(FileType::Pipe { pipe: Self { ptr } }, true, false)
-            , {kernel().free(Page::from_usize(ptr as _)); return Err(())});
-        let f1 = ok_or!(kernel()
-            .ftable
-            .alloc_file(FileType::Pipe { pipe: Self { ptr } }, false, true)
-            ,{kernel().free(Page::from_usize(ptr as _)); return Err(())});
+        let f0 = ok_or!(
+            kernel()
+                .ftable
+                .alloc_file(FileType::Pipe { pipe: Self { ptr } }, true, false),
+            {
+                kernel().free(Page::from_usize(ptr as _));
+                return Err(());
+            }
+        );
+        let f1 = ok_or!(
+            kernel()
+                .ftable
+                .alloc_file(FileType::Pipe { pipe: Self { ptr } }, false, true),
+            {
+                kernel().free(Page::from_usize(ptr as _));
+                return Err(());
+            }
+        );
 
         Ok((f0, f1))
     }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -139,17 +139,17 @@ impl AllocatedPipe {
                 .alloc_file(FileType::Pipe { pipe: Self { ptr } }, true, false),
             {
                 kernel().free(Page::from_usize(ptr as _));
-                return Err(())
+                return Err(());
             }
         );
         let f1 = ok_or!(
             kernel()
                 .ftable
                 .alloc_file(FileType::Pipe { pipe: Self { ptr } }, false, true),
-                {
-                    kernel().free(Page::from_usize(ptr as _));
-                    return Err(())
-                }
+            {
+                kernel().free(Page::from_usize(ptr as _));
+                return Err(());
+            }
         );
 
         Ok((f0, f1))

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -136,7 +136,6 @@ impl AllocatedPipe {
             .ftable
             .alloc_file(FileType::Pipe { pipe: Self { ptr } }, true, false)
             .map_err(|_| kernel().free(Page::from_usize(ptr as _)))?;
-
         let f1 = kernel()
             .ftable
             .alloc_file(FileType::Pipe { pipe: Self { ptr } }, false, true)

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -137,13 +137,19 @@ impl AllocatedPipe {
             kernel()
                 .ftable
                 .alloc_file(FileType::Pipe { pipe: Self { ptr } }, true, false),
-            return Err(kernel().free(Page::from_usize(ptr as _)))
+            {
+                kernel().free(Page::from_usize(ptr as _));
+                return Err(())
+            }
         );
         let f1 = ok_or!(
             kernel()
                 .ftable
                 .alloc_file(FileType::Pipe { pipe: Self { ptr } }, false, true),
-            return Err(kernel().free(Page::from_usize(ptr as _)))
+                {
+                    kernel().free(Page::from_usize(ptr as _));
+                    return Err(())
+                }
         );
 
         Ok((f0, f1))

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -137,19 +137,13 @@ impl AllocatedPipe {
             kernel()
                 .ftable
                 .alloc_file(FileType::Pipe { pipe: Self { ptr } }, true, false),
-            {
-                kernel().free(Page::from_usize(ptr as _));
-                return Err(());
-            }
+            return Err(kernel().free(Page::from_usize(ptr as _)))
         );
         let f1 = ok_or!(
             kernel()
                 .ftable
                 .alloc_file(FileType::Pipe { pipe: Self { ptr } }, false, true),
-            {
-                kernel().free(Page::from_usize(ptr as _));
-                return Err(());
-            }
+            return Err(kernel().free(Page::from_usize(ptr as _)))
         );
 
         Ok((f0, f1))

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -3,11 +3,11 @@ use crate::{
     kernel::kernel,
     page::Page,
     proc::{myproc, WaitChannel},
+    riscv::PGSIZE,
     spinlock::Spinlock,
     vm::UVAddr,
-    riscv::PGSIZE,
 };
-use core::{ops::Deref, ptr, mem};
+use core::{mem, ops::Deref, ptr};
 
 const PIPESIZE: usize = 512;
 
@@ -125,20 +125,23 @@ impl AllocatedPipe {
         // It is safe because unique access to page is guaranteed since page is just allocated,
         // and the pipe size and alignment are compatible with the page.
         unsafe {
-            ptr::write(ptr, Pipe {
-                inner: Spinlock::new(
-                    "pipe",
-                    PipeInner {
-                        data: [0; PIPESIZE],
-                        nwrite: 0,
-                        nread: 0,
-                        readopen: true,
-                        writeopen: true,
-                    },
-                ),
-                read_waitchannel: WaitChannel::new(),
-                write_waitchannel: WaitChannel::new(),
-            });
+            ptr::write(
+                ptr,
+                Pipe {
+                    inner: Spinlock::new(
+                        "pipe",
+                        PipeInner {
+                            data: [0; PIPESIZE],
+                            nwrite: 0,
+                            nread: 0,
+                            readopen: true,
+                            writeopen: true,
+                        },
+                    ),
+                    read_waitchannel: WaitChannel::new(),
+                    write_waitchannel: WaitChannel::new(),
+                },
+            );
         };
         let f0 = kernel()
             .ftable

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -651,6 +651,7 @@ impl ProcessSystem {
     /// Kill the process with the given pid.
     /// The victim won't exit until it tries to return
     /// to user space (see usertrap() in trap.c).
+    /// Returns Ok(()) on success, Err(()) on error.
     pub fn kill(&self, pid: i32) -> Result<(), ()> {
         for p in &self.process_pool {
             let mut guard = p.lock();
@@ -707,6 +708,7 @@ impl ProcessSystem {
 
     /// Create a new process, copying the parent.
     /// Sets up child kernel stack to return as if from fork() system call.
+    /// Returns Ok(new process id) on success, Err(()) on error.
     pub unsafe fn fork(&self) -> Result<i32, ()> {
         let p = myproc();
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -716,13 +716,7 @@ impl ProcessSystem {
         let pdata = &mut *(*p).data.get();
         let mut npdata = &mut *np.data.get();
         // Copy user memory from parent to child.
-        if pdata
-            .pagetable
-            .copy(&mut npdata.pagetable, pdata.sz)
-            .is_err()
-        {
-            return Err(());
-        }
+        pdata.pagetable.copy(&mut npdata.pagetable, pdata.sz)?;
         npdata.sz = pdata.sz;
 
         // Copy saved user registers.

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -793,7 +793,6 @@ impl ProcessSystem {
                                 )
                                 .is_err()
                         {
-                            drop(np);
                             return Err(());
                         }
                         // Reap the zombie child process.

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -651,13 +651,13 @@ impl ProcessSystem {
     /// Kill the process with the given pid.
     /// The victim won't exit until it tries to return
     /// to user space (see usertrap() in trap.c).
-    pub fn kill(&self, pid: i32) -> Result<i32, ()> {
+    pub fn kill(&self, pid: i32) -> Result<(), ()> {
         for p in &self.process_pool {
             let mut guard = p.lock();
             if guard.deref_info().pid == pid {
                 p.kill();
                 guard.wakeup();
-                return Ok(0);
+                return Ok(());
             }
         }
         Err(())

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::Kernel,
-    ok_or, println,
+    println,
     proc::myproc,
     vm::{UVAddr, VAddr},
 };
@@ -69,12 +69,12 @@ pub unsafe fn argstr(n: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
 }
 
 impl Kernel {
-    pub unsafe fn syscall(&'static self) {
+    pub unsafe fn syscall(&'static self) -> Result<usize, ()> {
         let p = myproc();
-        let mut data = &mut *(*p).data.get();
+        let data = &mut *(*p).data.get();
         let num = (*data.trapframe).a7 as i32;
 
-        let result = match num {
+        match num {
             1 => self.sys_fork(),
             2 => self.sys_exit(),
             3 => self.sys_wait(),
@@ -106,8 +106,6 @@ impl Kernel {
                 );
                 Err(())
             }
-        };
-
-        (*data.trapframe).a0 = ok_or!(result, usize::MAX);
+        }
     }
 }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::Kernel,
-    println,
+    ok_or, println,
     proc::myproc,
     vm::{UVAddr, VAddr},
 };
@@ -102,10 +102,10 @@ impl Kernel {
                     str::from_utf8(&(*p).name).unwrap_or("???"),
                     num
                 );
-                usize::MAX
+                Err(())
             }
         };
 
-        (*data.trapframe).a0 = result;
+        (*data.trapframe).a0 = ok_or!(result, usize::MAX);
     }
 }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -8,20 +8,21 @@ use core::{mem, slice, str};
 use cstr_core::CStr;
 
 /// Fetch the usize at addr from the current process.
-/// Returns Ok(()) on success, Err(()) on error.
-pub unsafe fn fetchaddr(addr: UVAddr, ip: *mut usize) -> Result<(), ()> {
+/// Returns Ok(ip) on success, Err(()) on error.
+pub unsafe fn fetchaddr(addr: UVAddr) -> Result<usize, ()> {
     let p = myproc();
     let data = &mut *(*p).data.get();
+    let mut ip = 0;
     if addr.into_usize() >= data.sz
         || addr.into_usize().wrapping_add(mem::size_of::<usize>()) > data.sz
     {
         return Err(());
     }
     data.pagetable.copy_in(
-        slice::from_raw_parts_mut(ip as *mut u8, mem::size_of::<usize>()),
+        slice::from_raw_parts_mut(&mut ip as *mut usize as *mut u8, mem::size_of::<usize>()),
         addr,
     )?;
-    Ok(())
+    Ok(ip)
 }
 
 /// Fetch the nul-terminated string at addr from the current process.

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -72,7 +72,7 @@ impl Kernel {
     pub unsafe fn syscall(&'static self) {
         let p = myproc();
         let mut data = &mut *(*p).data.get();
-        let num: i32 = (*data.trapframe).a7 as i32;
+        let num = (*data.trapframe).a7 as i32;
 
         let result = match num {
             1 => self.sys_fork(),

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -69,10 +69,8 @@ pub unsafe fn argstr(n: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
 }
 
 impl Kernel {
-    pub unsafe fn syscall(&'static self) -> Result<usize, ()> {
+    pub unsafe fn syscall(&'static self, num: i32) -> Result<usize, ()> {
         let p = myproc();
-        let data = &mut *(*p).data.get();
-        let num = (*data.trapframe).a7 as i32;
 
         match num {
             1 => self.sys_fork(),

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -8,7 +8,7 @@ use core::{mem, slice, str};
 use cstr_core::CStr;
 
 /// Fetch the usize at addr from the current process.
-/// Returns Ok(fetched address) on success, Err(()) on error.
+/// Returns Ok(fetched integer) on success, Err(()) on error.
 pub unsafe fn fetchaddr(addr: UVAddr) -> Result<usize, ()> {
     let p = myproc();
     let data = &mut *(*p).data.get();

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -8,6 +8,7 @@ use core::{mem, slice, str};
 use cstr_core::CStr;
 
 /// Fetch the usize at addr from the current process.
+/// Returns Ok(()) on success, Err(()) on error.
 pub unsafe fn fetchaddr(addr: UVAddr, ip: *mut usize) -> Result<(), ()> {
     let p = myproc();
     let data = &mut *(*p).data.get();

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -61,7 +61,7 @@ pub unsafe fn argaddr(n: usize) -> Result<usize, ()> {
 
 /// Fetch the nth word-sized system call argument as a null-terminated string.
 /// Copies into buf, at most max.
-/// Returns string length if OK (including nul), -1 if error.
+/// Returns reference to the string in the buffer.
 pub unsafe fn argstr(n: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
     let addr = argaddr(n)?;
     fetchstr(UVAddr::new(addr), buf)

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -8,7 +8,7 @@ use core::{mem, slice, str};
 use cstr_core::CStr;
 
 /// Fetch the usize at addr from the current process.
-/// Returns Ok(ip) on success, Err(()) on error.
+/// Returns Ok(fetched address) on success, Err(()) on error.
 pub unsafe fn fetchaddr(addr: UVAddr) -> Result<usize, ()> {
     let p = myproc();
     let data = &mut *(*p).data.get();

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -378,13 +378,14 @@ impl Kernel {
         let mut success = false;
         for (i, arg) in argv.iter_mut().enumerate() {
             let mut uarg = 0;
-            ok_or!(
-                fetchaddr(
-                    UVAddr::new(uargv + mem::size_of::<usize>() * i),
-                    &mut uarg as *mut usize,
-                ),
-                break
-            );
+            if fetchaddr(
+                UVAddr::new(uargv + mem::size_of::<usize>() * i),
+                &mut uarg as *mut usize,
+            )
+            .is_err()
+            {
+                break;
+            }
 
             if uarg == 0 {
                 *arg = ptr::null_mut();

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -150,7 +150,7 @@ impl Kernel {
                 let mut ip = ptr2.lock();
                 assert!(ip.deref_inner().nlink >= 1, "unlink: nlink < 1");
 
-                if ip.deref_inner().typ != InodeType::Dir || ip.isdirempty() {
+                if ip.deref_inner().typ != InodeType::Dir || ip.is_dir_empty() {
                     let bytes_write = dp.write(
                         KVAddr::new(&mut de as *mut Dirent as usize),
                         off,

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -167,7 +167,7 @@ impl Kernel {
 
         Err(())
     }
-    
+
     unsafe fn open(&'static self, name: &Path, omode: FcntlFlags) -> Result<usize, ()> {
         let tx = self.file_system.begin_transaction();
 
@@ -216,13 +216,13 @@ impl Kernel {
         let fd = f.fdalloc()?;
         Ok(fd as usize)
     }
-    
+
     unsafe fn mkdir(&self, dirname: &CStr) -> Result<usize, ()> {
         let tx = self.file_system.begin_transaction();
         create(Path::new(dirname), InodeType::Dir, &tx, |_| ())?;
         Ok(0)
     }
-    
+
     unsafe fn mknod(&self, filename: &CStr, major: u16, minor: u16) -> Result<usize, ()> {
         let tx = self.file_system.begin_transaction();
         create(
@@ -337,7 +337,7 @@ impl Kernel {
     pub unsafe fn sys_unlink(&self) -> usize {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
-        ok_or!(self.unlink(path), return usize::MAX)
+        ok_or!(self.unlink(path), usize::MAX)
     }
 
     pub unsafe fn sys_open(&'static self) -> usize {
@@ -346,13 +346,13 @@ impl Kernel {
         let path = Path::new(path);
         let omode = ok_or!(argint(1), return usize::MAX);
         let omode = FcntlFlags::from_bits_truncate(omode);
-        ok_or!(self.open(path, omode), return usize::MAX)
+        ok_or!(self.open(path, omode), usize::MAX)
     }
 
     pub unsafe fn sys_mkdir(&self) -> usize {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
-        ok_or!(self.mkdir(path), return usize::MAX)
+        ok_or!(self.mkdir(path), usize::MAX)
     }
 
     pub unsafe fn sys_mknod(&self) -> usize {
@@ -360,13 +360,13 @@ impl Kernel {
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
         let major = ok_or!(argint(1), return usize::MAX) as u16;
         let minor = ok_or!(argint(2), return usize::MAX) as u16;
-        ok_or!(self.mknod(path, major, minor), return usize::MAX)
+        ok_or!(self.mknod(path, major, minor), usize::MAX)
     }
 
     pub unsafe fn sys_chdir(&self) -> usize {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = ok_or!(argstr(0, &mut path), return usize::MAX);
-        ok_or!(self.chdir(path), return usize::MAX)
+        ok_or!(self.chdir(path), usize::MAX)
     }
 
     pub unsafe fn sys_exec(&self) -> usize {
@@ -419,6 +419,6 @@ impl Kernel {
     pub unsafe fn sys_pipe(&self) -> usize {
         // user pointer to array of two integers
         let fdarray = ok_or!(argaddr(0), return usize::MAX);
-        ok_or!(self.pipe(fdarray), return usize::MAX)
+        ok_or!(self.pipe(fdarray), usize::MAX)
     }
 }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -198,12 +198,11 @@ impl Kernel {
             },
         };
 
-        let f = 
-            self.ftable.alloc_file(
-                filetype,
-                !omode.intersects(FcntlFlags::O_WRONLY),
-                omode.intersects(FcntlFlags::O_WRONLY | FcntlFlags::O_RDWR)
-            )?;
+        let f = self.ftable.alloc_file(
+            filetype,
+            !omode.intersects(FcntlFlags::O_WRONLY),
+            omode.intersects(FcntlFlags::O_WRONLY | FcntlFlags::O_RDWR),
+        )?;
 
         if omode.contains(FcntlFlags::O_TRUNC) && typ == InodeType::File {
             match &f.typ {
@@ -380,10 +379,10 @@ impl Kernel {
 
         let mut success = false;
         for (i, arg) in argv.iter_mut().enumerate() {
-
-            let uarg = ok_or!(fetchaddr(
-                UVAddr::new(uargv + mem::size_of::<usize>() * i)
-            ), break);
+            let uarg = ok_or!(
+                fetchaddr(UVAddr::new(uargv + mem::size_of::<usize>() * i)),
+                break
+            );
 
             if uarg == 0 {
                 *arg = ptr::null_mut();

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -84,15 +84,18 @@ where
         }
         return Err(());
     }
+    // TODO(rv6): It is not safe until we check safty of alloc_inode.
     let ptr2 = unsafe { kernel().itable.alloc_inode(dp.dev, typ, tx) };
     let mut ip = ptr2.lock();
     ip.deref_inner_mut().nlink = 1;
+    // TODO(rv6): Need to check the safety of InodeGuard::update
     unsafe { ip.update(tx) };
 
     // Create . and .. entries.
     if typ == InodeType::Dir {
         // for ".."
         dp.deref_inner_mut().nlink += 1;
+        // TODO(rv6): Need to check the safety of InodeGuard::update
         unsafe { dp.update(tx) };
 
         // No ip->nlink++ for ".": avoid cyclic ref count.
@@ -119,6 +122,7 @@ impl Kernel {
             return Err(());
         }
         ip.deref_inner_mut().nlink += 1;
+        // TODO(rv6): Need to check the safety of InodeGuard::update
         unsafe { ip.update(&tx) };
         drop(ip);
 
@@ -132,6 +136,7 @@ impl Kernel {
 
         let mut ip = ptr.lock();
         ip.deref_inner_mut().nlink -= 1;
+        // TODO(rv6): Need to check the safety of InodeGuard::update
         unsafe { ip.update(&tx) };
         Err(())
     }
@@ -161,11 +166,13 @@ impl Kernel {
                     assert_eq!(bytes_write, Ok(DIRENT_SIZE), "unlink: writei");
                     if ip.deref_inner().typ == InodeType::Dir {
                         dp.deref_inner_mut().nlink -= 1;
+                        // TODO(rv6): Need to check the safety of InodeGuard::update
                         unsafe { dp.update(&tx) };
                     }
                     drop(dp);
                     drop(ptr);
                     ip.deref_inner_mut().nlink -= 1;
+                    // TODO(rv6): Need to check the safety of InodeGuard::update
                     unsafe { ip.update(&tx) };
                     return Ok(());
                 }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -380,15 +380,10 @@ impl Kernel {
 
         let mut success = false;
         for (i, arg) in argv.iter_mut().enumerate() {
-            let mut uarg = 0;
-            if fetchaddr(
-                UVAddr::new(uargv + mem::size_of::<usize>() * i),
-                &mut uarg as *mut usize,
-            )
-            .is_err()
-            {
-                break;
-            }
+
+            let uarg = ok_or!(fetchaddr(
+                UVAddr::new(uargv + mem::size_of::<usize>() * i)
+            ), break);
 
             if uarg == 0 {
                 *arg = ptr::null_mut();

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -4,8 +4,6 @@
 
 #![allow(clippy::unit_arg)]
 
-use cstr_core::CStr;
-
 use crate::{
     fcntl::FcntlFlags,
     file::{FileType, RcFile},
@@ -21,8 +19,8 @@ use crate::{
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
     vm::{KVAddr, UVAddr, VAddr},
 };
-
 use core::{cell::UnsafeCell, mem, ptr, slice};
+use cstr_core::CStr;
 
 impl RcFile<'static> {
     /// Allocate a file descriptor for the given file.

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -88,14 +88,14 @@ where
     let ptr2 = unsafe { kernel().itable.alloc_inode(dp.dev, typ, tx) };
     let mut ip = ptr2.lock();
     ip.deref_inner_mut().nlink = 1;
-    // TODO(rv6): Need to check the safety of InodeGuard::update()
+    // It is safe to call update() because unique access to ip is guaranteed.
     unsafe { ip.update(tx) };
 
     // Create . and .. entries.
     if typ == InodeType::Dir {
         // for ".."
         dp.deref_inner_mut().nlink += 1;
-        // TODO(rv6): Need to check the safety of InodeGuard::update()
+        // It is safe to call update() because unique access to dp is guaranteed.
         unsafe { dp.update(tx) };
 
         // No ip->nlink++ for ".": avoid cyclic ref count.
@@ -122,7 +122,7 @@ impl Kernel {
             return Err(());
         }
         ip.deref_inner_mut().nlink += 1;
-        // TODO(rv6): Need to check the safety of InodeGuard::update()
+        // It is safe to call update() because unique access to ip is guaranteed.
         unsafe { ip.update(&tx) };
         drop(ip);
 
@@ -136,7 +136,7 @@ impl Kernel {
 
         let mut ip = ptr.lock();
         ip.deref_inner_mut().nlink -= 1;
-        // TODO(rv6): Need to check the safety of InodeGuard::update()
+        // It is safe to call update() because unique access to ip is guaranteed.
         unsafe { ip.update(&tx) };
         Err(())
     }
@@ -166,13 +166,13 @@ impl Kernel {
                     assert_eq!(bytes_write, Ok(DIRENT_SIZE), "unlink: writei");
                     if ip.deref_inner().typ == InodeType::Dir {
                         dp.deref_inner_mut().nlink -= 1;
-                        // TODO(rv6): Need to check the safety of InodeGuard::update()
+                        // It is safe to call update() because unique access to dp is guaranteed.
                         unsafe { dp.update(&tx) };
                     }
                     drop(dp);
                     drop(ptr);
                     ip.deref_inner_mut().nlink -= 1;
-                    // TODO(rv6): Need to check the safety of InodeGuard::update()
+                    // It is safe to call update() because unique access to ip is guaranteed.
                     unsafe { ip.update(&tx) };
                     return Ok(());
                 }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -282,7 +282,7 @@ impl Kernel {
             .fdalloc()
             .map_err(|_| data.open_files[fd0 as usize] = None)?;
 
-        // Both copy_out is safe because fdarray and fd0, fd1 is valid.
+        // Both copy_out is safe because fdarray, fd0, fd1 is valid.
         if unsafe {
             data.pagetable.copy_out(
                 fdarray,

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -251,7 +251,7 @@ impl Kernel {
         Ok(())
     }
 
-    unsafe fn pipe(&self, fdarray: usize) -> Result<(), ()> {
+    unsafe fn pipe(&self, fdarray: UVAddr) -> Result<(), ()> {
         let p = myproc();
         let mut data = &mut *(*p).data.get();
         let (pipereader, pipewriter) = AllocatedPipe::alloc()?;
@@ -265,14 +265,14 @@ impl Kernel {
         if data
             .pagetable
             .copy_out(
-                UVAddr::new(fdarray),
+                fdarray,
                 slice::from_raw_parts_mut(&mut fd0 as *mut i32 as *mut u8, mem::size_of::<i32>()),
             )
             .is_err()
             || data
                 .pagetable
                 .copy_out(
-                    UVAddr::new(fdarray.wrapping_add(mem::size_of::<i32>())),
+                    UVAddr::new(fdarray.into_usize().wrapping_add(mem::size_of::<i32>())),
                     slice::from_raw_parts_mut(
                         &mut fd1 as *mut i32 as *mut u8,
                         mem::size_of::<i32>(),
@@ -416,7 +416,7 @@ impl Kernel {
 
     pub unsafe fn sys_pipe(&self) -> Result<usize, ()> {
         // user pointer to array of two integers
-        let fdarray = argaddr(0)?;
+        let fdarray = UVAddr::new(argaddr(0)?);
         self.pipe(fdarray)?;
         Ok(0)
     }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -321,6 +321,7 @@ impl Kernel {
 impl Kernel {
     /// Return a new file descriptor referring to the same file as given fd.
     /// Returns Ok(new file descriptor) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argfd) is yet unsafe.
     pub unsafe fn sys_dup(&self) -> Result<usize, ()> {
         let (_, f) = argfd(0)?;
         let newfile = f.clone();
@@ -330,6 +331,7 @@ impl Kernel {
 
     /// Read n bytes into buf.
     /// Returns Ok(number read) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argfd, argaddr, argint) is yet unsafe.
     pub unsafe fn sys_read(&self) -> Result<usize, ()> {
         let (_, f) = argfd(0)?;
         let n = argint(2)?;
@@ -339,6 +341,7 @@ impl Kernel {
 
     /// Write n bytes from buf to given file descriptor fd.
     /// Returns Ok(n) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argfd, argaddr, argint) is yet unsafe.
     pub unsafe fn sys_write(&self) -> Result<usize, ()> {
         let (_, f) = argfd(0)?;
         let n = argint(2)?;
@@ -348,14 +351,17 @@ impl Kernel {
 
     /// Release open file fd.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argfd) is yet unsafe.
     pub unsafe fn sys_close(&self) -> Result<usize, ()> {
         let (fd, _) = argfd(0)?;
+        // TODO(rv6): This line should be safe after we refactor myporc()
         (*(*myproc()).data.get()).open_files[fd as usize] = None;
         Ok(0)
     }
 
     /// Place info about an open file into struct stat.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argfd, argaddr) is yet unsafe.
     pub unsafe fn sys_fstat(&self) -> Result<usize, ()> {
         let (_, f) = argfd(0)?;
         // user pointer to struct stat
@@ -366,6 +372,7 @@ impl Kernel {
 
     /// Create the path new as a link to the same inode as old.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argstr) is yet unsafe.
     pub unsafe fn sys_link(&self) -> Result<usize, ()> {
         let mut new: [u8; MAXPATH] = [0; MAXPATH];
         let mut old: [u8; MAXPATH] = [0; MAXPATH];
@@ -377,6 +384,7 @@ impl Kernel {
 
     /// Remove a file.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argstr) is yet unsafe.
     pub unsafe fn sys_unlink(&self) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = argstr(0, &mut path)?;
@@ -386,6 +394,7 @@ impl Kernel {
 
     /// Open a file.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argstr, argint) is yet unsafe.
     pub unsafe fn sys_open(&'static self) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = argstr(0, &mut path)?;
@@ -397,6 +406,7 @@ impl Kernel {
 
     /// Create a new directory.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argstr) is yet unsafe.
     pub unsafe fn sys_mkdir(&self) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = argstr(0, &mut path)?;
@@ -406,6 +416,7 @@ impl Kernel {
 
     /// Create a new directory.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argstr, argint) is yet unsafe.
     pub unsafe fn sys_mknod(&self) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = argstr(0, &mut path)?;
@@ -417,6 +428,7 @@ impl Kernel {
 
     /// Change the current directory.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argstr) is yet unsafe.
     pub unsafe fn sys_chdir(&self) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = argstr(0, &mut path)?;
@@ -426,6 +438,7 @@ impl Kernel {
 
     /// Load a file and execute it with arguments.
     /// Returns Ok(argc argument to user main) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because it is using unsafe functions(argstr, argaddr, fetchaddr, fetchstr, exec)
     pub unsafe fn sys_exec(&self) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let mut argv: [*mut u8; MAXARG] = [ptr::null_mut(); MAXARG];
@@ -471,6 +484,7 @@ impl Kernel {
 
     /// Create a pipe.
     /// Returns Ok(0) on success, Err(()) on error.
+    /// TODO(rv6): This is unsafe because fetching argument(argaddr) is yet unsafe.
     pub unsafe fn sys_pipe(&self) -> Result<usize, ()> {
         // user pointer to array of two integers
         let fdarray = UVAddr::new(argaddr(0)?);

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -107,8 +107,7 @@ where
 
 impl Kernel {
     unsafe fn dup(&self, file: &'static RcFile<'static>) -> Result<usize, ()> {
-        let newfile = file.clone();
-        let fd = newfile.fdalloc()?;
+        let fd = file.clone().fdalloc()?;
         Ok(fd as usize)
     }
 

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -294,7 +294,7 @@ impl Kernel {
 
     unsafe fn mknod(&self, filename: &CStr, major: u16, minor: u16) -> Result<usize, ()> {
         let tx = self.file_system.begin_transaction();
-        let _ip = create(
+        create(
             Path::new(filename),
             InodeType::Device { major, minor },
             &tx,
@@ -346,13 +346,13 @@ impl Kernel {
         let mut success = false;
         for (i, arg) in argv.iter_mut().enumerate() {
             let mut uarg = 0;
-            if fetchaddr(
-                UVAddr::new(uargv + mem::size_of::<usize>() * i),
-                &mut uarg as *mut usize,
-            ) < 0
-            {
-                break;
-            }
+            ok_or!(
+                fetchaddr(
+                    UVAddr::new(uargv + mem::size_of::<usize>() * i),
+                    &mut uarg as *mut usize,
+                ),
+                break
+            );
 
             if uarg == 0 {
                 *arg = ptr::null_mut();

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -106,14 +106,11 @@ where
 }
 
 impl Kernel {
-    unsafe fn dup(&self, file: &'static RcFile<'static>) -> Result<usize, ()> {
-        let fd = file.clone().fdalloc()?;
-        Ok(fd as usize)
-    }
-
     pub unsafe fn sys_dup(&self) -> usize {
         let (_, f) = ok_or!(argfd(0), return usize::MAX);
-        ok_or!(self.dup(f), usize::MAX)
+        let newfile = f.clone();
+        let fd = ok_or!(newfile.fdalloc(), return usize::MAX);
+        fd as usize
     }
 
     pub unsafe fn sys_read(&self) -> usize {

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -67,7 +67,7 @@ impl Kernel {
 
     /// Return how many clock tick interrupts have occurred
     /// since start.
-    pub unsafe fn sys_uptime(&self) -> Result<usize, ()> {
+    pub fn sys_uptime(&self) -> Result<usize, ()> {
         Ok(*self.ticks.lock() as usize)
     }
 

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -7,24 +7,32 @@ use crate::{
 };
 
 impl Kernel {
+    /// Terminate the current process; status reported to wait(). No return.
     pub unsafe fn sys_exit(&self) -> Result<usize, ()> {
         let n = argint(0)?;
         self.procs.exit_current(n);
     }
 
+    /// Return the current process’s PID.
     pub unsafe fn sys_getpid(&self) -> Result<usize, ()> {
         Ok((*myproc()).pid() as _)
     }
 
+    /// Create a process.
+    /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub unsafe fn sys_fork(&self) -> Result<usize, ()> {
         Ok(self.procs.fork()? as _)
     }
 
+    /// Wait for a child to exit.
+    /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub unsafe fn sys_wait(&self) -> Result<usize, ()> {
         let p = argaddr(0)?;
         Ok(self.procs.wait(UVAddr::new(p))? as _)
     }
 
+    /// Grow process’s memory by n bytes.
+    /// Returns Ok(start of new memory) on success, Err(()) on error.
     pub unsafe fn sys_sbrk(&self) -> Result<usize, ()> {
         let n = argint(0)?;
         let addr = (*(*myproc()).data.get()).sz as i32;
@@ -34,6 +42,8 @@ impl Kernel {
         Ok(addr as usize)
     }
 
+    /// Pause for n clock ticks.
+    /// Returns Ok(0) on success, Err(()) on error.
     pub unsafe fn sys_sleep(&self) -> Result<usize, ()> {
         let n = argint(0)?;
         let mut ticks = self.ticks.lock();
@@ -47,6 +57,8 @@ impl Kernel {
         Ok(0)
     }
 
+    /// Terminate process PID.
+    /// Returns Ok(0) on success, Err(()) on error.
     pub unsafe fn sys_kill(&self) -> Result<usize, ()> {
         let pid = argint(0)?;
         self.procs.kill(pid)?;
@@ -59,6 +71,7 @@ impl Kernel {
         Ok(*self.ticks.lock() as usize)
     }
 
+    /// Shutdowns this machine, discarding all unsaved data. No return.
     pub unsafe fn sys_poweroff(&self) -> Result<usize, ()> {
         let exitcode = argint(0)?;
         poweroff::machine_poweroff(exitcode as _);

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,65 +1,65 @@
 use crate::{
     kernel::Kernel,
-    ok_or, poweroff,
+    poweroff,
     proc::{myproc, resizeproc},
     syscall::{argaddr, argint},
     vm::{UVAddr, VAddr},
 };
 
 impl Kernel {
-    pub unsafe fn sys_exit(&self) -> usize {
-        let n = ok_or!(argint(0), return usize::MAX);
+    pub unsafe fn sys_exit(&self) -> Result<usize, ()> {
+        let n = argint(0)?;
         self.procs.exit_current(n);
     }
 
-    pub unsafe fn sys_getpid(&self) -> usize {
-        (*myproc()).pid() as _
+    pub unsafe fn sys_getpid(&self) -> Result<usize, ()> {
+        Ok((*myproc()).pid() as _)
     }
 
-    pub unsafe fn sys_fork(&self) -> usize {
-        self.procs.fork() as _
+    pub unsafe fn sys_fork(&self) -> Result<usize, ()> {
+        Ok(self.procs.fork()? as _)
     }
 
-    pub unsafe fn sys_wait(&self) -> usize {
-        let p = ok_or!(argaddr(0), return usize::MAX);
-        self.procs.wait(UVAddr::new(p)) as _
+    pub unsafe fn sys_wait(&self) -> Result<usize, ()> {
+        let p = argaddr(0)?;
+        Ok(self.procs.wait(UVAddr::new(p))? as _)
     }
 
-    pub unsafe fn sys_sbrk(&self) -> usize {
-        let n = ok_or!(argint(0), return usize::MAX);
-        let addr: i32 = (*(*myproc()).data.get()).sz as i32;
+    pub unsafe fn sys_sbrk(&self) -> Result<usize, ()> {
+        let n = argint(0)?;
+        let addr = (*(*myproc()).data.get()).sz as i32;
         if resizeproc(n) < 0 {
-            return usize::MAX;
+            return Err(());
         }
-        addr as usize
+        Ok(addr as usize)
     }
 
-    pub unsafe fn sys_sleep(&self) -> usize {
-        let n = ok_or!(argint(0), return usize::MAX);
+    pub unsafe fn sys_sleep(&self) -> Result<usize, ()> {
+        let n = argint(0)?;
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
             if (*myproc()).killed() {
-                return usize::MAX;
+                return Err(());
             }
             ticks.sleep();
         }
-        0
+        Ok(0)
     }
 
-    pub unsafe fn sys_kill(&self) -> usize {
-        let pid = ok_or!(argint(0), return usize::MAX);
-        self.procs.kill(pid) as usize
+    pub unsafe fn sys_kill(&self) -> Result<usize, ()> {
+        let pid = argint(0)?;
+        Ok(self.procs.kill(pid)? as usize)
     }
 
-    /// return how many clock tick interrupts have occurred
+    /// Return how many clock tick interrupts have occurred
     /// since start.
-    pub unsafe fn sys_uptime(&self) -> usize {
-        *self.ticks.lock() as usize
+    pub unsafe fn sys_uptime(&self) -> Result<usize, ()> {
+        Ok(*self.ticks.lock() as usize)
     }
 
-    pub unsafe fn sys_poweroff(&self) -> usize {
-        let exitcode = ok_or!(argint(0), return usize::MAX);
+    pub unsafe fn sys_poweroff(&self) -> Result<usize, ()> {
+        let exitcode = argint(0)?;
         poweroff::machine_poweroff(exitcode as _);
     }
 }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -49,7 +49,8 @@ impl Kernel {
 
     pub unsafe fn sys_kill(&self) -> Result<usize, ()> {
         let pid = argint(0)?;
-        Ok(self.procs.kill(pid)? as usize)
+        self.procs.kill(pid)?;
+        Ok(0)
     }
 
     /// Return how many clock tick interrupts have occurred

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -65,7 +65,6 @@ pub unsafe extern "C" fn usertrap() {
         // An interrupt will change sstatus &c registers,
         // so don't enable until done with those registers.
         intr_on();
-
         (*data.trapframe).a0 = ok_or!(kernel().syscall(), usize::MAX);
     } else {
         which_dev = devintr();

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -1,6 +1,7 @@
 use crate::{
     kernel::kernel,
     memlayout::{TRAMPOLINE, TRAPFRAME, UART0_IRQ, VIRTIO0_IRQ},
+    ok_or,
     plic::{plic_claim, plic_complete},
     println,
     proc::{cpuid, myproc, proc_yield, Proc, Procstate},
@@ -64,7 +65,8 @@ pub unsafe extern "C" fn usertrap() {
         // An interrupt will change sstatus &c registers,
         // so don't enable until done with those registers.
         intr_on();
-        kernel().syscall();
+
+        (*data.trapframe).a0 = ok_or!(kernel().syscall(), usize::MAX);
     } else {
         which_dev = devintr();
         if which_dev == 0 {

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn usertrap() {
         // An interrupt will change sstatus &c registers,
         // so don't enable until done with those registers.
         intr_on();
-        (*data.trapframe).a0 = ok_or!(kernel().syscall(), usize::MAX);
+        (*data.trapframe).a0 = ok_or!(kernel().syscall((*data.trapframe).a7 as i32), usize::MAX);
     } else {
         which_dev = devintr();
         if which_dev == 0 {


### PR DESCRIPTION
- closes #332

---

주요 변경점입니다.

- `sys_*` 함수 중에서 https://github.com/kaist-cp/rv6/issues/332#issuecomment-759912575 에서 말씀하신 의도를 만족할 수 있는 부분만 분리했습니다. (내부 코드가 짧은 함수들은 그대로 유지)
  - `sys_*` 함수들이 call하는 함수들은 `Result` type을 return 하도록 변경했습니다.
  - `sys_exec`의 경우에는 `Kernel::exec`가 이미 기능을 하고 있다고 생각해서 변경하지 않았습니다.
- `fetchaddr` 도 `Result`를 return 합니다.
- `fdalloc`이 `Result<i32, Self>` 대신 `Result<i32, ()>`를 return 합니다.

---

#### `sys_*` 함수가 `usize`대신 `Result`를 리턴하는 것은 어떤지 궁금합니다.
  https://github.com/kaist-cp/rv6/blob/f5f6a8f4ddc3e45a17feeaf529ec7f8f835e993e/kernel-rs/src/syscall.rs#L115
  - 여기서 `ok_or!`등을 사용해서 `usize`로 변환하는 방향입니다.