### PR TITLE
Fix WaitChannel's API

### DIFF
--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -216,7 +216,7 @@ pub trait Waitable {
     /// `raw_release()` and `raw_acquire` must always be used as a pair.
     /// Use these only for temporarily releasing (and then acquiring) the lock.
     /// Also, do not access `self` until re-acquiring the lock with `raw_acquire()`.
-    unsafe fn raw_release(&self);
+    unsafe fn raw_release(&mut self);
 
     /// Acquires the inner `RawSpinlock`.
     ///
@@ -224,7 +224,7 @@ pub trait Waitable {
     ///
     /// `raw_release()` and `raw_acquire` must always be used as a pair.
     /// Use these only for temporarily releasing (and then acquiring) the lock.
-    unsafe fn raw_acquire(&self);
+    unsafe fn raw_acquire(&mut self);
 }
 
 pub struct WaitChannel {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -207,9 +207,15 @@ pub enum Procstate {
     USED,
 }
 
-pub trait WaitableGuard {
+/// Represents lock guards that can be slept in a `WaitChannel`.
+pub trait Waitable {
     /// Returns a reference to the inner `RawSpinlock`.
-    fn get_raw(&self) -> &RawSpinlock;
+    ///
+    /// # Safety
+    ///
+    /// You should manually prove the correctness when directly accessing
+    /// the inner `RawSpinlock` instead of using the lock's API.
+    unsafe fn get_raw(&self) -> &RawSpinlock;
 }
 
 pub struct WaitChannel {
@@ -229,7 +235,7 @@ impl WaitChannel {
     /// # Safety
     ///
     /// Make sure `lk` is the only lock we currently hold.
-    pub unsafe fn sleep<T: WaitableGuard>(&self, lk: &mut T) {
+    pub unsafe fn sleep<T: Waitable>(&self, lk: &mut T) {
         let p = &*myproc();
 
         // Must acquire p->lock in order to

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -1,5 +1,5 @@
 //! Sleepable locks
-use crate::proc::{WaitChannel, WaitableGuard};
+use crate::proc::{WaitChannel, Waitable};
 use crate::spinlock::RawSpinlock;
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
@@ -71,8 +71,8 @@ impl<T> SleepablelockGuard<'_, T> {
     }
 }
 
-impl<T> WaitableGuard for SleepablelockGuard<'_, T> {
-    fn get_raw(&self) -> &RawSpinlock {
+impl<T> Waitable for SleepablelockGuard<'_, T> {
+    unsafe fn get_raw(&self) -> &RawSpinlock {
         &self.lock.lock
     }
 }

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -70,10 +70,10 @@ impl<T> SleepablelockGuard<'_, T> {
 }
 
 impl<T> Waitable for SleepablelockGuard<'_, T> {
-    unsafe fn raw_release(&self) {
+    unsafe fn raw_release(&mut self) {
         self.lock.lock.release();
     }
-    unsafe fn raw_acquire(&self) {
+    unsafe fn raw_acquire(&mut self) {
         self.lock.lock.acquire();
     }
 }

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -61,9 +61,7 @@ impl<T> Sleepablelock<T> {
 
 impl<T> SleepablelockGuard<'_, T> {
     pub fn sleep(&mut self) {
-        unsafe {
-            self.lock.waitchannel.sleep(self);
-        }
+        self.lock.waitchannel.sleep(self);
     }
 
     pub fn wakeup(&self) {
@@ -72,8 +70,11 @@ impl<T> SleepablelockGuard<'_, T> {
 }
 
 impl<T> Waitable for SleepablelockGuard<'_, T> {
-    unsafe fn get_raw(&self) -> &RawSpinlock {
-        &self.lock.lock
+    unsafe fn raw_release(&self) {
+        self.lock.lock.release();
+    }
+    unsafe fn raw_acquire(&self) {
+        self.lock.lock.acquire();
     }
 }
 

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -1,6 +1,6 @@
 //! Sleepable locks
-use crate::proc::WaitChannel;
-use crate::spinlock::{Guard, RawSpinlock};
+use crate::proc::{WaitChannel, WaitableGuard};
+use crate::spinlock::RawSpinlock;
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
@@ -71,7 +71,7 @@ impl<T> SleepablelockGuard<'_, T> {
     }
 }
 
-impl<T> Guard for SleepablelockGuard<'_, T> {
+impl<T> WaitableGuard for SleepablelockGuard<'_, T> {
     fn get_raw(&self) -> &RawSpinlock {
         &self.lock.lock
     }

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::kernel,
-    proc::{Cpu, WaitableGuard},
+    proc::{Cpu, Waitable},
     riscv::{intr_get, intr_off, intr_on},
 };
 use core::cell::UnsafeCell;
@@ -198,8 +198,8 @@ impl<T> SpinlockGuard<'_, T> {
     }
 }
 
-impl<T> WaitableGuard for SpinlockGuard<'_, T> {
-    fn get_raw(&self) -> &RawSpinlock {
+impl<T> Waitable for SpinlockGuard<'_, T> {
+    unsafe fn get_raw(&self) -> &RawSpinlock {
         &self.lock.lock
     }
 }
@@ -264,8 +264,8 @@ impl<T> SpinlockProtected<T> {
     }
 }
 
