### PR TITLE
Refactoring virtio_disk

### DIFF
--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -17,7 +17,6 @@ use crate::{
     spinlock::Spinlock,
     trap::{trapinit, trapinithart},
     uart::Uart,
-    virtio_disk::virtio_disk_init,
     vm::KernelMemory,
 };
 
@@ -216,7 +215,7 @@ pub unsafe fn kernel_main() -> ! {
         KERNEL.bcache.get_mut().init();
 
         // Emulated hard disk.
-        virtio_disk_init(&mut KERNEL.virtqueue, KERNEL.file_system.disk.get_mut());
+        KERNEL.file_system.disk.get_mut().init();
 
         // First user process.
         KERNEL.procs.user_proc_init();

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -62,7 +62,9 @@ mod trap;
 mod uart;
 #[deny(unsafe_op_in_unsafe_fn)]
 mod utils;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod virtio;
+#[deny(unsafe_op_in_unsafe_fn)]
 mod virtio_disk;
 #[deny(unsafe_op_in_unsafe_fn)]
 mod vm;

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -213,7 +213,7 @@ pub unsafe fn devintr() -> i32 {
         if irq as usize == UART0_IRQ {
             kernel().uart.intr();
         } else if irq as usize == VIRTIO0_IRQ {
-            kernel().file_system.disk.lock().virtio_intr();
+            kernel().file_system.disk.lock().intr();
         } else if irq != 0 {
             println!("unexpected interrupt irq={}\n", irq);
         }


### PR DESCRIPTION
* `Disk`가 `RawPage`를 받아 해당 페이지의 내부를 가리키는 포인터를 만드는 기존의 코드를 없애고, 처음부터 올바르게 align된 배열을 `Disk`가 가지고 있게 만들었습니다. 이를 통해 `Disk`가 자기 자신을 참조할 필요가 없게 되었습니다. 다만, 여전히 `Disk`의 배열의 주소를 MMIO 레지스터에 기록하기 때문에 이후에 가능하다면 `Disk`를 `Pin`으로 보호하는 것이 좋을 것 같습니다.
* `Descriptor`가 `Disk`에 있는 `desc` 배열의 특정 부분을 가리키는 포인터를 가지고 있던 것을 없애고, xv6 구현처럼 index를 나타내는 `usize`만 가지고 있도록 다시 바꾸었습니다. 
  * 포인터를 가지고 있는 경우 해당 포인터가 유효한지 보장할 수 없기 때문에 기존 구현에 있던 아래와 같은 `Deref` 및 `DerefMut` 구현은 올바르지 않습니다.
https://github.com/kaist-cp/rv6/blob/1afd6bfe99027e9e64b0c5d7c5d9d1ee9665be61/kernel-rs/src/virtio_disk.rs#L123-L135
 따라서 `Descriptor`가 가지고 있는 포인터를 사용하려면 반드시 `unsafe`가 필요하고 이는 `unsafe`를 불필요하게 늘립니다.
  * 반면 index만 가지고 있고 이 index를 사용해 `desc` 배열에 접근하는 것은 언제나 안전합니다. Rust에서는 배열에 접근할 때 index를 검사하므로 xv6에 비해 약간의 성능 손해가 발생할 수 있습니다. 그러나, 현실적으로 rv6 전체에서 배열 접근을 없앨 수 는 없기 때문에 굳이 배열에 접근하는 코드를 모두 없애려 할 필요는 없다고 생각하며, 무시할 수 있을 정도의 성능 손해라고 생각합니다.