### PR TITLE
Fix bug: count unsafe of source codes in subdirectories.

### DIFF
--- a/count_unsafe.py
+++ b/count_unsafe.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os, re, sys, glob
+import subprocess, re, sys, glob
 from collections import defaultdict
 
 path = 'kernel-rs/**/*.rs'
@@ -8,12 +8,12 @@ path = 'kernel-rs/**/*.rs'
 if len(sys.argv) > 1:
     path = sys.argv[1]
 
-if os.system('which count-unsafe > /dev/null 2>&1') != 0:
+if subprocess.call('which count-unsafe > /dev/null 2>&1', shell=True) != 0:
     print('''Please install count-unsafe by\n
 `rustup update nightly && cargo +nightly install --git https://github.com/efenniht/count-unsafe`''')
     exit(-1)
 
-if os.system('which cloc > /dev/null 2>&1') != 0:
+if subprocess.call('which cloc > /dev/null 2>&1', shell=True) != 0:
     print('''Please install cloc by `apt install cloc`''')
     exit(-1)
 
@@ -21,21 +21,23 @@ space = re.compile(r'\s+')
 
 unsafes = defaultdict(lambda: 0)
 
-for line in os.popen(f'count-unsafe {path}').readlines()[1:]:
-    file, begin, end, cnt, ty = line.split(',')
-
-    unsafes[file] += int(cnt)
-
 slocs = {}
 
 for file in glob.glob(path, recursive=True):
-    stat = os.popen(f'cloc {file}').readlines()[-2].strip()
+    for line in subprocess.check_output(['count-unsafe', file], text=True).splitlines()[1:]:
+        file, begin, end, cnt, ty = line.split(',')
+        unsafes[file] += int(cnt)
+
+    stat = subprocess.check_output(['cloc', file], text=True).splitlines()[-2].strip()
     sloc = int(space.split(stat)[-1])
 
     slocs[file] = sloc
 
-    print(f'{file} : {unsafes[file]}/{sloc} = {unsafes[file]*100//sloc}')
+    print(f'{file}: {unsafes[file]}/{sloc} = {unsafes[file]*100//sloc}%')
 
 print('Total:')
 
-print(f'{sum(unsafes.values())}/{sum(slocs.values())}')
+unsafe_total = sum(unsafes.values())
+sloc_total = sum(slocs.values())
+
+print(f'{unsafe_total}/{sloc_total} = {unsafe_total*100//sloc_total}%')

--- a/count_unsafe.py
+++ b/count_unsafe.py
@@ -24,11 +24,11 @@ unsafes = defaultdict(lambda: 0)
 slocs = {}
 
 for file in glob.glob(path, recursive=True):
-    for line in subprocess.check_output(['count-unsafe', file], text=True).splitlines()[1:]:
+    for line in subprocess.check_output(['count-unsafe', file], universal_newlines=True).splitlines()[1:]:
         file, begin, end, cnt, ty = line.split(',')
         unsafes[file] += int(cnt)
 
-    stat = subprocess.check_output(['cloc', file], text=True).splitlines()[-2].strip()
+    stat = subprocess.check_output(['cloc', file], universal_newlines=True).splitlines()[-2].strip()
     sloc = int(space.split(stat)[-1])
 
     slocs[file] = sloc


### PR DESCRIPTION
`count_unsafe.py`를 실행할 때 `fs/*.rs` 파일들이 제대로 카운트되지 않는 버그가 있어 수정했습니다.

현재 unsafe line 수는 다음과 같습니다:
```
kernel-rs/src/virtio.rs: 6/76 = 7%
kernel-rs/src/riscv.rs: 154/274 = 56%
kernel-rs/src/sleepablelock.rs: 14/74 = 18%
kernel-rs/src/pipe.rs: 115/170 = 67%
kernel-rs/src/uart.rs: 11/155 = 7%
kernel-rs/src/console.rs: 97/158 = 61%
kernel-rs/src/vm.rs: 197/578 = 34%
kernel-rs/src/page.rs: 10/65 = 15%
kernel-rs/src/start.rs: 34/57 = 59%
kernel-rs/src/stat.rs: 0/10 = 0%
kernel-rs/src/sleeplock.rs: 13/92 = 14%
kernel-rs/src/utils.rs: 0/7 = 0%
kernel-rs/src/plic.rs: 18/22 = 81%
kernel-rs/src/etrace.rs: 0/117 = 0%
kernel-rs/src/trap.rs: 122/143 = 85%
kernel-rs/src/file.rs: 86/175 = 49%
kernel-rs/src/kalloc.rs: 13/45 = 28%
kernel-rs/src/memlayout.rs: 0/34 = 0%
kernel-rs/src/fcntl.rs: 0/9 = 0%
kernel-rs/src/bio.rs: 13/132 = 9%
kernel-rs/src/param.rs: 0/15 = 0%
kernel-rs/src/virtio_disk.rs: 128/287 = 44%
kernel-rs/src/lib.rs: 0/58 = 0%
kernel-rs/src/kernel.rs: 34/149 = 22%
kernel-rs/src/sysfile.rs: 152/351 = 43%
kernel-rs/src/poweroff.rs: 3/10 = 30%
kernel-rs/src/list.rs: 15/54 = 27%
kernel-rs/src/arena.rs: 72/369 = 19%
kernel-rs/src/exec.rs: 112/182 = 61%
kernel-rs/src/proc.rs: 278/594 = 46%
kernel-rs/src/syscall.rs: 79/89 = 88%
kernel-rs/src/sysproc.rs: 43/55 = 78%
kernel-rs/src/spinlock.rs: 49/191 = 25%
kernel-rs/src/fs/superblock.rs: 5/30 = 16%
kernel-rs/src/fs/inode.rs: 130/470 = 27%
kernel-rs/src/fs/path.rs: 11/91 = 12%
kernel-rs/src/fs/log.rs: 124/158 = 78%
kernel-rs/src/fs/mod.rs: 43/115 = 37%
Total:
2181/5661 = 38%
```