### PR TITLE
Refactoring VM by exploiting invariants of Page and PageTable

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -45,7 +45,7 @@ impl Console {
     unsafe fn write(&mut self, src: UVAddr, n: i32) -> i32 {
         for i in 0..n {
             let mut c = [0 as u8];
-            if VAddr::copyin(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
+            if VAddr::copy_in(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
                 return i;
             }
             // TODO(@coolofficials): Temporarily using global function kernel().
@@ -81,7 +81,7 @@ impl Console {
             } else {
                 // Copy the input byte to the user-space buffer.
                 let cbuf = [cin as u8];
-                if UVAddr::copyout(dst, &cbuf).is_err() {
+                if UVAddr::copy_out(dst, &cbuf).is_err() {
                     break;
                 }
                 dst = dst + 1;

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::Kernel,
     ok_or,
     param::MAXARG,
-    proc::{myproc, proc_freepagetable, proc_pagetable, Proc},
+    proc::{myproc, proc_freepagetable, Proc},
     riscv::PGSIZE,
     string::{safestrcpy, strlen},
     vm::{KVAddr, PageTable, UVAddr, VAddr},
@@ -119,7 +119,7 @@ impl Kernel {
             return Err(());
         }
 
-        let pt = proc_pagetable(p)?;
+        let pt = PageTable::uvm_new(data.trapframe).ok_or(())?;
 
         let mut ptable_guard = scopeguard::guard((pt, sz), |(pt, sz)| {
             proc_freepagetable(pt, sz);

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -119,7 +119,7 @@ impl Kernel {
             return Err(());
         }
 
-        let pt = PageTable::uvm_new(data.trapframe).ok_or(())?;
+        let pt = PageTable::<UVAddr>::new(data.trapframe).ok_or(())?;
 
         let mut ptable_guard = scopeguard::guard((pt, sz), |(pt, sz)| {
             proc_freepagetable(pt, sz);
@@ -146,7 +146,7 @@ impl Kernel {
                 if ph.vaddr.wrapping_add(ph.memsz) < ph.vaddr {
                     return Err(());
                 }
-                let sz1 = pt.uvm_alloc(*sz, ph.vaddr.wrapping_add(ph.memsz))?;
+                let sz1 = pt.alloc(*sz, ph.vaddr.wrapping_add(ph.memsz))?;
                 *sz = sz1;
                 if ph.vaddr.wrapping_rem(PGSIZE) != 0 {
                     return Err(());
@@ -169,9 +169,9 @@ impl Kernel {
         // Use the second as the user stack.
         *sz = sz.wrapping_add(PGSIZE).wrapping_sub(1) & !PGSIZE.wrapping_sub(1);
 
-        let sz1 = pt.uvm_alloc(*sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)))?;
+        let sz1 = pt.alloc(*sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)))?;
         *sz = sz1;
-        pt.uvm_guard(UVAddr::new(sz.wrapping_sub(2usize.wrapping_mul(PGSIZE))));
+        pt.guard(UVAddr::new(sz.wrapping_sub(2usize.wrapping_mul(PGSIZE))));
         let mut sp: usize = *sz;
         let stackbase: usize = sp.wrapping_sub(PGSIZE);
 
@@ -270,7 +270,7 @@ unsafe fn loadseg(
 
     for i in num_iter::range_step(0, sz, PGSIZE as _) {
         let pa = pagetable
-            .uvm_walk_addr(va + i as usize)
+            .walk_addr(va + i as usize)
             .expect("loadseg: address should exist")
             .into_usize();
 

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -75,7 +75,7 @@ impl File {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
-                (*(*p).data.get()).pagetable.copyout(
+                (*(*p).data.get()).pagetable.copy_out(
                     addr,
                     slice::from_raw_parts_mut(
                         &mut st as *mut Stat as *mut u8,

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -394,7 +394,7 @@ impl InodeGuard<'_> {
             let begin = off.wrapping_rem(BSIZE as u32) as usize;
             let end = begin + m as usize;
             unsafe {
-                VAddr::copyout(dst, &bp.deref_mut_inner().data[begin..end])?;
+                VAddr::copy_out(dst, &bp.deref_mut_inner().data[begin..end])?;
             }
             tot = tot.wrapping_add(m);
             off = off.wrapping_add(m);
@@ -433,7 +433,7 @@ impl InodeGuard<'_> {
             let begin = off.wrapping_rem(BSIZE as u32) as usize;
             let end = begin + m as usize;
             unsafe {
-                if VAddr::copyin(&mut bp.deref_mut_inner().data[begin..end], src).is_err() {
+                if VAddr::copy_in(&mut bp.deref_mut_inner().data[begin..end], src).is_err() {
                     break;
                 }
             }

--- a/kernel-rs/src/kalloc.rs
+++ b/kernel-rs/src/kalloc.rs
@@ -20,11 +20,12 @@ struct Run {
     next: *mut Run,
 }
 
-// Internal safety invariant:
-// This singly linked list does not have a cycle.
-// If head is null, then it is an empty list.
-// Ohterwise, it is nonempty, and head is its first element, which
-// is a valid page.
+/// # Safety
+///
+/// The invariants of this struct are as follows:
+/// - This singly linked list does not have a cycle.
+/// - If head is null, then it is an empty list. Ohterwise, it is nonempty, and
+///   head is its first element, which is a valid page.
 pub struct Kmem {
     head: *mut Run,
 }

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -112,7 +112,7 @@ impl Kernel {
     /// initializing the allocator; see Kmem::init.)
     pub fn free(&self, mut page: Page) {
         let pa = page.addr().into_usize();
-        assert!(
+        debug_assert!(
             pa % PGSIZE == 0 && (pa as *mut _) >= unsafe { end.as_mut_ptr() } && pa < PHYSTOP,
             "[Kernel::free]"
         );
@@ -199,10 +199,10 @@ pub unsafe fn kernel_main() -> ! {
         KERNEL.kmem.get_mut().init();
 
         // Create kernel page table.
-        KERNEL.page_table = PageTable::kvm_new().expect("kvm_new failed");
+        KERNEL.page_table = PageTable::<KVAddr>::new().expect("PageTable::new failed");
 
         // Turn on paging.
-        KERNEL.page_table.kvm_init_hart();
+        KERNEL.page_table.init_hart();
 
         // Process system.
         procinit(&mut KERNEL.procs);
@@ -236,7 +236,7 @@ pub unsafe fn kernel_main() -> ! {
         println!("hart {} starting", cpuid());
 
         // Turn on paging.
-        KERNEL.page_table.kvm_init_hart();
+        KERNEL.page_table.init_hart();
 
         // Install kernel trap vector.
         trapinithart();

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -6,7 +6,7 @@ use crate::{
     console::{consoleinit, Console, Printer},
     file::{Devsw, FileTable},
     fs::{FileSystem, Itable},
-    kalloc::{end, kinit, Kmem},
+    kalloc::{end, Kmem},
     memlayout::PHYSTOP,
     page::{Page, RawPage},
     param::{NCPU, NDEV},
@@ -47,7 +47,7 @@ pub struct Kernel {
     kmem: Spinlock<Kmem>,
 
     /// The kernel's page table.
-    pub page_table: PageTable<KVAddr>,
+    pub page_table: Option<PageTable<KVAddr>>,
 
     pub ticks: Sleepablelock<u32>,
 
@@ -82,7 +82,7 @@ impl Kernel {
             uart: Uart::new(),
             printer: Spinlock::new("PRINTLN", Printer::new()),
             kmem: Spinlock::new("KMEM", Kmem::new()),
-            page_table: PageTable::zero(),
+            page_table: None,
             ticks: Sleepablelock::new("time", 0),
             procs: ProcessSystem::zero(),
             cpus: [Cpu::new(); NCPU],
@@ -109,11 +109,11 @@ impl Kernel {
     /// Free the page of physical memory pointed at by v,
     /// which normally should have been returned by a
     /// call to kernel().alloc().  (The exception is when
-    /// initializing the allocator; see kinit above.)
-    pub unsafe fn free(&self, mut page: Page) {
+    /// initializing the allocator; see Kmem::init.)
+    pub fn free(&self, mut page: Page) {
         let pa = page.addr().into_usize();
         assert!(
-            pa.wrapping_rem(PGSIZE) == 0 && (pa as *mut _) >= end.as_mut_ptr() && pa < PHYSTOP,
+            pa % PGSIZE == 0 && (pa as *mut _) >= unsafe { end.as_mut_ptr() } && pa < PHYSTOP,
             "[Kernel::free]"
         );
 
@@ -126,7 +126,7 @@ impl Kernel {
     /// Allocate one 4096-byte page of physical memory.
     /// Returns a pointer that the kernel can use.
     /// Returns 0 if the memory cannot be allocated.
-    pub unsafe fn alloc(&self) -> Option<Page> {
+    pub fn alloc(&self) -> Option<Page> {
         let mut page = kernel().kmem.lock().alloc()?;
 
         // fill with junk
@@ -196,13 +196,13 @@ pub unsafe fn kernel_main() -> ! {
         println!();
 
         // Physical page allocator.
-        kinit(KERNEL.kmem.get_mut());
+        KERNEL.kmem.get_mut().init();
 
         // Create kernel page table.
-        KERNEL.page_table.kvminit();
+        KERNEL.page_table = PageTable::kvm_new();
 
         // Turn on paging.
-        kernel().page_table.kvminithart();
+        KERNEL.kvm_init_hart();
 
         // Process system.
         procinit(&mut KERNEL.procs);
@@ -236,7 +236,7 @@ pub unsafe fn kernel_main() -> ! {
         println!("hart {} starting", cpuid());
 
         // Turn on paging.
-        kernel().page_table.kvminithart();
+        KERNEL.kvm_init_hart();
 
         // Install kernel trap vector.
         trapinithart();

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -17,6 +17,7 @@
 #![feature(maybe_uninit_extra)]
 #![feature(min_const_generics)]
 #![feature(generic_associated_types)]
+#![feature(unsafe_block_in_unsafe_fn)]
 
 mod arena;
 mod bio;

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -12,11 +12,13 @@ pub struct RawPage {
     inner: [u8; PGSIZE],
 }
 
-// Internal safety invariant:
-// - inner is 4096 bytes-aligned.
-// - end <= inner < PHYSTOP
-// - Two different pages never overwrap. If p1: Page and p2: Page, then
-//   *(p1.inner).inner and *(p1.inner).inner are non-overwrapping arrays.
+/// # Safety
+///
+/// The invariants of this struct are as follows:
+/// - inner is 4096 bytes-aligned.
+/// - end <= inner < PHYSTOP
+/// - Two different pages never overwrap. If p1: Page and p2: Page, then
+///   *(p1.inner).inner and *(p1.inner).inner are non-overwrapping arrays.
 pub struct Page {
     inner: *mut RawPage,
 }

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -12,6 +12,11 @@ pub struct RawPage {
     inner: [u8; PGSIZE],
 }
 
+// Internal safety invariant:
+// - inner is 4096 bytes-aligned.
+// - end <= inner < PHYSTOP
+// - Two different pages never overwrap. If p1: Page and p2: Page, then
+//   *(p1.inner).inner and *(p1.inner).inner are non-overwrapping arrays.
 pub struct Page {
     inner: *mut RawPage,
 }
@@ -48,7 +53,14 @@ impl Page {
         result
     }
 
-    pub fn from_usize(addr: usize) -> Self {
+    /// # Safety
+    ///
+    /// Given addr must not break the invariant of Page.
+    /// - addr is a multiple of 4096.
+    /// - end <= addr < PHYSTOP
+    /// - If p: Page, then *(p.inner).inner and (addr as *RawPage).inner are
+    ///   non-overwrapping arrays.
+    pub unsafe fn from_usize(addr: usize) -> Self {
         Self {
             inner: addr as *mut _,
         }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -174,7 +174,7 @@ impl PipeInner {
                 //DOC: pipewrite-full
                 return Ok(i);
             }
-            if data.pagetable.copyin(&mut ch, addr + i).is_err() {
+            if data.pagetable.copy_in(&mut ch, addr + i).is_err() {
                 return Err(PipeError::InvalidCopyin(i));
             }
             self.data[self.nwrite as usize % PIPESIZE] = ch[0];
@@ -202,7 +202,7 @@ impl PipeInner {
             }
             let ch = [self.data[self.nread as usize % PIPESIZE]];
             self.nread = self.nread.wrapping_add(1);
-            if data.pagetable.copyout(addr + i, &ch).is_err() {
+            if data.pagetable.copy_out(addr + i, &ch).is_err() {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -301,6 +301,7 @@ pub struct ProcData {
     pub sz: usize,
 
     /// User page table.
+    // TODO(rv6): change it to Option<PageTable<UVAddr>>
     pub pagetable: PageTable<UVAddr>,
 
     /// Data page for trampoline.S.
@@ -453,7 +454,7 @@ impl ProcData {
         Self {
             kstack: 0,
             sz: 0,
-            pagetable: PageTable::zero(),
+            pagetable: unsafe { PageTable::zero() },
             trapframe: ptr::null_mut(),
             context: Context::new(),
             open_files: [None; NOFILE],
@@ -648,7 +649,7 @@ impl ProcessSystem {
         let data = &mut *guard.data.get();
         // Allocate one user page and copy init's instructions
         // and data into it.
-        data.pagetable.uvminit(&INITCODE);
+        data.pagetable.uvm_init(&INITCODE);
         data.sz = PGSIZE;
 
         // Prepare for the very first "return" from kernel to user.
@@ -680,7 +681,7 @@ impl ProcessSystem {
         // Copy user memory from parent to child.
         if pdata
             .pagetable
-            .uvmcopy(&mut npdata.pagetable, pdata.sz)
+            .uvm_copy(&mut npdata.pagetable, pdata.sz)
             .is_err()
         {
             freeproc(np, None);
@@ -746,7 +747,7 @@ impl ProcessSystem {
                         if !addr.is_null()
                             && data
                                 .pagetable
-                                .copyout(
+                                .copy_out(
                                     addr,
                                     slice::from_raw_parts_mut(
                                         &mut np.deref_mut_info().xstate as *mut i32 as *mut u8,
@@ -837,11 +838,14 @@ impl ProcessSystem {
 /// Allocate a page for the process's kernel stack.
 /// Map it high in memory, followed by an invalid
 /// guard page.
-pub unsafe fn proc_mapstacks(page_table: &mut PageTable<KVAddr>) {
-    for (i, _) in &mut KERNEL.procs.process_pool.iter_mut().enumerate() {
+pub fn proc_mapstacks(page_table: &mut PageTable<KVAddr>) {
+    for (i, _) in unsafe { &mut KERNEL.procs.process_pool }
+        .iter_mut()
+        .enumerate()
+    {
         let pa = kernel().alloc().expect("kalloc").into_usize();
         let va: usize = kstack(i);
-        page_table.kvmmap(
+        page_table.kvm_map(
             KVAddr::new(va),
             PAddr::new(pa as usize),
             PGSIZE,
@@ -892,10 +896,9 @@ unsafe fn freeproc(mut p: ProcGuard, parent_guard: Option<SpinlockProtectedGuard
         kernel().free(Page::from_usize(data.trapframe as _));
     }
     data.trapframe = ptr::null_mut();
-    if !data.pagetable.is_null() {
-        let sz = data.sz;
-        proc_freepagetable(&mut data.pagetable, sz);
-    }
+    let mut page_table = PageTable::zero();
+    mem::swap(&mut data.pagetable, &mut page_table);
+    proc_freepagetable(page_table, data.sz);
     data.pagetable = PageTable::zero();
     data.sz = 0;
     if let Some(mut guard) = parent_guard {
@@ -913,15 +916,14 @@ unsafe fn freeproc(mut p: ProcGuard, parent_guard: Option<SpinlockProtectedGuard
 /// with no user memory, but with trampoline pages.
 pub unsafe fn proc_pagetable(p: *mut Proc) -> Result<PageTable<UVAddr>, ()> {
     // An empty page table.
-    let mut pagetable = PageTable::<UVAddr>::zero();
-    pagetable.alloc_root()?;
+    let mut pagetable = PageTable::<UVAddr>::new().ok_or(())?;
 
     // Map the trampoline code (for system call return)
     // at the highest user virtual address.
     // Only the supervisor uses it, on the way
     // to/from user space, so not PTE_U.
     if pagetable
-        .mappages(
+        .map_pages(
             UVAddr::new(TRAMPOLINE),
             PGSIZE,
             trampoline.as_mut_ptr() as usize,
@@ -929,13 +931,13 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> Result<PageTable<UVAddr>, ()> {
         )
         .is_err()
     {
-        pagetable.uvmfree(0);
+        pagetable.uvm_free(0);
         return Err(());
     }
 
     // Map the trapframe just below TRAMPOLINE, for trampoline.S.
     if pagetable
-        .mappages(
+        .map_pages(
             UVAddr::new(TRAPFRAME),
             PGSIZE,
             (*(*p).data.get()).trapframe as usize,
@@ -943,8 +945,8 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> Result<PageTable<UVAddr>, ()> {
         )
         .is_err()
     {
-        pagetable.uvmunmap(UVAddr::new(TRAMPOLINE), 1, false);
-        pagetable.uvmfree(0);
+        pagetable.uvm_unmap(UVAddr::new(TRAMPOLINE), 1, false);
+        pagetable.uvm_free(0);
         return Err(());
     }
     Ok(pagetable)
@@ -952,10 +954,10 @@ pub unsafe fn proc_pagetable(p: *mut Proc) -> Result<PageTable<UVAddr>, ()> {
 
 /// Free a process's page table, and free the
 /// physical memory it refers to.
-pub unsafe fn proc_freepagetable(pagetable: &mut PageTable<UVAddr>, sz: usize) {
-    pagetable.uvmunmap(UVAddr::new(TRAMPOLINE), 1, false);
-    pagetable.uvmunmap(UVAddr::new(TRAPFRAME), 1, false);
-    pagetable.uvmfree(sz);
+pub unsafe fn proc_freepagetable(mut pagetable: PageTable<UVAddr>, sz: usize) {
+    pagetable.uvm_unmap(UVAddr::new(TRAMPOLINE), 1, false);
+    pagetable.uvm_unmap(UVAddr::new(TRAPFRAME), 1, false);
+    pagetable.uvm_free(sz);
 }
 
 /// A user program that calls exec("/init").
@@ -975,10 +977,10 @@ pub unsafe fn resizeproc(n: i32) -> i32 {
     let sz = match n.cmp(&0) {
         cmp::Ordering::Equal => sz,
         cmp::Ordering::Greater => {
-            let sz = data.pagetable.uvmalloc(sz, sz.wrapping_add(n as usize));
+            let sz = data.pagetable.uvm_alloc(sz, sz.wrapping_add(n as usize));
             ok_or!(sz, return -1)
         }
-        cmp::Ordering::Less => data.pagetable.uvmdealloc(sz, sz.wrapping_add(n as usize)),
+        cmp::Ordering::Less => data.pagetable.uvm_dealloc(sz, sz.wrapping_add(n as usize)),
     };
     data.sz = sz;
     0

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -18,7 +18,7 @@ pub unsafe fn fetchaddr(addr: UVAddr, ip: *mut usize) -> i32 {
     }
     if data
         .pagetable
-        .copyin(
+        .copy_in(
             slice::from_raw_parts_mut(ip as *mut u8, mem::size_of::<usize>()),
             addr,
         )
@@ -33,7 +33,7 @@ pub unsafe fn fetchaddr(addr: UVAddr, ip: *mut usize) -> i32 {
 /// Returns reference to the string in the buffer.
 pub unsafe fn fetchstr(addr: UVAddr, buf: &mut [u8]) -> Result<&CStr, ()> {
     let p: *mut Proc = myproc();
-    (*(*p).data.get()).pagetable.copyinstr(buf, addr)?;
+    (*(*p).data.get()).pagetable.copy_in_str(buf, addr)?;
 
     Ok(CStr::from_ptr(buf.as_ptr()))
 }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -380,14 +380,14 @@ impl Kernel {
 
         if data
             .pagetable
-            .copyout(
+            .copy_out(
                 UVAddr::new(fdarray),
                 slice::from_raw_parts_mut(&mut fd0 as *mut i32 as *mut u8, mem::size_of::<i32>()),
             )
             .is_err()
             || data
                 .pagetable
-                .copyout(
+                .copy_out(
                     UVAddr::new(fdarray.wrapping_add(mem::size_of::<i32>())),
                     slice::from_raw_parts_mut(
                         &mut fd1 as *mut i32 as *mut u8,

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -139,7 +139,7 @@ pub unsafe fn usertrapret() {
     w_sepc((*data.trapframe).epc);
 
     // Tell trampoline.S the user page table to switch to.
-    let satp: usize = make_satp(data.pagetable.as_raw() as usize);
+    let satp: usize = make_satp(data.pagetable.as_usize());
 
     // Jump to trampoline.S at the top of memory, which
     // switches to the user page table, restores user registers,

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -1,7 +1,8 @@
 use crate::{
     kernel::kernel,
+    kernel::Kernel,
     memlayout::{FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, UART0, VIRTIO0},
-    page::{Page, RawPage},
+    page::Page,
     proc::{myproc, proc_mapstacks},
     riscv::{
         make_satp, pa2pte, pgrounddown, pgroundup, pte2pa, pte_flags, px, sfence_vma, w_satp, PteT,
@@ -9,12 +10,7 @@ use crate::{
     },
     some_or,
 };
-use core::{
-    marker::PhantomData,
-    mem,
-    ops::{Add, Deref, DerefMut},
-    ptr,
-};
+use core::{marker::PhantomData, mem, ops::Add, ptr};
 
 extern "C" {
     // kernel.ld sets this to end of kernel code.
@@ -126,7 +122,7 @@ impl VAddr for UVAddr {
         let p = myproc();
         (*(*p).data.get())
             .pagetable
-            .copyin(dst, src)
+            .copy_in(dst, src)
             .map_or(Err(()), |_v| Ok(()))
     }
 
@@ -134,13 +130,13 @@ impl VAddr for UVAddr {
         let p = myproc();
         (*(*p).data.get())
             .pagetable
-            .copyout(dst, src)
+            .copy_out(dst, src)
             .map_or(Err(()), |_v| Ok(()))
     }
 }
 
 #[derive(Default)]
-pub struct PageTableEntry {
+struct PageTableEntry {
     inner: PteT,
 }
 
@@ -169,102 +165,146 @@ impl PageTableEntry {
         pte2pa(self.inner)
     }
 
-    unsafe fn as_page(&self) -> &RawPage {
-        &*(pte2pa(self.inner).into_usize() as *const RawPage)
+    fn is_valid(&self) -> bool {
+        self.check_flag(PTE_V)
     }
 
-    fn as_table_mut(&mut self) -> Option<&mut RawPageTable> {
-        if self.check_flag(PTE_V) && !self.check_flag((PTE_R | PTE_W | PTE_X) as usize) {
-            Some(unsafe { &mut *(pte2pa(self.inner).into_usize() as *mut RawPageTable) })
+    fn is_table(&self) -> bool {
+        self.is_valid() && !self.check_flag((PTE_R | PTE_W | PTE_X) as usize)
+    }
+
+    fn is_data(&self) -> bool {
+        self.is_valid() && self.check_flag((PTE_R | PTE_W | PTE_X) as usize)
+    }
+
+    /// # Safety
+    ///
+    /// If `self.is_table()` is true, then it must refer to a valid page-table page.
+    ///
+    /// Return `Some(..)` if it refers to a page-table page.
+    /// Return `None` if it refers to a data page.
+    /// Return `None` if it is invalid.
+    unsafe fn as_table_mut(&mut self) -> Option<&mut RawPageTable> {
+        if self.is_table() {
+            (pte2pa(self.inner).into_usize() as *mut RawPageTable).as_mut()
         } else {
             None
         }
-    }
-
-    unsafe fn as_table_mut_unchecked(&mut self) -> &mut RawPageTable {
-        &mut *(pte2pa(self.inner).into_usize() as *mut RawPageTable)
     }
 }
 
 const PTE_PER_PT: usize = PGSIZE / mem::size_of::<PageTableEntry>();
 
-pub struct RawPageTable {
+struct RawPageTable {
+    // Internal safety invariant:
+    // If an entry's V flag is set but its RWX flags are not set,
+    // then it must refer to a valid page-table page.
+    // It should be safely converted to a Page without breaking the invariants
+    // of Page.
+    // It should not be accessed outside RawPageTable to guarantee the invariant.
     inner: [PageTableEntry; PTE_PER_PT],
 }
 
-impl Deref for RawPageTable {
-    type Target = [PageTableEntry; PTE_PER_PT];
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl DerefMut for RawPageTable {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
-    }
-}
-
 impl RawPageTable {
+    /// Make a new emtpy raw page table by allocating a new page.
+    /// Return `Ok(..)` if the allocation has succeeded.
+    /// Return `None` if the allocation has failed.
+    fn new() -> Option<*mut RawPageTable> {
+        let mut page = kernel().alloc()?;
+        page.write_bytes(0);
+        Some(page.into_usize() as *mut RawPageTable)
+    }
+
+    /// Return `Some(..)` if the `index`th entry refers to a page-table page.
+    /// Return `Some(..)` by allocating a new page if the `index`th
+    /// entry is invalid but `alloc` is true. The result becomes `None` when the
+    /// allocation has failed.
+    /// Return `None` if the `index`th entry refers to a data page.
+    /// Return `None` if the `index`th entry is invalid and `alloc` is false.
+    fn get_table_mut(&mut self, index: usize, alloc: bool) -> Option<&mut RawPageTable> {
+        let pte = &mut self.inner[index];
+        if !pte.is_valid() {
+            if !alloc {
+                return None;
+            }
+            let page = Self::new()?;
+            let k = page as usize;
+            pte.set_inner(pa2pte(PAddr::new(k)) | PTE_V);
+        }
+        // It is safe because of the RawPageTable's invariant.
+        unsafe { pte.as_table_mut() }
+    }
+
+    /// Return a `PageTableEntry` if the `index`th entry refers to a data page.
+    /// Return a `PageTableEntry` if the `index`th entry is invalid.
+    /// Panic if the `index`th entry refers to a page-table page.
+    fn get_entry_mut(&mut self, index: usize) -> &mut PageTableEntry {
+        let pte = &mut self.inner[index];
+        assert!(!pte.is_table());
+        pte
+    }
+
     /// Recursively free page-table pages.
     /// All leaf mappings must already have been removed.
-    unsafe fn freewalk(&mut self) {
+    /// This method frees the page table itself, so this page table must
+    /// not be used after an invocation of this method.
+    #[deny(unsafe_op_in_unsafe_fn)]
+    unsafe fn free_walk(&mut self) {
         // There are 2^9 = 512 PTEs in a page table.
         for pte in &mut self.inner {
-            if let Some(ptable) = pte.as_table_mut() {
-                ptable.freewalk();
+            // It is safe because of the RawPageTable's invariant.
+            if let Some(ptable) = unsafe { pte.as_table_mut() } {
+                // It is safe because ptable will not be used anymore.
+                unsafe { ptable.free_walk() };
                 pte.set_inner(0);
-            } else {
-                assert!(!pte.check_flag(PTE_V), "freewalk: leaf");
             }
         }
-        kernel().free(Page::from_usize(self.as_mut_ptr() as _));
+        // It is safe to convert inner to a Page because of the invariant.
+        let page = unsafe { Page::from_usize(self.inner.as_mut_ptr() as _) };
+        kernel().free(page);
     }
 }
 
 pub struct PageTable<A> {
+    // Internal safety invariant:
+    // ptr uniquely refers to a valid 3-level RawPageTable.
     ptr: *mut RawPageTable,
     _marker: PhantomData<A>,
 }
 
 impl<A: VAddr> PageTable<A> {
-    pub const fn zero() -> Self {
+    // TODO(rv6): it remains for initialization of ProcData.
+    // When ProcData changes to have Option<PageTable<_>> instead of
+    // PageTable<_>, this method can be removed.
+    pub const unsafe fn zero() -> Self {
         Self {
             ptr: ptr::null_mut(),
             _marker: PhantomData,
         }
     }
 
-    pub fn alloc_root(&mut self) -> Result<(), ()> {
-        let mut page = unsafe { kernel().alloc().ok_or(())? };
-        page.write_bytes(0);
-        self.ptr = page.into_usize() as *mut _;
-        Ok(())
-    }
-
-    pub fn from_raw(ptr: *mut RawPageTable) -> Self {
-        Self {
-            ptr,
+    /// Make a new empty page table by allocating a new page.
+    /// Return `Ok(..)` if the allocation has succeeded.
+    /// Return `None` if the allocation has failed.
+    pub fn new() -> Option<Self> {
+        Some(Self {
+            ptr: RawPageTable::new()?,
             _marker: PhantomData,
-        }
+        })
     }
 
-    pub fn into_raw(self) -> *mut RawPageTable {
-        let ret = self.ptr;
-        mem::forget(self);
-        ret
+    pub fn as_usize(&self) -> usize {
+        self.ptr as usize
     }
 
-    pub fn is_null(&self) -> bool {
-        self.ptr.is_null()
+    fn as_raw_mut(&mut self) -> &mut RawPageTable {
+        // It is safe because self.ptr uniquely refers to a valid RawPageTable
+        // according to the invariant.
+        unsafe { self.ptr.as_mut() }.expect("ptr must not be null")
     }
 
-    pub fn as_raw(&self) -> *mut RawPageTable {
-        self.ptr
-    }
-
-    /// Return the address of the PTE in page table pagetable
-    /// that corresponds to virtual address va. If alloc!=0,
+    /// Return the reference of the PTE in this page table
+    /// that corresponds to virtual address `va`. If `alloc` is true,
     /// create any required page-table pages.
     ///
     /// The risc-v Sv39 scheme has three levels of page-table
@@ -275,63 +315,25 @@ impl<A: VAddr> PageTable<A> {
     ///   21..29 -- 9 bits of level-1 index.
     ///   12..20 -- 9 bits of level-0 index.
     ///    0..11 -- 12 bits of byte offset within the page.
-    unsafe fn walk(&self, va: A, alloc: i32) -> Option<&mut PageTableEntry> {
-        let mut pagetable = &mut *self.as_raw();
+    fn walk(&mut self, va: A, alloc: bool) -> Option<&mut PageTableEntry> {
         assert!(va.into_usize() < MAXVA, "walk");
-
+        let mut page_table = self.as_raw_mut();
         for level in (1..3).rev() {
-            let pte = &mut pagetable[px(level, va)];
-            if pte.check_flag(PTE_V) {
-                pagetable = pte.as_table_mut_unchecked();
-            } else {
-                if alloc == 0 {
-                    return None;
-                }
-                let mut page = kernel().alloc()?;
-                page.write_bytes(0);
-                let k = page.into_usize();
-
-                pte.set_inner(pa2pte(PAddr::new(k)));
-                pte.set_flag(PTE_V);
-                pagetable = pte.as_table_mut_unchecked();
-            }
+            page_table = page_table.get_table_mut(px(level, va), alloc)?;
         }
-        Some(&mut pagetable[px(0, va)])
-    }
-
-    /// Look up a virtual address, return the physical address,
-    /// or 0 if not mapped.
-    pub unsafe fn walkaddr(&mut self, va: A) -> Option<PAddr> {
-        if va.into_usize() >= MAXVA {
-            return None;
-        }
-        let pt = self;
-        let pte = pt.walk(va, 0)?;
-        if !pte.check_flag(PTE_V) {
-            return None;
-        }
-        if !pte.check_flag(PTE_U as usize) {
-            return None;
-        }
-        Some(pte.get_pa())
+        Some(page_table.get_entry_mut(px(0, va)))
     }
 
     /// Create PTEs for virtual addresses starting at va that refer to
     /// physical addresses starting at pa. va and size might not
     /// be page-aligned. Returns Ok(()) on success, Err(()) if walk() couldn't
     /// allocate a needed page-table page.
-    pub unsafe fn mappages(
-        &mut self,
-        va: A,
-        size: usize,
-        mut pa: usize,
-        perm: i32,
-    ) -> Result<(), ()> {
+    pub fn map_pages(&mut self, va: A, size: usize, mut pa: usize, perm: i32) -> Result<(), ()> {
         let mut a = pgrounddown(va.into_usize());
         let last = pgrounddown(va.into_usize() + size - 1usize);
         loop {
-            let pte = self.walk(VAddr::new(a), 1).ok_or(())?;
-            assert!(!pte.check_flag(PTE_V), "remap");
+            let pte = self.walk(VAddr::new(a), true).ok_or(())?;
+            assert!(!pte.is_valid(), "remap");
 
             pte.set_inner(pa2pte(PAddr::new(pa)) | perm as usize | PTE_V);
             if a == last {
@@ -342,17 +344,183 @@ impl<A: VAddr> PageTable<A> {
         }
         Ok(())
     }
+}
+
+impl PageTable<UVAddr> {
+    /// Look up a virtual address, return Some(physical address),
+    /// or None if not mapped.
+    pub fn uvm_walk_addr(&mut self, va: UVAddr) -> Option<PAddr> {
+        if va.into_usize() >= MAXVA {
+            return None;
+        }
+        let pte = self.walk(va, false)?;
+        if !pte.is_valid() {
+            return None;
+        }
+        if !pte.check_flag(PTE_U as usize) {
+            return None;
+        }
+        Some(pte.get_pa())
+    }
+
+    /// Load the user initcode into address 0 of pagetable,
+    /// for the very first process.
+    /// sz must be less than a page.
+    pub unsafe fn uvm_init(&mut self, src: &[u8]) {
+        assert!(src.len() < PGSIZE, "inituvm: more than a page");
+
+        let mem = kernel().alloc().unwrap().into_usize() as *mut u8;
+        ptr::write_bytes(mem, 0, PGSIZE);
+        self.map_pages(
+            VAddr::new(0),
+            PGSIZE,
+            mem as usize,
+            PTE_W | PTE_R | PTE_X | PTE_U,
+        )
+        .expect("inituvm: mappage");
+        ptr::copy(src.as_ptr(), mem, src.len());
+    }
+
+    /// Allocate PTEs and physical memory to grow process from oldsz to
+    /// newsz, which need not be page aligned.  Returns Ok(new size) or Err(()) on error.
+    pub fn uvm_alloc(&mut self, mut oldsz: usize, newsz: usize) -> Result<usize, ()> {
+        if newsz < oldsz {
+            return Ok(oldsz);
+        }
+        oldsz = pgroundup(oldsz);
+        let mut a = oldsz;
+        while a < newsz {
+            let mut mem = some_or!(kernel().alloc(), {
+                self.uvm_dealloc(a, oldsz);
+                return Err(());
+            });
+            mem.write_bytes(0);
+            let pa = mem.into_usize();
+            if self
+                .map_pages(VAddr::new(a), PGSIZE, pa, PTE_W | PTE_X | PTE_R | PTE_U)
+                .is_err()
+            {
+                // It is safe because pa is an address of mem, which is a page
+                // obtained by alloc().
+                kernel().free(unsafe { Page::from_usize(pa) });
+                self.uvm_dealloc(a, oldsz);
+                return Err(());
+            }
+            a += PGSIZE;
+        }
+        Ok(newsz)
+    }
+
+    /// Given a parent process's page table, copy
+    /// its memory into a child's page table.
+    /// Copies both the page table and the
+    /// physical memory.
+    /// Returns Ok(()) on success, Err(()) on failure.
+    /// Frees any allocated pages on failure.
+    pub unsafe fn uvm_copy(
+        &mut self,
+        mut new: &mut PageTable<UVAddr>,
+        sz: usize,
+    ) -> Result<(), ()> {
+        for i in num_iter::range_step(0, sz, PGSIZE) {
+            let pte = self
+                .walk(UVAddr::new(i), false)
+                .expect("uvmcopy: pte should exist");
+            assert!(pte.is_valid(), "uvmcopy: page not present");
+
+            let mut new_ptable = scopeguard::guard(new, |ptable| {
+                ptable.uvm_unmap(UVAddr::new(0), i.wrapping_div(PGSIZE), true);
+            });
+            let pa = pte.get_pa();
+            let flags = pte.get_flags() as u32;
+            let mem = kernel().alloc().ok_or(())?.into_usize();
+            ptr::copy(
+                pa.into_usize() as *mut u8 as *const u8,
+                mem as *mut u8,
+                PGSIZE,
+            );
+            if (*new_ptable)
+                .map_pages(VAddr::new(i), PGSIZE, mem as usize, flags as i32)
+                .is_err()
+            {
+                kernel().free(Page::from_usize(mem as _));
+                return Err(());
+            }
+            new = scopeguard::ScopeGuard::into_inner(new_ptable);
+        }
+        Ok(())
+    }
+
+    /// Remove npages of mappings starting from va. va must be
+    /// page-aligned. The mappings must exist.
+    /// Optionally free the physical memory.
+    pub fn uvm_unmap(&mut self, va: UVAddr, npages: usize, do_free: bool) {
+        if va.into_usize().wrapping_rem(PGSIZE) != 0 {
+            panic!("uvmunmap: not aligned");
+        }
+        let start = va.into_usize();
+        let end = start.wrapping_add(npages.wrapping_mul(PGSIZE));
+        for a in num_iter::range_step(start, end, PGSIZE) {
+            let pt = &mut *self;
+            let pte = pt.walk(UVAddr::new(a), false).expect("uvmunmap: walk");
+            assert!(pte.is_data(), "uvmunmap: not a valid leaf");
+
+            if do_free {
+                let pa = pte.get_pa().into_usize();
+                // TODO(rv6)
+                // We do not know anything about pa, so, for now, we cannot
+                // guarantee that it is safe.
+                kernel().free(unsafe { Page::from_usize(pa) });
+            }
+            pte.set_inner(0);
+        }
+    }
+
+    /// Deallocate user pages to bring the process size from oldsz to
+    /// newsz.  oldsz and newsz need not be page-aligned, nor does newsz
+    /// need to be less than oldsz.  oldsz can be larger than the actual
+    /// process size.  Returns the new process size.
+    pub fn uvm_dealloc(&mut self, oldsz: usize, newsz: usize) -> usize {
+        if newsz >= oldsz {
+            return oldsz;
+        }
+
+        if pgroundup(newsz) < pgroundup(oldsz) {
+            let npages = (pgroundup(oldsz).wrapping_sub(pgroundup(newsz))).wrapping_div(PGSIZE);
+            self.uvm_unmap(UVAddr::new(pgroundup(newsz)), npages, true);
+        }
+        newsz
+    }
+
+    /// Free user memory pages,
+    /// then free page-table pages.
+    pub fn uvm_free(mut self, sz: usize) {
+        if sz > 0 {
+            self.uvm_unmap(UVAddr::new(0), pgroundup(sz).wrapping_div(PGSIZE), true);
+        }
+        // It is safe because this method consumes self, so the internal
+        // raw page table will not be use anymore.
+        unsafe { self.as_raw_mut().free_walk() };
+    }
+
+    /// Mark a PTE invalid for user access.
+    /// Used by exec for the user stack guard page.
+    pub fn uvm_guard(&mut self, va: UVAddr) {
+        self.walk(va, false)
+            .expect("uvmguard")
+            .clear_flag(PTE_U as usize);
+    }
 
     /// Copy from kernel to user.
     /// Copy len bytes from src to virtual address dstva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub unsafe fn copyout(&mut self, dstva: UVAddr, src: &[u8]) -> Result<(), ()> {
+    pub unsafe fn copy_out(&mut self, dstva: UVAddr, src: &[u8]) -> Result<(), ()> {
         let mut dst = dstva.into_usize();
         let mut len = src.len();
         let mut offset = 0;
         while len > 0 {
             let va0 = pgrounddown(dst);
-            let pa0 = self.walkaddr(VAddr::new(va0)).ok_or(())?.into_usize();
+            let pa0 = self.uvm_walk_addr(VAddr::new(va0)).ok_or(())?.into_usize();
             let mut n = PGSIZE - (dst - va0);
             if n > len {
                 n = len
@@ -368,159 +536,17 @@ impl<A: VAddr> PageTable<A> {
         }
         Ok(())
     }
-}
-
-impl PageTable<UVAddr> {
-    /// Load the user initcode into address 0 of pagetable,
-    /// for the very first process.
-    /// sz must be less than a page.
-    pub unsafe fn uvminit(&mut self, src: &[u8]) {
-        assert!(src.len() < PGSIZE, "inituvm: more than a page");
-
-        let mem = kernel().alloc().unwrap().into_usize() as *mut u8;
-        ptr::write_bytes(mem, 0, PGSIZE);
-        self.mappages(
-            VAddr::new(0),
-            PGSIZE,
-            mem as usize,
-            PTE_W | PTE_R | PTE_X | PTE_U,
-        )
-        .expect("inituvm: mappage");
-        ptr::copy(src.as_ptr(), mem, src.len());
-    }
-
-    /// Allocate PTEs and physical memory to grow process from oldsz to
-    /// newsz, which need not be page aligned.  Returns Ok(new size) or Err(()) on error.
-    pub unsafe fn uvmalloc(&mut self, mut oldsz: usize, newsz: usize) -> Result<usize, ()> {
-        if newsz < oldsz {
-            return Ok(oldsz);
-        }
-        oldsz = pgroundup(oldsz);
-        let mut a = oldsz;
-        while a < newsz {
-            let mut mem = some_or!(kernel().alloc(), {
-                self.uvmdealloc(a, oldsz);
-                return Err(());
-            });
-            mem.write_bytes(0);
-            let pa = mem.into_usize();
-            if self
-                .mappages(VAddr::new(a), PGSIZE, pa, PTE_W | PTE_X | PTE_R | PTE_U)
-                .is_err()
-            {
-                kernel().free(Page::from_usize(pa));
-                self.uvmdealloc(a, oldsz);
-                return Err(());
-            }
-            a += PGSIZE;
-        }
-        Ok(newsz)
-    }
-
-    /// Given a parent process's page table, copy
-    /// its memory into a child's page table.
-    /// Copies both the page table and the
-    /// physical memory.
-    /// Returns Ok(()) on success, Err(()) on failure.
-    /// Frees any allocated pages on failure.
-    pub unsafe fn uvmcopy(&mut self, mut new: &mut PageTable<UVAddr>, sz: usize) -> Result<(), ()> {
-        for i in num_iter::range_step(0, sz, PGSIZE) {
-            let pte = self
-                .walk(UVAddr::new(i), 0)
-                .expect("uvmcopy: pte should exist");
-            assert!(pte.check_flag(PTE_V), "uvmcopy: page not present");
-
-            let mut new_ptable = scopeguard::guard(new, |ptable| {
-                ptable.uvmunmap(UVAddr::new(0), i.wrapping_div(PGSIZE), true);
-            });
-            let pa = pte.get_pa();
-            let flags = pte.get_flags() as u32;
-            let mem = kernel().alloc().ok_or(())?.into_usize();
-            ptr::copy(
-                pa.into_usize() as *mut u8 as *const u8,
-                mem as *mut u8,
-                PGSIZE,
-            );
-            if (*new_ptable)
-                .mappages(VAddr::new(i), PGSIZE, mem as usize, flags as i32)
-                .is_err()
-            {
-                kernel().free(Page::from_usize(mem as _));
-                return Err(());
-            }
-            new = scopeguard::ScopeGuard::into_inner(new_ptable);
-        }
-        Ok(())
-    }
-
-    /// Remove npages of mappings starting from va. va must be
-    /// page-aligned. The mappings must exist.
-    /// Optionally free the physical memory.
-    pub unsafe fn uvmunmap(&mut self, va: UVAddr, npages: usize, do_free: bool) {
-        if va.into_usize().wrapping_rem(PGSIZE) != 0 {
-            panic!("uvmunmap: not aligned");
-        }
-        let start = va.into_usize();
-        let end = start.wrapping_add(npages.wrapping_mul(PGSIZE));
-        for a in num_iter::range_step(start, end, PGSIZE) {
-            let pt = &mut *self;
-            let pte = pt.walk(UVAddr::new(a), 0).expect("uvmunmap: walk");
-            if !pte.check_flag(PTE_V) {
-                panic!("uvmunmap: not mapped");
-            }
-            assert_ne!(pte.get_flags(), PTE_V, "uvmunmap: not a leaf");
-
-            if do_free {
-                let pa = pte.get_pa().into_usize();
-                kernel().free(Page::from_usize(pa as _));
-            }
-            pte.set_inner(0);
-        }
-    }
-
-    /// Deallocate user pages to bring the process size from oldsz to
-    /// newsz.  oldsz and newsz need not be page-aligned, nor does newsz
-    /// need to be less than oldsz.  oldsz can be larger than the actual
-    /// process size.  Returns the new process size.
-    pub unsafe fn uvmdealloc(&mut self, oldsz: usize, newsz: usize) -> usize {
-        if newsz >= oldsz {
-            return oldsz;
-        }
-
-        if pgroundup(newsz) < pgroundup(oldsz) {
-            let npages = (pgroundup(oldsz).wrapping_sub(pgroundup(newsz))).wrapping_div(PGSIZE);
-            self.uvmunmap(UVAddr::new(pgroundup(newsz)), npages, true);
-        }
-        newsz
-    }
-
-    /// Free user memory pages,
-    /// then free page-table pages.
-    pub unsafe fn uvmfree(&mut self, sz: usize) {
-        if sz > 0 {
-            self.uvmunmap(UVAddr::new(0), pgroundup(sz).wrapping_div(PGSIZE), true);
-        }
-        self.freewalk();
-    }
-
-    /// Mark a PTE invalid for user access.
-    /// Used by exec for the user stack guard page.
-    pub unsafe fn uvmclear(&mut self, va: UVAddr) {
-        self.walk(va, 0)
-            .expect("uvmclear")
-            .clear_flag(PTE_U as usize);
-    }
 
     /// Copy from user to kernel.
     /// Copy len bytes to dst from virtual address srcva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub unsafe fn copyin(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
+    pub unsafe fn copy_in(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
         let mut src = srcva.into_usize();
         let mut len = dst.len();
         let mut offset = 0;
         while len > 0 {
             let va0 = pgrounddown(src);
-            let pa0 = self.walkaddr(VAddr::new(va0)).ok_or(())?.into_usize();
+            let pa0 = self.uvm_walk_addr(VAddr::new(va0)).ok_or(())?.into_usize();
             let mut n = PGSIZE - (src - va0);
             if n > len {
                 n = len
@@ -541,14 +567,14 @@ impl PageTable<UVAddr> {
     /// Copy bytes to dst from virtual address srcva in a given page table,
     /// until a '\0', or max.
     /// Return OK(()) on success, Err(()) on error.
-    pub unsafe fn copyinstr(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
+    pub unsafe fn copy_in_str(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
         let mut got_null: i32 = 0;
         let mut src = srcva.into_usize();
         let mut offset = 0;
         let mut max = dst.len();
         while got_null == 0 && max > 0 {
             let va0 = pgrounddown(src);
-            let pa0 = self.walkaddr(VAddr::new(va0)).ok_or(())?.into_usize();
+            let pa0 = self.uvm_walk_addr(VAddr::new(va0)).ok_or(())?.into_usize();
             let mut n = PGSIZE - (src - va0);
             if n > max {
                 n = max
@@ -577,26 +603,18 @@ impl PageTable<UVAddr> {
     }
 }
 
-impl<T> Deref for PageTable<T> {
-    type Target = RawPageTable;
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.ptr }
-    }
-}
-
-impl<T> DerefMut for PageTable<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.ptr }
-    }
-}
-
 impl PageTable<KVAddr> {
     /// Make a direct-map page table for the kernel.
-    pub unsafe fn kvmmake(&mut self) {
-        let _ = self.alloc_root();
+    pub fn kvm_new() -> Option<Self> {
+        let mut page_table = Self::new()?;
+        page_table.kvm_make();
+        Some(page_table)
+    }
 
+    /// Add direct-mappings for the kernel to this page table.
+    pub fn kvm_make(&mut self) {
         // SiFive Test Finisher MMIO
-        self.kvmmap(
+        self.kvm_map(
             KVAddr::new(FINISHER),
             PAddr::new(FINISHER),
             PGSIZE,
@@ -604,10 +622,10 @@ impl PageTable<KVAddr> {
         );
 
         // Uart registers
-        self.kvmmap(KVAddr::new(UART0), PAddr::new(UART0), PGSIZE, PTE_R | PTE_W);
+        self.kvm_map(KVAddr::new(UART0), PAddr::new(UART0), PGSIZE, PTE_R | PTE_W);
 
         // Virtio mmio disk interface
-        self.kvmmap(
+        self.kvm_map(
             KVAddr::new(VIRTIO0),
             PAddr::new(VIRTIO0),
             PGSIZE,
@@ -615,29 +633,25 @@ impl PageTable<KVAddr> {
         );
 
         // PLIC
-        self.kvmmap(KVAddr::new(PLIC), PAddr::new(PLIC), 0x400000, PTE_R | PTE_W);
+        self.kvm_map(KVAddr::new(PLIC), PAddr::new(PLIC), 0x400000, PTE_R | PTE_W);
 
         // Map kernel text executable and read-only.
-        self.kvmmap(
+        let et = unsafe { etext.as_mut_ptr() as usize };
+        self.kvm_map(
             KVAddr::new(KERNBASE),
             PAddr::new(KERNBASE),
-            (etext.as_mut_ptr() as usize) - KERNBASE,
+            et - KERNBASE,
             PTE_R | PTE_X,
         );
 
         // Map kernel data and the physical RAM we'll make use of.
-        self.kvmmap(
-            KVAddr::new(etext.as_mut_ptr() as usize),
-            PAddr::new(etext.as_mut_ptr() as usize),
-            PHYSTOP - (etext.as_mut_ptr() as usize),
-            PTE_R | PTE_W,
-        );
+        self.kvm_map(KVAddr::new(et), PAddr::new(et), PHYSTOP - et, PTE_R | PTE_W);
 
         // Map the trampoline for trap entry/exit to
         // the highest virtual address in the kernel.
-        self.kvmmap(
+        self.kvm_map(
             KVAddr::new(TRAMPOLINE),
-            PAddr::new(trampoline.as_mut_ptr() as usize),
+            PAddr::new(unsafe { trampoline.as_mut_ptr() as usize }),
             PGSIZE,
             PTE_R | PTE_X,
         );
@@ -646,14 +660,9 @@ impl PageTable<KVAddr> {
         proc_mapstacks(self);
     }
 
-    /// Initialize the one kernel_pagetable
-    pub unsafe fn kvminit(&mut self) {
-        self.kvmmake();
-    }
-
     /// Switch h/w page table register to the kernel's page table,
     /// and enable paging.
-    pub unsafe fn kvminithart(&self) {
+    pub unsafe fn kvm_init_hart(&self) {
         w_satp(make_satp(self.ptr as usize));
         sfence_vma();
     }
@@ -661,8 +670,17 @@ impl PageTable<KVAddr> {
     /// Add a mapping to the kernel page table.
     /// Only used when booting.
     /// Does not flush TLB or enable paging.
-    pub unsafe fn kvmmap(&mut self, va: KVAddr, pa: PAddr, sz: usize, perm: i32) {
-        self.mappages(va, sz, pa.into_usize(), perm)
-            .expect("kvmmap");
+    pub fn kvm_map(&mut self, va: KVAddr, pa: PAddr, sz: usize, perm: i32) {
+        self.map_pages(va, sz, pa.into_usize(), perm)
+            .expect("kvm_map");
+    }
+}
+
+impl Kernel {
+    pub unsafe fn kvm_init_hart(&self) {
+        self.page_table
+            .as_ref()
+            .expect("kernel page table must not be None")
+            .kvm_init_hart();
     }
 }


### PR DESCRIPTION
```rust
acquire("vm.rs")
```

~제가 현재 VM 관련 코드를 리팩토링 중이라는 사실을 명시적으로 알려 드리기 위한 draft PR입니다. 앞으로 수정이 많이 이루어질 것 같으니 리뷰는 그 이후에 부탁드리겠습니다.~

```rust
release("vm.rs")
```

## Invariant

자세한 내용은 코드에 주석으로 있음.

* `Page`: 서로 다른 두 `Page`는 겹치지 않음.
* `RawPageTable`: V 플래그는 켜져 있고 R, W, X 플래그는 지워진 엔트리는 page-table 페이지를 가리킴. 임의 높이의 트리로 생각.
* `PageTable`: 3-level 트리 구조 유지. 임의의 `VAddr`을 받아 대응되는 `PAddr`을 내놓는 맵으로 생각.

현재는 `PageTable` 구조의 올바름을 보장할 수 있지만, `PageTable`이 가지고 있는 `PAddr`이 올바른 페이지에 대응된다는 사실을 보장할 수 없음. 따라서 `PageTable<UVAddr>::copy_out`과 같이 페이지 주소를 찾아 그 페이지에 데이터를 쓰거나 페이지로부터 데이터를 읽는 메서드의 안전성을 보장할 수 없음. 이는 `PageTable`의 invariant가 아니라 다른 타입의 invariant로 보장할 예정. 현재는 `Proc`이 `PageTable`을 가지고 있지만, 이 사이에 한 단계를 추가해 `Proc`은 `MemoryManager`를, `MemoryManager`는 `PageTable`를 가지고, `MemoryManager`의 invariant가 `PageTable`이 가지고 있는 주소의 올바름을 보장하도록 이후의 PR에서 수정할 예정.

## 수정 사항

* 초기화된 `PageTable<_>`을 만드는 `PageTable<_>::new()` 추가. `PageTable<_>::zero`는 이후에 없애야 함. 초기화된 커널 `PageTable<KVAddr>`을 만드는 `PageTable<KVAddr>::kvm_new` 추가하고 기존의 `PageTable<KVAddr>::kvminit` 삭제.
* `PageTable<_>::walkaddr`과 `PageTable<_>::copyout`을 `PageTable<UVAddr>::uvm_walk_addr`과 `PageTable<UVAddr>::uvm_copy_out`으로 이동. `walkaddr`은 내부에서 PTE_U 플래그를 확인하므로 `PageTable<UVAddr>` 안에 있어야 함.
* `PageTable<UVAddr>::uvmclear`의 이름을 `PageTable<UVAddr>::uvm_guard`로 바꿈. PTE_U 플래그를 지워 guard 페이지를 만드는 것이 목적인 메서드이므로 `uvmclear`라는 이름은 용도를 헷갈리게 함.
* `PageTable<UVAddr>::uvmfree`가 `&mut self` 대신 `mut self`를 인자로 받도록 함. 이 메서드는 자기 자신이 위치한 페이지 할당을 해제하므로 이 메서드가 불린 이후에는 해당 페이지 테이블이 더 이상 사용되어서는 안 됨.
* `Kernel`이 `PageTable` 대신 `Option<PageTable>` 타입의 필드를 가지도록 수정.
* 전역 함수 `kinit`을 `Kmem` 메서드 `init`으로 이동.
* Safety condition, internal safety invariant, unsafe block이 안전한 이유 주석으로 추가(주로 `vm.rs`. `Page` 관련된 코드도 일부 해당).
* `uvmalloc` -> `uvm_alloc` 등 메서드 이름에 snake case 사용.