### PR TITLE
[Closes #339] Exploit invariant of PageTableEntry

### DIFF
--- a/kernel-rs/src/kalloc.rs
+++ b/kernel-rs/src/kalloc.rs
@@ -22,7 +22,6 @@ struct Run {
 
 /// # Safety
 ///
-/// The invariants of this struct are as follows:
 /// - This singly linked list does not have a cycle.
 /// - If head is null, then it is an empty list. Ohterwise, it is nonempty, and
 ///   head is its first element, which is a valid page.

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -14,7 +14,6 @@ pub struct RawPage {
 
 /// # Safety
 ///
-/// The invariants of this struct are as follows:
 /// - inner is 4096 bytes-aligned.
 /// - end <= inner < PHYSTOP
 /// - Two different pages never overwrap. If p1: Page and p2: Page, then


### PR DESCRIPTION
Closes #339

"V 플래그는 켜져 있지만 RWX 플래그는 꺼져 있는 엔트리는 페이지 테이블을 가리킨다"는 성질을 `PageTableEntry`의 invariant로 변경했습니다. `PageTableEntry`의 invariant가 엔트리 수정 시에도 유지될 수 있도록 `set_inner`와 같이 invariant를 깰 수 있는 메서드를 없애고 다음과 같은 메서드를 추가했습니다.

* `set_table`: 페이지 테이블을 가리키는 엔트리로 만듦
* `set_entry`: 데이터 페이지를 가리키는 엔트리로 만듦
* `make_user_inaccessible`: `PTE_U`를 지워 유저 프로세스의 접근을 막음
* `invalidate`: 유효하지 않은 엔트리로 만듦

더 나은 메서드 이름을 제안해 주시면 좋을 거 같습니다.