### PR TITLE
Add `UserMemory` type to exploit invariant of user process memory

### DIFF
--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -75,7 +75,7 @@ impl File {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
-                (*(*p).data.get()).pagetable.copy_out(
+                (*(*p).data.get()).memory.copy_out(
                     addr,
                     slice::from_raw_parts_mut(
                         &mut st as *mut Stat as *mut u8,

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -19,22 +19,32 @@
 #![feature(generic_associated_types)]
 #![feature(unsafe_block_in_unsafe_fn)]
 
+// TODO(rv6): We must apply #[deny(unsafe_op_in_unsafe_fn)] to every module.
 mod arena;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod bio;
 mod console;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod etrace;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod exec;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod fcntl;
 mod file;
 mod fs;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod kalloc;
 mod kernel;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod list;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod memlayout;
 mod page;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod param;
 mod pipe;
 mod plic;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod poweroff;
 mod proc;
 mod riscv;
@@ -42,15 +52,19 @@ mod sleepablelock;
 mod sleeplock;
 mod spinlock;
 mod start;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod stat;
 mod syscall;
 mod sysfile;
 mod sysproc;
 mod trap;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod uart;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod utils;
 mod virtio;
 mod virtio_disk;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod vm;
 
 #[macro_use]

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -55,10 +55,14 @@ impl Page {
         result
     }
 
+    pub fn addr(&self) -> PAddr {
+        PAddr::new(self.inner.as_ptr() as _)
+    }
+
     /// # Safety
     ///
     /// Given addr must not break the invariant of Page.
-    /// - addr is a multiple of 4096.
+    /// - addr is a multiple of PGSIZE.
     /// - end <= addr < PHYSTOP
     /// - If p: Page, then *(p.inner).inner and (addr as *RawPage).inner are
     ///   non-overwrapping arrays.
@@ -66,10 +70,6 @@ impl Page {
         Self {
             inner: NonNull::new_unchecked(addr as *mut _),
         }
-    }
-
-    pub fn addr(&self) -> PAddr {
-        PAddr::new(self.inner.as_ptr() as _)
     }
 }
 

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -187,7 +187,7 @@ impl PipeInner {
                 //DOC: pipewrite-full
                 return Ok(i);
             }
-            if data.pagetable.copy_in(&mut ch, addr + i).is_err() {
+            if data.memory.copy_in(&mut ch, addr + i).is_err() {
                 return Err(PipeError::InvalidCopyin(i));
             }
             self.data[self.nwrite as usize % PIPESIZE] = ch[0];
@@ -215,7 +215,7 @@ impl PipeInner {
             }
             let ch = [self.data[self.nread as usize % PIPESIZE]];
             self.nread = self.nread.wrapping_add(1);
-            if data.pagetable.copy_out(addr + i, &ch).is_err() {
+            if data.memory.copy_out(addr + i, &ch).is_err() {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -13,12 +13,12 @@ pub unsafe fn fetchaddr(addr: UVAddr) -> Result<usize, ()> {
     let p = myproc();
     let data = &mut *(*p).data.get();
     let mut ip = 0;
-    if addr.into_usize() >= data.sz
-        || addr.into_usize().wrapping_add(mem::size_of::<usize>()) > data.sz
+    if addr.into_usize() >= data.memory.size()
+        || addr.into_usize().wrapping_add(mem::size_of::<usize>()) > data.memory.size()
     {
         return Err(());
     }
-    data.pagetable.copy_in(
+    data.memory.copy_in(
         slice::from_raw_parts_mut(&mut ip as *mut usize as *mut u8, mem::size_of::<usize>()),
         addr,
     )?;
@@ -29,7 +29,7 @@ pub unsafe fn fetchaddr(addr: UVAddr) -> Result<usize, ()> {
 /// Returns reference to the string in the buffer.
 pub unsafe fn fetchstr(addr: UVAddr, buf: &mut [u8]) -> Result<&CStr, ()> {
     let p = myproc();
-    (*(*p).data.get()).pagetable.copy_in_str(buf, addr)?;
+    (*(*p).data.get()).memory.copy_in_str(buf, addr)?;
 
     Ok(CStr::from_ptr(buf.as_ptr()))
 }
@@ -38,12 +38,12 @@ unsafe fn argraw(n: usize) -> usize {
     let p = myproc();
     let data = &mut *(*p).data.get();
     match n {
-        0 => (*data.trapframe).a0,
-        1 => (*data.trapframe).a1,
-        2 => (*data.trapframe).a2,
-        3 => (*data.trapframe).a3,
-        4 => (*data.trapframe).a4,
-        5 => (*data.trapframe).a5,
+        0 => data.trap_frame().a0,
+        1 => data.trap_frame().a1,
+        2 => data.trap_frame().a2,
+        3 => data.trap_frame().a3,
+        4 => data.trap_frame().a4,
+        5 => data.trap_frame().a5,
         _ => panic!("argraw"),
     }
 }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,7 +1,7 @@
 use crate::{
     kernel::Kernel,
     poweroff,
-    proc::{myproc, resizeproc},
+    proc::myproc,
     syscall::{argaddr, argint},
     vm::{UVAddr, VAddr},
 };
@@ -35,11 +35,9 @@ impl Kernel {
     /// Returns Ok(start of new memory) on success, Err(()) on error.
     pub unsafe fn sys_sbrk(&self) -> Result<usize, ()> {
         let n = argint(0)?;
-        let addr = (*(*myproc()).data.get()).sz as i32;
-        if resizeproc(n) < 0 {
-            return Err(());
-        }
-        Ok(addr as usize)
+        let p = myproc();
+        let data = &mut *(*p).data.get();
+        data.memory.resize(n)
     }
 
     /// Pause for n clock ticks.


### PR DESCRIPTION
유저 프로세스 메모리를 관리하는 `UserMemory` 타입을 추가했습니다. `UserMemory`는 다음과 같은 invariant를 가집니다.

(For brevity, `pt` := `page_table`, and we treat `pt` as a function from `va` to `pa`.)

* `TRAMPOLINE` ∈ dom(`pt`) ∧ `pt(TRAMPOLINE)` = `trampoline`.
* `TRAPFRAME` ∈ dom(`pt`) ∧ `pt(TRAPFRAM)E` = `trap_frame`.
* If `va` ∈ dom(`pt`), `va` mod `PGSIZE` = 0 ∧ `pt(va)` mod `PGSIZE` = 0.
* If `va` ∈ dom(`pt`) where `va` ∉ { `TRAMPOLINE`, `TRAPFRAME` }, then `Page::from_usize(pt(va))` succeeds without breaking the invariant of `Page`.
* If `va` ∈ dom(`pt`) where `va` ∉ { 0, `TRAMPOLINE`, `TRAPFRAME` }, then `va - PGSIZE` ∈ dom(`pt`).
* `pgroundup(size)` ∉ dom(`pt`).
* If `size` > 0, then `pgroundup(size) - PGSIZE` ∈ dom(`pt`).
* `Page::from_usize(trap_frame)` succeeds without breaking the invariant of `Page`.

이제 `PageTable`은 단순히 `VAddr`에서 `PAddr`로 가는 맵 자료 구조로 취급됩니다.

Closes #338