### PR TITLE
Enlarge filesystem to make usertests runnable with higher optimization level.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,11 @@ LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
-CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb
+ifndef OPTFLAGS
+OPTFALGS := -O
+endif
+
+CFLAGS = -Wall -Werror $(OPTFLAGS) -fno-omit-frame-pointer -ggdb
 CFLAGS += -MD
 CFLAGS += -mcmodel=medany
 CFLAGS += -ffreestanding -fno-common -nostdlib -mno-relax

--- a/kernel-rs/src/param.rs
+++ b/kernel-rs/src/param.rs
@@ -36,7 +36,7 @@ pub const LOGSIZE: usize = MAXOPBLOCKS * 3;
 pub const NBUF: usize = MAXOPBLOCKS * 3;
 
 /// Size of file system in blocks.
-pub const FSSIZE: usize = 1000;
+pub const FSSIZE: usize = 2000;
 
 /// Maximum file path name.
 pub const MAXPATH: usize = 128;

--- a/kernel/param.h
+++ b/kernel/param.h
@@ -9,5 +9,5 @@
 #define MAXOPBLOCKS  10  // max # of blocks any FS op writes
 #define LOGSIZE      (MAXOPBLOCKS*3)  // max data blocks in on-disk log
 #define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
-#define FSSIZE       1000  // size of file system in blocks
+#define FSSIZE       2000  // size of file system in blocks
 #define MAXPATH      128   // maximum file path name


### PR DESCRIPTION
Closes #345 

To build and test xv6 with higher optimization levels, this PR additionally provides `OPTFLAGS` option. e.g. `make qemu OPTFLAGS=-O3`.