-impl WaitableGuard for SpinlockProtectedGuard<'_> {
-    fn get_raw(&self) -> &RawSpinlock {
+impl Waitable for SpinlockProtectedGuard<'_> {
+    unsafe fn get_raw(&self) -> &RawSpinlock {
         &self.lock
     }
 }

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::kernel,
-    proc::Cpu,
+    proc::{Cpu, WaitableGuard},
     riscv::{intr_get, intr_off, intr_on},
 };
 use core::cell::UnsafeCell;
@@ -101,11 +101,6 @@ impl RawSpinlock {
     }
 }
 
-pub trait Guard {
-    /// Returns a reference to the inner `RawSpinlock`.
-    fn get_raw(&self) -> &RawSpinlock;
-}
-
 pub struct SpinlockGuard<'s, T> {
     lock: &'s Spinlock<T>,
     _marker: PhantomData<*const ()>,
@@ -203,7 +198,7 @@ impl<T> SpinlockGuard<'_, T> {
     }
 }
 
-impl<T> Guard for SpinlockGuard<'_, T> {
+impl<T> WaitableGuard for SpinlockGuard<'_, T> {
     fn get_raw(&self) -> &RawSpinlock {
         &self.lock.lock
     }
@@ -269,7 +264,7 @@ impl<T> SpinlockProtected<T> {
     }
 }
 
-impl Guard for SpinlockProtectedGuard<'_> {
+impl WaitableGuard for SpinlockProtectedGuard<'_> {
     fn get_raw(&self) -> &RawSpinlock {
         &self.lock
     }

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -199,8 +199,11 @@ impl<T> SpinlockGuard<'_, T> {
 }
 
 impl<T> Waitable for SpinlockGuard<'_, T> {
-    unsafe fn get_raw(&self) -> &RawSpinlock {
-        &self.lock.lock
+    unsafe fn raw_release(&self) {
+        self.lock.lock.release();
+    }
+    unsafe fn raw_acquire(&self) {
+        self.lock.lock.acquire();
     }
 }
 
@@ -265,8 +268,11 @@ impl<T> SpinlockProtected<T> {
 }
 
 impl Waitable for SpinlockProtectedGuard<'_> {
-    unsafe fn get_raw(&self) -> &RawSpinlock {
-        &self.lock
+    unsafe fn raw_release(&self) {
+        self.lock.release();
+    }
+    unsafe fn raw_acquire(&self) {
+        self.lock.acquire();
     }
 }
 

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -199,10 +199,10 @@ impl<T> SpinlockGuard<'_, T> {
 }
 
 impl<T> Waitable for SpinlockGuard<'_, T> {
-    unsafe fn raw_release(&self) {
+    unsafe fn raw_release(&mut self) {
         self.lock.lock.release();
     }
-    unsafe fn raw_acquire(&self) {
+    unsafe fn raw_acquire(&mut self) {
         self.lock.lock.acquire();
     }
 }
@@ -268,10 +268,10 @@ impl<T> SpinlockProtected<T> {
 }
 
 impl Waitable for SpinlockProtectedGuard<'_> {
-    unsafe fn raw_release(&self) {
+    unsafe fn raw_release(&mut self) {
         self.lock.release();
     }
-    unsafe fn raw_acquire(&self) {
+    unsafe fn raw_acquire(&mut self) {
         self.lock.acquire();
     }
 }

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -317,7 +317,7 @@ impl Disk {
 
         // Wait for virtio_disk_intr() to say request has finished.
         while b.deref_mut_inner().disk {
-            (*b).vdisk_request_waitchannel.sleep_sleepable(this);
+            (*b).vdisk_request_waitchannel.sleep(this);
         }
         this.info[desc[0].idx].b = ptr::null_mut();
         IntoIter::new(desc).for_each(|desc| this.desc.free(desc));


### PR DESCRIPTION
#241 작업을 하기 전에 먼저 `WaitChannel`의 지저분한 부분을 조금 다듬어봤습니다.
* 기존에는 `WaitChannel`에 대해서 sleep을 하기 위해서는 `SpinlockGuard`는 `sleep()`로, `SleepablelockGuard`는 `sleep_sleepable()`로, 그리고 `SpinlockProtected`는 `sleep_raw()`로 **여러가지로 API가 나눠져있는 걸 하나로 합쳤습니다.**
	* 이를 위해, `Guard`라는 trait을 추가했습니다. (현재 `SpinlockGuard`, `SpinlockProtectedGuard`, `SleepablelockGuard`이 이걸 impl합니다.)
* 다만, 별개로, **현재 `SleepablelockGuard::sleep()`이 `unsafe`이 아닌데, 이래도 괜찮은지 잘 모르겠습니다.** 	
	* 먼저, `WaitChannel::sleep()`이 `unsafe`한 이유는 `guard.sched()`을 call할때는 항상 `p->lock`이외에는 어떠한 RawSpinlock도 acquire한 상태여선 안되기 때문입니다. (`guard.sched()`내에서도 `assert_eq!((*kernel().mycpu()).noff, 1, "sched locks");`로 이걸 확인합니다). 그러나 `SleepablelockGuard::sleep()`은 내부에서 `WaitChannel::sleep()`을 사용하는데도 unsafe이 아닙니다.