### PR TITLE
Refactoring VM by exploiting invariants of Page and PageTable

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -45,7 +45,7 @@ impl Console {
     unsafe fn write(&mut self, src: UVAddr, n: i32) -> i32 {
         for i in 0..n {
             let mut c = [0 as u8];
-            if VAddr::copyin(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
+            if VAddr::copy_in(&mut c, UVAddr::new(src.into_usize() + (i as usize))).is_err() {
                 return i;
             }
             // TODO(@coolofficials): Temporarily using global function kernel().
@@ -81,7 +81,7 @@ impl Console {
             } else {
                 // Copy the input byte to the user-space buffer.
                 let cbuf = [cin as u8];
-                if UVAddr::copyout(dst, &cbuf).is_err() {
+                if UVAddr::copy_out(dst, &cbuf).is_err() {
                     break;
                 }
                 dst = dst + 1;

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::Kernel,
     ok_or,
     param::MAXARG,
-    proc::{myproc, proc_freepagetable, proc_pagetable, Proc},
+    proc::{myproc, proc_freepagetable, Proc},
     riscv::PGSIZE,
     string::{safestrcpy, strlen},
     vm::{KVAddr, PageTable, UVAddr, VAddr},
@@ -119,10 +119,10 @@ impl Kernel {
             return Err(());
         }
 
-        let pt = proc_pagetable(p)?;
+        let pt = PageTable::<UVAddr>::new(data.trapframe).ok_or(())?;
 
-        let mut ptable_guard = scopeguard::guard((pt, sz), |(mut pt, sz)| {
-            proc_freepagetable(&mut pt, sz);
+        let mut ptable_guard = scopeguard::guard((pt, sz), |(pt, sz)| {
+            proc_freepagetable(pt, sz);
         });
 
         let (pt, sz) = &mut *ptable_guard;
@@ -146,7 +146,7 @@ impl Kernel {
                 if ph.vaddr.wrapping_add(ph.memsz) < ph.vaddr {
                     return Err(());
                 }
-                let sz1 = pt.uvmalloc(*sz, ph.vaddr.wrapping_add(ph.memsz))?;
+                let sz1 = pt.alloc(*sz, ph.vaddr.wrapping_add(ph.memsz))?;
                 *sz = sz1;
                 if ph.vaddr.wrapping_rem(PGSIZE) != 0 {
                     return Err(());
@@ -169,9 +169,9 @@ impl Kernel {
         // Use the second as the user stack.
         *sz = sz.wrapping_add(PGSIZE).wrapping_sub(1) & !PGSIZE.wrapping_sub(1);
 
-        let sz1 = pt.uvmalloc(*sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)))?;
+        let sz1 = pt.alloc(*sz, sz.wrapping_add(2usize.wrapping_mul(PGSIZE)))?;
         *sz = sz1;
-        pt.uvmclear(UVAddr::new(sz.wrapping_sub(2usize.wrapping_mul(PGSIZE))));
+        pt.clear(UVAddr::new(sz.wrapping_sub(2usize.wrapping_mul(PGSIZE))));
         let mut sp: usize = *sz;
         let stackbase: usize = sp.wrapping_sub(PGSIZE);
 
@@ -191,7 +191,7 @@ impl Kernel {
             if sp < stackbase {
                 return Err(());
             }
-            pt.copyout(
+            pt.copy_out(
                 UVAddr::new(sp),
                 slice::from_raw_parts_mut(argv[argc], (strlen(argv[argc]) + 1) as usize),
             )?;
@@ -206,7 +206,7 @@ impl Kernel {
 
         if sp >= stackbase
             && pt
-                .copyout(
+                .copy_out(
                     UVAddr::new(sp),
                     slice::from_raw_parts_mut(
                         ustack.as_mut_ptr() as *mut u8,
@@ -237,7 +237,7 @@ impl Kernel {
             );
 
             // Commit to the user image.
-            let mut oldpagetable = mem::replace(&mut data.pagetable, pt);
+            let oldpagetable = mem::replace(&mut data.pagetable, pt);
             data.sz = sz;
 
             // initial program counter = main
@@ -245,7 +245,7 @@ impl Kernel {
 
             // initial stack pointer
             (*data.trapframe).sp = sp;
-            proc_freepagetable(&mut oldpagetable, oldsz);
+            proc_freepagetable(oldpagetable, oldsz);
 
             // this ends up in a0, the first argument to main(argc, argv)
             return Ok(argc);
@@ -270,7 +270,7 @@ unsafe fn loadseg(
 
     for i in num_iter::range_step(0, sz, PGSIZE as _) {
         let pa = pagetable
-            .walkaddr(va + i as usize)
+            .walk_addr(va + i as usize)
             .expect("loadseg: address should exist")
             .into_usize();
 

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -75,7 +75,7 @@ impl File {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
-                (*(*p).data.get()).pagetable.copyout(
+                (*(*p).data.get()).pagetable.copy_out(
                     addr,
                     slice::from_raw_parts_mut(
                         &mut st as *mut Stat as *mut u8,

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -394,7 +394,7 @@ impl InodeGuard<'_> {
             let begin = off.wrapping_rem(BSIZE as u32) as usize;
             let end = begin + m as usize;
             unsafe {
-                VAddr::copyout(dst, &bp.deref_mut_inner().data[begin..end])?;
+                VAddr::copy_out(dst, &bp.deref_mut_inner().data[begin..end])?;
             }
             tot = tot.wrapping_add(m);
             off = off.wrapping_add(m);
@@ -433,7 +433,7 @@ impl InodeGuard<'_> {
             let begin = off.wrapping_rem(BSIZE as u32) as usize;
             let end = begin + m as usize;
             unsafe {
-                if VAddr::copyin(&mut bp.deref_mut_inner().data[begin..end], src).is_err() {
+                if VAddr::copy_in(&mut bp.deref_mut_inner().data[begin..end], src).is_err() {
                     break;
                 }
             }

--- a/kernel-rs/src/kalloc.rs
+++ b/kernel-rs/src/kalloc.rs
@@ -20,6 +20,12 @@ struct Run {
     next: *mut Run,
 }
 
+/// # Safety
+///
+/// The invariants of this struct are as follows:
+/// - This singly linked list does not have a cycle.
+/// - If head is null, then it is an empty list. Ohterwise, it is nonempty, and
+///   head is its first element, which is a valid page.
 pub struct Kmem {
     head: *mut Run,
 }
@@ -31,13 +37,27 @@ impl Kmem {
         }
     }
 
-    pub unsafe fn free(&mut self, pa: Page) {
+    /// # Safety
+    ///
+    /// Must be called only once. Create pages between `end` and `PHYSTOP` by
+    /// calling freerange.
+    pub unsafe fn init(&mut self) {
+        self.freerange(end.as_mut_ptr(), PHYSTOP as _);
+    }
+
+    pub fn free(&mut self, pa: Page) {
         let mut r = pa.into_usize() as *mut Run;
-        (*r).next = self.head;
+        // By the invariant of Page, it does not create a cycle in this list and
+        // thus is safe.
+        unsafe { (*r).next = self.head };
         self.head = r;
     }
 
-    pub unsafe fn freerange(&mut self, pa_start: *mut u8, pa_end: *mut u8) {
+    /// # Safety
+    ///
+    /// Create pages between `pa_start` and `pa_end`. Created pages must
+    /// not overwrap with any existing pages.
+    unsafe fn freerange(&mut self, pa_start: *mut u8, pa_end: *mut u8) {
         let mut p = pgroundup(pa_start as _) as *mut u8;
         while p.add(PGSIZE) <= pa_end {
             self.free(Page::from_usize(p as _));
@@ -45,15 +65,14 @@ impl Kmem {
         }
     }
 
-    pub unsafe fn alloc(&mut self) -> Option<Page> {
+    pub fn alloc(&mut self) -> Option<Page> {
         if self.head.is_null() {
             return None;
         }
-        let next = (*self.head).next;
-        Some(Page::from_usize(mem::replace(&mut self.head, next) as _))
+        // It is safe because head is not null and the structure of this list
+        // is maintained by the invariant.
+        let next = unsafe { (*self.head).next };
+        // It is safe because the first element is a valid page by the invariant.
+        Some(unsafe { Page::from_usize(mem::replace(&mut self.head, next) as _) })
     }
-}
-
-pub unsafe fn kinit(kmem: &mut Kmem) {
-    kmem.freerange(end.as_mut_ptr(), PHYSTOP as _);
 }

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -17,6 +17,7 @@
 #![feature(maybe_uninit_extra)]
 #![feature(min_const_generics)]
 #![feature(generic_associated_types)]
+#![feature(unsafe_block_in_unsafe_fn)]
 
 mod arena;
 mod bio;

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -12,6 +12,13 @@ pub struct RawPage {
     inner: [u8; PGSIZE],
 }
 
+/// # Safety
+///
+/// The invariants of this struct are as follows:
+/// - inner is 4096 bytes-aligned.
+/// - end <= inner < PHYSTOP
+/// - Two different pages never overwrap. If p1: Page and p2: Page, then
+///   *(p1.inner).inner and *(p1.inner).inner are non-overwrapping arrays.
 pub struct Page {
     inner: *mut RawPage,
 }
@@ -48,7 +55,14 @@ impl Page {
         result
     }
 
-    pub fn from_usize(addr: usize) -> Self {
+    /// # Safety
+    ///
+    /// Given addr must not break the invariant of Page.
+    /// - addr is a multiple of 4096.
+    /// - end <= addr < PHYSTOP
+    /// - If p: Page, then *(p.inner).inner and (addr as *RawPage).inner are
+    ///   non-overwrapping arrays.
+    pub unsafe fn from_usize(addr: usize) -> Self {
         Self {
             inner: addr as *mut _,
         }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -174,7 +174,7 @@ impl PipeInner {
                 //DOC: pipewrite-full
                 return Ok(i);
             }
-            if data.pagetable.copyin(&mut ch, addr + i).is_err() {
+            if data.pagetable.copy_in(&mut ch, addr + i).is_err() {
                 return Err(PipeError::InvalidCopyin(i));
             }
             self.data[self.nwrite as usize % PIPESIZE] = ch[0];
@@ -202,7 +202,7 @@ impl PipeInner {
             }
             let ch = [self.data[self.nread as usize % PIPESIZE]];
             self.nread = self.nread.wrapping_add(1);
-            if data.pagetable.copyout(addr + i, &ch).is_err() {
+            if data.pagetable.copy_out(addr + i, &ch).is_err() {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -18,7 +18,7 @@ pub unsafe fn fetchaddr(addr: UVAddr, ip: *mut usize) -> i32 {
     }
     if data
         .pagetable
-        .copyin(
+        .copy_in(
             slice::from_raw_parts_mut(ip as *mut u8, mem::size_of::<usize>()),
             addr,
         )
@@ -33,7 +33,7 @@ pub unsafe fn fetchaddr(addr: UVAddr, ip: *mut usize) -> i32 {
 /// Returns reference to the string in the buffer.
 pub unsafe fn fetchstr(addr: UVAddr, buf: &mut [u8]) -> Result<&CStr, ()> {
     let p: *mut Proc = myproc();
-    (*(*p).data.get()).pagetable.copyinstr(buf, addr)?;
+    (*(*p).data.get()).pagetable.copy_in_str(buf, addr)?;
 
     Ok(CStr::from_ptr(buf.as_ptr()))
 }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -380,14 +380,14 @@ impl Kernel {
 
         if data
             .pagetable
-            .copyout(
+            .copy_out(
                 UVAddr::new(fdarray),
                 slice::from_raw_parts_mut(&mut fd0 as *mut i32 as *mut u8, mem::size_of::<i32>()),
             )
             .is_err()
             || data
                 .pagetable
-                .copyout(
+                .copy_out(
                     UVAddr::new(fdarray.wrapping_add(mem::size_of::<i32>())),
                     slice::from_raw_parts_mut(
                         &mut fd1 as *mut i32 as *mut u8,

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -139,7 +139,7 @@ pub unsafe fn usertrapret() {
     w_sepc((*data.trapframe).epc);
 
     // Tell trampoline.S the user page table to switch to.
-    let satp: usize = make_satp(data.pagetable.as_raw() as usize);
+    let satp: usize = make_satp(data.pagetable.as_usize());
 
     // Jump to trampoline.S at the top of memory, which
     // switches to the user page table, restores user registers,

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -1,20 +1,16 @@
 use crate::{
     kernel::kernel,
-    memlayout::{FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, UART0, VIRTIO0},
-    page::{Page, RawPage},
-    proc::{myproc, proc_mapstacks},
+    memlayout::{kstack, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, TRAPFRAME, UART0, VIRTIO0},
+    page::Page,
+    param::NPROC,
+    proc::{myproc, Trapframe},
     riscv::{
         make_satp, pa2pte, pgrounddown, pgroundup, pte2pa, pte_flags, px, sfence_vma, w_satp, PteT,
         MAXVA, PGSIZE, PTE_R, PTE_U, PTE_V, PTE_W, PTE_X,
     },
     some_or,
 };
-use core::{
-    marker::PhantomData,
-    mem,
-    ops::{Add, Deref, DerefMut},
-    ptr,
-};
+use core::{marker::PhantomData, mem, ops::Add, ptr};
 
 extern "C" {
     // kernel.ld sets this to end of kernel code.
@@ -32,6 +28,14 @@ pub struct KVAddr(usize);
 
 #[derive(Clone, Copy)]
 pub struct UVAddr(usize);
+
+impl Add<usize> for PAddr {
+    type Output = Self;
+
+    fn add(self, rhs: usize) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
 
 impl PAddr {
     pub const fn new(value: usize) -> Self {
@@ -70,11 +74,11 @@ pub trait VAddr: Copy + Add<usize, Output = Self> {
 
     /// Copy from either a user address, or kernel address.
     /// Returns Ok(()) on success, Err(()) on error.
-    unsafe fn copyin(dst: &mut [u8], src: Self) -> Result<(), ()>;
+    unsafe fn copy_in(dst: &mut [u8], src: Self) -> Result<(), ()>;
 
     /// Copy to either a user address, or kernel address.
     /// Returns Ok(()) on success, Err(()) on error.
-    unsafe fn copyout(dst: Self, src: &[u8]) -> Result<(), ()>;
+    unsafe fn copy_out(dst: Self, src: &[u8]) -> Result<(), ()>;
 }
 
 impl VAddr for KVAddr {
@@ -94,12 +98,12 @@ impl VAddr for KVAddr {
         self.0 % PGSIZE == 0
     }
 
-    unsafe fn copyin(dst: &mut [u8], src: Self) -> Result<(), ()> {
+    unsafe fn copy_in(dst: &mut [u8], src: Self) -> Result<(), ()> {
         ptr::copy(src.into_usize() as *const u8, dst.as_mut_ptr(), dst.len());
         Ok(())
     }
 
-    unsafe fn copyout(dst: Self, src: &[u8]) -> Result<(), ()> {
+    unsafe fn copy_out(dst: Self, src: &[u8]) -> Result<(), ()> {
         ptr::copy(src.as_ptr(), dst.into_usize() as *mut u8, src.len());
         Ok(())
     }
@@ -122,25 +126,25 @@ impl VAddr for UVAddr {
         self.0 % PGSIZE == 0
     }
 
-    unsafe fn copyin(dst: &mut [u8], src: Self) -> Result<(), ()> {
+    unsafe fn copy_in(dst: &mut [u8], src: Self) -> Result<(), ()> {
         let p = myproc();
         (*(*p).data.get())
             .pagetable
-            .copyin(dst, src)
+            .copy_in(dst, src)
             .map_or(Err(()), |_v| Ok(()))
     }
 
-    unsafe fn copyout(dst: Self, src: &[u8]) -> Result<(), ()> {
+    unsafe fn copy_out(dst: Self, src: &[u8]) -> Result<(), ()> {
         let p = myproc();
         (*(*p).data.get())
             .pagetable
-            .copyout(dst, src)
+            .copy_out(dst, src)
             .map_or(Err(()), |_v| Ok(()))
     }
 }
 
 #[derive(Default)]
-pub struct PageTableEntry {
+struct PageTableEntry {
     inner: PteT,
 }
 
@@ -169,102 +173,161 @@ impl PageTableEntry {
         pte2pa(self.inner)
     }
 
-    unsafe fn as_page(&self) -> &RawPage {
-        &*(pte2pa(self.inner).into_usize() as *const RawPage)
+    fn is_valid(&self) -> bool {
+        self.check_flag(PTE_V)
     }
 
-    fn as_table_mut(&mut self) -> Option<&mut RawPageTable> {
-        if self.check_flag(PTE_V) && !self.check_flag((PTE_R | PTE_W | PTE_X) as usize) {
-            Some(unsafe { &mut *(pte2pa(self.inner).into_usize() as *mut RawPageTable) })
+    fn is_user_accessible(&self) -> bool {
+        self.check_flag(PTE_V | PTE_U as usize)
+    }
+
+    fn is_table(&self) -> bool {
+        self.is_valid() && !self.check_flag((PTE_R | PTE_W | PTE_X) as usize)
+    }
+
+    fn is_data(&self) -> bool {
+        self.is_valid() && self.check_flag((PTE_R | PTE_W | PTE_X) as usize)
+    }
+
+    /// # Safety
+    ///
+    /// If `self.is_table()` is true, then it must refer to a valid page-table page.
+    ///
+    /// Return `Some(..)` if it refers to a page-table page.
+    /// Return `None` if it refers to a data page.
+    /// Return `None` if it is invalid.
+    // TODO(rv6)
+    // It is unsafe because it can be used safely only with the invariant of
+    // RawPageTable. If we consider the invariant as an invariant of
+    // PageTableEntry, the unsafe modifier can be removed. However, it will
+    // make other methods such as set_inner unsafe.
+    // https://github.com/kaist-cp/rv6/issues/339
+    unsafe fn as_table_mut(&mut self) -> Option<&mut RawPageTable> {
+        if self.is_table() {
+            Some(&mut *(pte2pa(self.inner).into_usize() as *mut RawPageTable))
         } else {
             None
         }
-    }
-
-    unsafe fn as_table_mut_unchecked(&mut self) -> &mut RawPageTable {
-        &mut *(pte2pa(self.inner).into_usize() as *mut RawPageTable)
     }
 }
 
 const PTE_PER_PT: usize = PGSIZE / mem::size_of::<PageTableEntry>();
 
-pub struct RawPageTable {
+/// # Safety
+///
+/// The invariants of this struct are as follows:
+/// - If an entry's V flag is set but its RWX flags are not set,
+///   then it must refer to a valid page-table page.
+/// - It should be safely converted to a Page without breaking the invariants
+///   of Page.
+/// - It should not be accessed outside RawPageTable to guarantee the
+///   invariant.
+struct RawPageTable {
     inner: [PageTableEntry; PTE_PER_PT],
 }
 
-impl Deref for RawPageTable {
-    type Target = [PageTableEntry; PTE_PER_PT];
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl DerefMut for RawPageTable {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
-    }
-}
-
 impl RawPageTable {
+    /// Make a new emtpy raw page table by allocating a new page.
+    /// Return `Ok(..)` if the allocation has succeeded.
+    /// Return `None` if the allocation has failed.
+    fn new() -> Option<*mut RawPageTable> {
+        let mut page = kernel().alloc()?;
+        page.write_bytes(0);
+        Some(page.into_usize() as *mut RawPageTable)
+    }
+
+    /// Return `Some(..)` if the `index`th entry refers to a page-table page.
+    /// Return `Some(..)` by allocating a new page if the `index`th
+    /// entry is invalid but `alloc` is true. The result becomes `None` when the
+    /// allocation has failed.
+    /// Return `None` if the `index`th entry refers to a data page.
+    /// Return `None` if the `index`th entry is invalid and `alloc` is false.
+    fn get_table_mut(&mut self, index: usize, alloc: bool) -> Option<&mut RawPageTable> {
+        let pte = &mut self.inner[index];
+        if !pte.is_valid() {
+            if !alloc {
+                return None;
+            }
+            let page = Self::new()?;
+            let k = page as usize;
+            pte.set_inner(pa2pte(PAddr::new(k)) | PTE_V);
+        }
+        // It is safe because of the RawPageTable's invariant.
+        unsafe { pte.as_table_mut() }
+    }
+
+    /// Return a `PageTableEntry` if the `index`th entry refers to a data page.
+    /// Return a `PageTableEntry` if the `index`th entry is invalid.
+    /// Panic if the `index`th entry refers to a page-table page.
+    fn get_entry_mut(&mut self, index: usize) -> &mut PageTableEntry {
+        let pte = &mut self.inner[index];
+        assert!(!pte.is_table());
+        pte
+    }
+
     /// Recursively free page-table pages.
     /// All leaf mappings must already have been removed.
-    unsafe fn freewalk(&mut self) {
+    /// This method frees the page table itself, so this page table must
+    /// not be used after an invocation of this method.
+    #[deny(unsafe_op_in_unsafe_fn)]
+    unsafe fn free_walk(&mut self) {
         // There are 2^9 = 512 PTEs in a page table.
         for pte in &mut self.inner {
-            if let Some(ptable) = pte.as_table_mut() {
-                ptable.freewalk();
+            // It is safe because of the RawPageTable's invariant.
+            if let Some(ptable) = unsafe { pte.as_table_mut() } {
+                // It is safe because ptable will not be used anymore.
+                unsafe { ptable.free_walk() };
                 pte.set_inner(0);
-            } else {
-                assert!(!pte.check_flag(PTE_V), "freewalk: leaf");
             }
         }
-        kernel().free(Page::from_usize(self.as_mut_ptr() as _));
+        // It is safe to convert inner to a Page because of the invariant.
+        let page = unsafe { Page::from_usize(self.inner.as_mut_ptr() as _) };
+        kernel().free(page);
     }
 }
 
+/// # Safety
+///
+/// The invariant of this struct is that ptr uniquely refers to a valid 3-level
+/// RawPageTable.
 pub struct PageTable<A> {
     ptr: *mut RawPageTable,
     _marker: PhantomData<A>,
 }
 
 impl<A: VAddr> PageTable<A> {
-    pub const fn zero() -> Self {
+    /// # Saftey
+    ///
+    /// Any page table returned by this method must not be used at all.
+    pub const unsafe fn zero() -> Self {
         Self {
             ptr: ptr::null_mut(),
             _marker: PhantomData,
         }
     }
 
-    pub fn alloc_root(&mut self) -> Result<(), ()> {
-        let mut page = unsafe { kernel().alloc().ok_or(())? };
-        page.write_bytes(0);
-        self.ptr = page.into_usize() as *mut _;
-        Ok(())
-    }
-
-    pub fn from_raw(ptr: *mut RawPageTable) -> Self {
-        Self {
-            ptr,
+    /// Make a new empty page table by allocating a new page.
+    /// Return `Ok(..)` if the allocation has succeeded.
+    /// Return `None` if the allocation has failed.
+    fn new_empty_table() -> Option<Self> {
+        Some(Self {
+            ptr: RawPageTable::new()?,
             _marker: PhantomData,
-        }
+        })
     }
 
-    pub fn into_raw(self) -> *mut RawPageTable {
-        let ret = self.ptr;
-        mem::forget(self);
-        ret
+    pub fn as_usize(&self) -> usize {
+        self.ptr as usize
     }
 
-    pub fn is_null(&self) -> bool {
-        self.ptr.is_null()
+    fn as_inner_mut(&mut self) -> &mut RawPageTable {
+        // It is safe because self.ptr uniquely refers to a valid RawPageTable
+        // according to the invariant.
+        unsafe { &mut *self.ptr }
     }
 
-    pub fn as_raw(&self) -> *mut RawPageTable {
-        self.ptr
-    }
-
-    /// Return the address of the PTE in page table pagetable
-    /// that corresponds to virtual address va. If alloc!=0,
+    /// Return the reference of the PTE in this page table
+    /// that corresponds to virtual address `va`. If `alloc` is true,
     /// create any required page-table pages.
     ///
     /// The risc-v Sv39 scheme has three levels of page-table
@@ -275,84 +338,259 @@ impl<A: VAddr> PageTable<A> {
     ///   21..29 -- 9 bits of level-1 index.
     ///   12..20 -- 9 bits of level-0 index.
     ///    0..11 -- 12 bits of byte offset within the page.
-    unsafe fn walk(&self, va: A, alloc: i32) -> Option<&mut PageTableEntry> {
-        let mut pagetable = &mut *self.as_raw();
+    fn walk(&mut self, va: A, alloc: bool) -> Option<&mut PageTableEntry> {
         assert!(va.into_usize() < MAXVA, "walk");
-
+        let mut page_table = self.as_inner_mut();
         for level in (1..3).rev() {
-            let pte = &mut pagetable[px(level, va)];
-            if pte.check_flag(PTE_V) {
-                pagetable = pte.as_table_mut_unchecked();
-            } else {
-                if alloc == 0 {
-                    return None;
-                }
-                let mut page = kernel().alloc()?;
-                page.write_bytes(0);
-                let k = page.into_usize();
-
-                pte.set_inner(pa2pte(PAddr::new(k)));
-                pte.set_flag(PTE_V);
-                pagetable = pte.as_table_mut_unchecked();
-            }
+            page_table = page_table.get_table_mut(px(level, va), alloc)?;
         }
-        Some(&mut pagetable[px(0, va)])
-    }
-
-    /// Look up a virtual address, return the physical address,
-    /// or 0 if not mapped.
-    pub unsafe fn walkaddr(&mut self, va: A) -> Option<PAddr> {
-        if va.into_usize() >= MAXVA {
-            return None;
-        }
-        let pt = self;
-        let pte = pt.walk(va, 0)?;
-        if !pte.check_flag(PTE_V) {
-            return None;
-        }
-        if !pte.check_flag(PTE_U as usize) {
-            return None;
-        }
-        Some(pte.get_pa())
+        Some(page_table.get_entry_mut(px(0, va)))
     }
 
     /// Create PTEs for virtual addresses starting at va that refer to
     /// physical addresses starting at pa. va and size might not
     /// be page-aligned. Returns Ok(()) on success, Err(()) if walk() couldn't
     /// allocate a needed page-table page.
-    pub unsafe fn mappages(
-        &mut self,
-        va: A,
-        size: usize,
-        mut pa: usize,
-        perm: i32,
-    ) -> Result<(), ()> {
+    fn map_pages(&mut self, va: A, size: usize, mut pa: PAddr, perm: i32) -> Result<(), ()> {
         let mut a = pgrounddown(va.into_usize());
         let last = pgrounddown(va.into_usize() + size - 1usize);
         loop {
-            let pte = self.walk(VAddr::new(a), 1).ok_or(())?;
-            assert!(!pte.check_flag(PTE_V), "remap");
+            let pte = self.walk(VAddr::new(a), true).ok_or(())?;
+            assert!(!pte.is_valid(), "remap");
 
-            pte.set_inner(pa2pte(PAddr::new(pa)) | perm as usize | PTE_V);
+            pte.set_inner(pa2pte(pa) | perm as usize | PTE_V);
             if a == last {
                 break;
             }
             a += PGSIZE;
-            pa += PGSIZE;
+            pa = pa + PGSIZE;
         }
         Ok(())
+    }
+}
+
+impl PageTable<UVAddr> {
+    /// Create a user page table with no user memory,
+    /// but with the trampoline and a given trap frame.
+    /// Return Some(..) if every allocation has succeeded.
+    /// Return None otherwise.
+    // TODO(rv6)
+    // Change the parameter type.
+    // https://github.com/kaist-cp/rv6/issues/338
+    pub fn new(trap_frame: *mut Trapframe) -> Option<Self> {
+        let mut page_table = Self::new_empty_table()?;
+
+        // Map the trampoline code (for system call return)
+        // at the highest user virtual address.
+        // Only the supervisor uses it, on the way
+        // to/from user space, so not PTE_U.
+        if page_table
+            .map_pages(
+                UVAddr::new(TRAMPOLINE),
+                PGSIZE,
+                PAddr::new(unsafe { trampoline.as_mut_ptr() as usize }),
+                PTE_R | PTE_X,
+            )
+            .is_err()
+        {
+            page_table.free(0);
+            return None;
+        }
+
+        // Map the trapframe just below TRAMPOLINE, for trampoline.S.
+        if page_table
+            .map_pages(
+                UVAddr::new(TRAPFRAME),
+                PGSIZE,
+                PAddr::new(trap_frame as _),
+                PTE_R | PTE_W,
+            )
+            .is_err()
+        {
+            page_table.unmap(UVAddr::new(TRAMPOLINE), 1, false);
+            page_table.free(0);
+            return None;
+        }
+        Some(page_table)
+    }
+
+    /// Load the user initcode into address 0 of pagetable,
+    /// for the very first process.
+    /// src.len() must be less than a page.
+    pub unsafe fn init(&mut self, src: &[u8]) -> Result<(), ()> {
+        assert!(src.len() < PGSIZE, "init: more than a page");
+
+        let page = kernel().alloc().ok_or(())?;
+        let mem = page.into_usize() as *mut u8;
+        ptr::write_bytes(mem, 0, PGSIZE);
+        ptr::copy(src.as_ptr(), mem, src.len());
+        self.map_pages(
+            VAddr::new(0),
+            PGSIZE,
+            PAddr::new(mem as usize),
+            PTE_W | PTE_R | PTE_X | PTE_U,
+        )
+    }
+
+    /// Look up a virtual address, return Some(physical address),
+    /// or None if not mapped.
+    pub fn walk_addr(&mut self, va: UVAddr) -> Option<PAddr> {
+        if va.into_usize() >= MAXVA {
+            return None;
+        }
+        let pte = self.walk(va, false)?;
+        if !pte.is_user_accessible() {
+            return None;
+        }
+        Some(pte.get_pa())
+    }
+
+    /// Allocate PTEs and physical memory to grow process from oldsz to
+    /// newsz, which need not be page aligned. Returns Ok(new size) or Err(()) on error.
+    pub fn alloc(&mut self, mut oldsz: usize, newsz: usize) -> Result<usize, ()> {
+        if newsz < oldsz {
+            return Ok(oldsz);
+        }
+        oldsz = pgroundup(oldsz);
+        let mut a = oldsz;
+        while a < newsz {
+            let mut mem = some_or!(kernel().alloc(), {
+                self.dealloc(a, oldsz);
+                return Err(());
+            });
+            mem.write_bytes(0);
+            let pa = mem.into_usize();
+            if self
+                .map_pages(
+                    VAddr::new(a),
+                    PGSIZE,
+                    PAddr::new(pa),
+                    PTE_W | PTE_X | PTE_R | PTE_U,
+                )
+                .is_err()
+            {
+                // It is safe because pa is an address of mem, which is a page
+                // obtained by alloc().
+                kernel().free(unsafe { Page::from_usize(pa) });
+                self.dealloc(a, oldsz);
+                return Err(());
+            }
+            a += PGSIZE;
+        }
+        Ok(newsz)
+    }
+
+    /// Given a parent process's page table, copy
+    /// its memory into a child's page table.
+    /// Copies both the page table and the
+    /// physical memory.
+    /// Returns Ok(()) on success, Err(()) on failure.
+    /// Frees any allocated pages on failure.
+    pub unsafe fn copy(&mut self, mut new: &mut PageTable<UVAddr>, sz: usize) -> Result<(), ()> {
+        for i in num_iter::range_step(0, sz, PGSIZE) {
+            let pte = self
+                .walk(UVAddr::new(i), false)
+                .expect("uvmcopy: pte should exist");
+            assert!(pte.is_valid(), "uvmcopy: page not present");
+
+            let mut new_ptable = scopeguard::guard(new, |ptable| {
+                ptable.unmap(UVAddr::new(0), i.wrapping_div(PGSIZE), true);
+            });
+            let pa = pte.get_pa();
+            let flags = pte.get_flags() as u32;
+            let mem = kernel().alloc().ok_or(())?.into_usize();
+            ptr::copy(
+                pa.into_usize() as *mut u8 as *const u8,
+                mem as *mut u8,
+                PGSIZE,
+            );
+            if (*new_ptable)
+                .map_pages(
+                    VAddr::new(i),
+                    PGSIZE,
+                    PAddr::new(mem as usize),
+                    flags as i32,
+                )
+                .is_err()
+            {
+                kernel().free(Page::from_usize(mem as _));
+                return Err(());
+            }
+            new = scopeguard::ScopeGuard::into_inner(new_ptable);
+        }
+        Ok(())
+    }
+
+    /// Remove npages of mappings starting from va. va must be
+    /// page-aligned. The mappings must exist.
+    /// Optionally free the physical memory.
+    pub fn unmap(&mut self, va: UVAddr, npages: usize, do_free: bool) {
+        if va.into_usize().wrapping_rem(PGSIZE) != 0 {
+            panic!("uvmunmap: not aligned");
+        }
+        let start = va.into_usize();
+        let end = start.wrapping_add(npages.wrapping_mul(PGSIZE));
+        for a in num_iter::range_step(start, end, PGSIZE) {
+            let pt = &mut *self;
+            let pte = pt.walk(UVAddr::new(a), false).expect("uvmunmap: walk");
+            assert!(pte.is_data(), "uvmunmap: not a valid leaf");
+
+            if do_free {
+                let pa = pte.get_pa().into_usize();
+                // TODO(rv6)
+                // We do not know anything about pa, so, for now, we cannot
+                // guarantee that it is safe.
+                kernel().free(unsafe { Page::from_usize(pa) });
+            }
+            pte.set_inner(0);
+        }
+    }
+
+    /// Deallocate user pages to bring the process size from oldsz to
+    /// newsz.  oldsz and newsz need not be page-aligned, nor does newsz
+    /// need to be less than oldsz.  oldsz can be larger than the actual
+    /// process size.  Returns the new process size.
+    pub fn dealloc(&mut self, oldsz: usize, newsz: usize) -> usize {
+        if newsz >= oldsz {
+            return oldsz;
+        }
+
+        if pgroundup(newsz) < pgroundup(oldsz) {
+            let npages = (pgroundup(oldsz).wrapping_sub(pgroundup(newsz))).wrapping_div(PGSIZE);
+            self.unmap(UVAddr::new(pgroundup(newsz)), npages, true);
+        }
+        newsz
+    }
+
+    /// Free user memory pages,
+    /// then free page-table pages.
+    pub fn free(mut self, sz: usize) {
+        if sz > 0 {
+            self.unmap(UVAddr::new(0), pgroundup(sz).wrapping_div(PGSIZE), true);
+        }
+        // It is safe because this method consumes self, so the internal
+        // raw page table will not be use anymore.
+        unsafe { self.as_inner_mut().free_walk() };
+    }
+
+    /// Mark a PTE invalid for user access.
+    /// Used by exec for the user stack guard page.
+    pub fn clear(&mut self, va: UVAddr) {
+        self.walk(va, false)
+            .expect("clear")
+            .clear_flag(PTE_U as usize);
     }
 
     /// Copy from kernel to user.
     /// Copy len bytes from src to virtual address dstva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub unsafe fn copyout(&mut self, dstva: UVAddr, src: &[u8]) -> Result<(), ()> {
+    pub unsafe fn copy_out(&mut self, dstva: UVAddr, src: &[u8]) -> Result<(), ()> {
         let mut dst = dstva.into_usize();
         let mut len = src.len();
         let mut offset = 0;
         while len > 0 {
             let va0 = pgrounddown(dst);
-            let pa0 = self.walkaddr(VAddr::new(va0)).ok_or(())?.into_usize();
+            let pa0 = self.walk_addr(VAddr::new(va0)).ok_or(())?.into_usize();
             let mut n = PGSIZE - (dst - va0);
             if n > len {
                 n = len
@@ -368,159 +606,17 @@ impl<A: VAddr> PageTable<A> {
         }
         Ok(())
     }
-}
-
-impl PageTable<UVAddr> {
-    /// Load the user initcode into address 0 of pagetable,
-    /// for the very first process.
-    /// sz must be less than a page.
-    pub unsafe fn uvminit(&mut self, src: &[u8]) {
-        assert!(src.len() < PGSIZE, "inituvm: more than a page");
-
-        let mem = kernel().alloc().unwrap().into_usize() as *mut u8;
-        ptr::write_bytes(mem, 0, PGSIZE);
-        self.mappages(
-            VAddr::new(0),
-            PGSIZE,
-            mem as usize,
-            PTE_W | PTE_R | PTE_X | PTE_U,
-        )
-        .expect("inituvm: mappage");
-        ptr::copy(src.as_ptr(), mem, src.len());
-    }
-
-    /// Allocate PTEs and physical memory to grow process from oldsz to
-    /// newsz, which need not be page aligned.  Returns Ok(new size) or Err(()) on error.
-    pub unsafe fn uvmalloc(&mut self, mut oldsz: usize, newsz: usize) -> Result<usize, ()> {
-        if newsz < oldsz {
-            return Ok(oldsz);
-        }
-        oldsz = pgroundup(oldsz);
-        let mut a = oldsz;
-        while a < newsz {
-            let mut mem = some_or!(kernel().alloc(), {
-                self.uvmdealloc(a, oldsz);
-                return Err(());
-            });
-            mem.write_bytes(0);
-            let pa = mem.into_usize();
-            if self
-                .mappages(VAddr::new(a), PGSIZE, pa, PTE_W | PTE_X | PTE_R | PTE_U)
-                .is_err()
-            {
-                kernel().free(Page::from_usize(pa));
-                self.uvmdealloc(a, oldsz);
-                return Err(());
-            }
-            a += PGSIZE;
-        }
-        Ok(newsz)
-    }
-
-    /// Given a parent process's page table, copy
-    /// its memory into a child's page table.
-    /// Copies both the page table and the
-    /// physical memory.
-    /// Returns Ok(()) on success, Err(()) on failure.
-    /// Frees any allocated pages on failure.
-    pub unsafe fn uvmcopy(&mut self, mut new: &mut PageTable<UVAddr>, sz: usize) -> Result<(), ()> {
-        for i in num_iter::range_step(0, sz, PGSIZE) {
-            let pte = self
-                .walk(UVAddr::new(i), 0)
-                .expect("uvmcopy: pte should exist");
-            assert!(pte.check_flag(PTE_V), "uvmcopy: page not present");
-
-            let mut new_ptable = scopeguard::guard(new, |ptable| {
-                ptable.uvmunmap(UVAddr::new(0), i.wrapping_div(PGSIZE), true);
-            });
-            let pa = pte.get_pa();
-            let flags = pte.get_flags() as u32;
-            let mem = kernel().alloc().ok_or(())?.into_usize();
-            ptr::copy(
-                pa.into_usize() as *mut u8 as *const u8,
-                mem as *mut u8,
-                PGSIZE,
-            );
-            if (*new_ptable)
-                .mappages(VAddr::new(i), PGSIZE, mem as usize, flags as i32)
-                .is_err()
-            {
-                kernel().free(Page::from_usize(mem as _));
-                return Err(());
-            }
-            new = scopeguard::ScopeGuard::into_inner(new_ptable);
-        }
-        Ok(())
-    }
-
-    /// Remove npages of mappings starting from va. va must be
-    /// page-aligned. The mappings must exist.
-    /// Optionally free the physical memory.
-    pub unsafe fn uvmunmap(&mut self, va: UVAddr, npages: usize, do_free: bool) {
-        if va.into_usize().wrapping_rem(PGSIZE) != 0 {
-            panic!("uvmunmap: not aligned");
-        }
-        let start = va.into_usize();
-        let end = start.wrapping_add(npages.wrapping_mul(PGSIZE));
-        for a in num_iter::range_step(start, end, PGSIZE) {
-            let pt = &mut *self;
-            let pte = pt.walk(UVAddr::new(a), 0).expect("uvmunmap: walk");
-            if !pte.check_flag(PTE_V) {
-                panic!("uvmunmap: not mapped");
-            }
-            assert_ne!(pte.get_flags(), PTE_V, "uvmunmap: not a leaf");
-
-            if do_free {
-                let pa = pte.get_pa().into_usize();
-                kernel().free(Page::from_usize(pa as _));
-            }
-            pte.set_inner(0);
-        }
-    }
-
-    /// Deallocate user pages to bring the process size from oldsz to
-    /// newsz.  oldsz and newsz need not be page-aligned, nor does newsz
-    /// need to be less than oldsz.  oldsz can be larger than the actual
-    /// process size.  Returns the new process size.
-    pub unsafe fn uvmdealloc(&mut self, oldsz: usize, newsz: usize) -> usize {
-        if newsz >= oldsz {
-            return oldsz;
-        }
-
-        if pgroundup(newsz) < pgroundup(oldsz) {
-            let npages = (pgroundup(oldsz).wrapping_sub(pgroundup(newsz))).wrapping_div(PGSIZE);
-            self.uvmunmap(UVAddr::new(pgroundup(newsz)), npages, true);
-        }
-        newsz
-    }
-
-    /// Free user memory pages,
-    /// then free page-table pages.
-    pub unsafe fn uvmfree(&mut self, sz: usize) {
-        if sz > 0 {
-            self.uvmunmap(UVAddr::new(0), pgroundup(sz).wrapping_div(PGSIZE), true);
-        }
-        self.freewalk();
-    }
-
-    /// Mark a PTE invalid for user access.
-    /// Used by exec for the user stack guard page.
-    pub unsafe fn uvmclear(&mut self, va: UVAddr) {
-        self.walk(va, 0)
-            .expect("uvmclear")
-            .clear_flag(PTE_U as usize);
-    }
 
     /// Copy from user to kernel.
     /// Copy len bytes to dst from virtual address srcva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub unsafe fn copyin(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
+    pub unsafe fn copy_in(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
         let mut src = srcva.into_usize();
         let mut len = dst.len();
         let mut offset = 0;
         while len > 0 {
             let va0 = pgrounddown(src);
-            let pa0 = self.walkaddr(VAddr::new(va0)).ok_or(())?.into_usize();
+            let pa0 = self.walk_addr(VAddr::new(va0)).ok_or(())?.into_usize();
             let mut n = PGSIZE - (src - va0);
             if n > len {
                 n = len
@@ -541,14 +637,14 @@ impl PageTable<UVAddr> {
     /// Copy bytes to dst from virtual address srcva in a given page table,
     /// until a '\0', or max.
     /// Return OK(()) on success, Err(()) on error.
-    pub unsafe fn copyinstr(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
+    pub unsafe fn copy_in_str(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
         let mut got_null: i32 = 0;
         let mut src = srcva.into_usize();
         let mut offset = 0;
         let mut max = dst.len();
         while got_null == 0 && max > 0 {
             let va0 = pgrounddown(src);
-            let pa0 = self.walkaddr(VAddr::new(va0)).ok_or(())?.into_usize();
+            let pa0 = self.walk_addr(VAddr::new(va0)).ok_or(())?.into_usize();
             let mut n = PGSIZE - (src - va0);
             if n > max {
                 n = max
@@ -577,92 +673,91 @@ impl PageTable<UVAddr> {
     }
 }
 
-impl<T> Deref for PageTable<T> {
-    type Target = RawPageTable;
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.ptr }
-    }
-}
-
-impl<T> DerefMut for PageTable<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.ptr }
-    }
-}
-
 impl PageTable<KVAddr> {
     /// Make a direct-map page table for the kernel.
-    pub unsafe fn kvmmake(&mut self) {
-        let _ = self.alloc_root();
+    pub fn new() -> Option<Self> {
+        let mut page_table = Self::new_empty_table()?;
 
         // SiFive Test Finisher MMIO
-        self.kvmmap(
-            KVAddr::new(FINISHER),
-            PAddr::new(FINISHER),
-            PGSIZE,
-            PTE_R | PTE_W,
-        );
+        page_table
+            .map_pages(
+                KVAddr::new(FINISHER),
+                PGSIZE,
+                PAddr::new(FINISHER),
+                PTE_R | PTE_W,
+            )
+            .ok()?;
 
         // Uart registers
-        self.kvmmap(KVAddr::new(UART0), PAddr::new(UART0), PGSIZE, PTE_R | PTE_W);
+        page_table
+            .map_pages(KVAddr::new(UART0), PGSIZE, PAddr::new(UART0), PTE_R | PTE_W)
+            .ok()?;
 
         // Virtio mmio disk interface
-        self.kvmmap(
-            KVAddr::new(VIRTIO0),
-            PAddr::new(VIRTIO0),
-            PGSIZE,
-            PTE_R | PTE_W,
-        );
+        page_table
+            .map_pages(
+                KVAddr::new(VIRTIO0),
+                PGSIZE,
+                PAddr::new(VIRTIO0),
+                PTE_R | PTE_W,
+            )
+            .ok()?;
 
         // PLIC
-        self.kvmmap(KVAddr::new(PLIC), PAddr::new(PLIC), 0x400000, PTE_R | PTE_W);
+        page_table
+            .map_pages(KVAddr::new(PLIC), 0x400000, PAddr::new(PLIC), PTE_R | PTE_W)
+            .ok()?;
 
         // Map kernel text executable and read-only.
-        self.kvmmap(
-            KVAddr::new(KERNBASE),
-            PAddr::new(KERNBASE),
-            (etext.as_mut_ptr() as usize) - KERNBASE,
-            PTE_R | PTE_X,
-        );
+        let et = unsafe { etext.as_mut_ptr() as usize };
+        page_table
+            .map_pages(
+                KVAddr::new(KERNBASE),
+                et - KERNBASE,
+                PAddr::new(KERNBASE),
+                PTE_R | PTE_X,
+            )
+            .ok()?;
 
         // Map kernel data and the physical RAM we'll make use of.
-        self.kvmmap(
-            KVAddr::new(etext.as_mut_ptr() as usize),
-            PAddr::new(etext.as_mut_ptr() as usize),
-            PHYSTOP - (etext.as_mut_ptr() as usize),
-            PTE_R | PTE_W,
-        );
+        page_table
+            .map_pages(KVAddr::new(et), PHYSTOP - et, PAddr::new(et), PTE_R | PTE_W)
+            .ok()?;
 
         // Map the trampoline for trap entry/exit to
         // the highest virtual address in the kernel.
-        self.kvmmap(
-            KVAddr::new(TRAMPOLINE),
-            PAddr::new(trampoline.as_mut_ptr() as usize),
-            PGSIZE,
-            PTE_R | PTE_X,
-        );
+        page_table
+            .map_pages(
+                KVAddr::new(TRAMPOLINE),
+                PGSIZE,
+                PAddr::new(unsafe { trampoline.as_mut_ptr() as usize }),
+                PTE_R | PTE_X,
+            )
+            .ok()?;
 
-        // map kernel stacks
-        proc_mapstacks(self);
-    }
+        // Allocate a page for the process's kernel stack.
+        // Map it high in memory, followed by an invalid
+        // guard page.
+        for i in 0..NPROC {
+            let pa = kernel().alloc()?.into_usize();
+            let va: usize = kstack(i);
+            page_table
+                .map_pages(
+                    KVAddr::new(va),
+                    PGSIZE,
+                    PAddr::new(pa as usize),
+                    PTE_R | PTE_W,
+                )
+                .ok()?;
+        }
 
-    /// Initialize the one kernel_pagetable
-    pub unsafe fn kvminit(&mut self) {
-        self.kvmmake();
+        Some(page_table)
     }
 
     /// Switch h/w page table register to the kernel's page table,
     /// and enable paging.
-    pub unsafe fn kvminithart(&self) {
+    pub unsafe fn init_hart(&self) {
         w_satp(make_satp(self.ptr as usize));
         sfence_vma();
-    }
-
-    /// Add a mapping to the kernel page table.
-    /// Only used when booting.
-    /// Does not flush TLB or enable paging.
-    pub unsafe fn kvmmap(&mut self, va: KVAddr, pa: PAddr, sz: usize, perm: i32) {
-        self.mappages(va, sz, pa.into_usize(), perm)
-            .expect("kvmmap");
     }
 }


### PR DESCRIPTION
## Invariant

자세한 내용은 코드에 주석으로 있음.

* `Page`: 서로 다른 두 `Page`는 겹치지 않음.
* `RawPageTable`: V 플래그는 켜져 있고 R, W, X 플래그는 지워진 엔트리는 page-table 페이지를 가리킴. 임의 높이의 트리로 생각.
* `PageTable`: 3-level 트리 구조 유지. 임의의 `VAddr`을 받아 대응되는 `PAddr`을 내놓는 맵으로 생각.

현재는 `PageTable` 구조의 올바름을 보장할 수 있지만, `PageTable`이 가지고 있는 `PAddr`이 올바른 페이지에 대응된다는 사실을 보장할 수 없음. 따라서 `PageTable<UVAddr>::copy_out`과 같이 페이지 주소를 찾아 그 페이지에 데이터를 쓰거나 페이지로부터 데이터를 읽는 메서드의 안전성을 보장할 수 없음. 이는 `PageTable`의 invariant가 아니라 다른 타입의 invariant로 보장할 예정. 현재는 `Proc`이 `PageTable`을 가지고 있지만, 이 사이에 한 단계를 추가해 `Proc`은 `MemoryManager`를, `MemoryManager`는 `PageTable`를 가지고, `MemoryManager`의 invariant가 `PageTable`이 가지고 있는 주소의 올바름을 보장하도록 이후의 PR에서 수정할 예정.