### PR TITLE
Add benchmark script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkfs
 kernel/kernel
 user/usys.S
 .gdbinit
+bench.result

--- a/README-rv6.md
+++ b/README-rv6.md
@@ -158,6 +158,33 @@
     set disassemble-next-line auto
     ```
 
+## Benchmark
+
+Run `bench.py`. This script runs `usertests` 10 times by default.
+
+```sh
+./bench.py
+# Or, run 30 times
+./bench.py -n 30
+```
+
+You can see the result in `bench.result`. An exemplary output is:
+
+```
+Start benchmark 2021-01-21 16:01:02.001441
+73.16322882205714
+73.82074988691602
+74.60743912809994
+73.06701795198023
+74.04991712688934
+74.74715550499968
+73.93327224906534
+74.19972170796245
+73.0705537419999
+72.86001828499138
+Mean=73.75190744049614, Standard Deviation=0.6422428124461621, N=10
+```
+
 ## How we ported xv6 to Rust
 
 - Run [c2rust](https://github.com/immunant/c2rust) to transpile C code to Rust.

--- a/bench.py
+++ b/bench.py
@@ -1,0 +1,36 @@
+import os, argparse, datetime, time, numpy
+
+parser = argparse.ArgumentParser(description='usertests benchmark')
+parser.add_argument('-n', '--number', type=int, default=10, help='number of usertests')
+parser.add_argument('-o', '--output', type=str, default='bench.result', help='benchmark result path')
+parser.add_argument('--option', type=str, default='RUST_MODE=release OPTFLAGS=-O3', help='make option')
+
+def main(args):
+    stat = []
+
+    f = open(args.output, 'a', buffering=1)
+    f.write('Start benchmark {}\n'.format(datetime.datetime.now()))
+    
+    os.system('make clean')
+    os.system(f'make kernel/kernel USERTEST=yes {args.option}')
+    os.system(f'make fs.img USERTEST=yes {args.option}')
+
+    for _ in range(args.number):
+        begin = time.perf_counter()
+        os.system(f'make qemu USERTEST=yes {args.option} 2>/dev/null')
+        elapsed = time.perf_counter() - begin
+        f.write(f'{elapsed}\n')
+        stat.append(elapsed)
+
+        os.remove('fs.img')
+        os.system(f'make fs.img USERTEST=yes {args.option}')
+
+    avg = numpy.average(stat)
+    std = numpy.std(stat)
+
+    f.write(f'Mean={avg}, Standard Deviation={std}, N={args.number}\n')
+    f.write('Finish benchmark\n')
+
+    f.close()
+
+main(parser.parse_args())

--- a/bench.py
+++ b/bench.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os, argparse, datetime, time, statistics, subprocess
 
 parser = argparse.ArgumentParser(description='usertests benchmark')


### PR DESCRIPTION
Performance evaluation 을 하기 위해서 usertests benchmark 를 하였습니다. 이를 위해:
 - Filesystem 크기를 2배로 키웠습니다. ( Closes #345 )
 - `usertests` 를 10번 실행하는 benchmark script 를 작성했습니다.

Benchmark 다음 세 가지를 비교하였습니다:
 - xv6 with gcc -O3    (gcc: 10.2.0)
 - xv6 with clang -O3   (clang: 11.0.0)
 - rv6 with release mode

xv6-riscv 에도 동일한 수정을 하였습니다: https://github.com/efenniht/xv6-riscv/tree/bench 또한, xv6-riscv 는 GCC 확장을 사용하고 있어 해당 코드를 clang 에도 컴파일되도록 표준 문법으로 바꾸었습니다.

벤치마크 결과는 다음과 같습니다:
```
xv6 w/ gcc: 79.83 ± 1.04s
xv6 w/ clang: 118.87 ± 2.34s
rv6: 74.18 ± 0.78s
```

왠지 모르겠지만 rv6 가 더 빠릅니다 (??)

