### PR TITLE
[Closes #241] Use Pin API for unmovable structs

### DIFF
--- a/kernel-rs/Cargo.lock
+++ b/kernel-rs/Cargo.lock
@@ -92,6 +92,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rv6-kernel"
 version = "0.1.0"
 dependencies = [
@@ -101,6 +139,7 @@ dependencies = [
  "cstr_core",
  "itertools",
  "num-iter",
+ "pin-project",
  "scopeguard",
  "spin",
  "static_assertions",
@@ -123,3 +162,20 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "syn"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"

--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -29,6 +29,7 @@ spin = { version = "0.7.0", default-features = false }
 array-macro = "2.0.0"
 static_assertions = "1.1.0"
 itertools = { version = "0.9.0", default-features = false }
+pin-project = "1.0.4"
 
 # Compiler options for sysroot packages.
 # Cargo currently warns following packages are not dependencies.

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -5,7 +5,7 @@ use crate::{
     fs::RcInode,
     kernel::kernel,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
-    pipe::AllocatedPipe,
+    pipe::{Pipe, AllocatedPipe},
     proc::{myproc, Proc},
     spinlock::Spinlock,
     stat::Stat,
@@ -95,7 +95,7 @@ impl File {
         }
 
         match &self.typ {
-            FileType::Pipe { pipe } => pipe.read(addr, usize::try_from(n).unwrap_or(0)),
+            FileType::Pipe { pipe } => Pipe::read(pipe.inner(), addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
                 let mut ip = ip.deref().lock();
                 let curr_off = *off.get();
@@ -122,7 +122,7 @@ impl File {
         }
 
         match &self.typ {
-            FileType::Pipe { pipe } => pipe.write(addr, usize::try_from(n).unwrap_or(0)),
+            FileType::Pipe { pipe } => Pipe::write(pipe.inner(), addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
                 // write a few blocks at a time to avoid exceeding
                 // the maximum log transaction size, including

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -178,7 +178,7 @@ impl ArenaObject for File {
         A::reacquire_after(guard, || {
             let typ = mem::replace(&mut self.typ, FileType::None);
             match typ {
-                FileType::Pipe { mut pipe } => unsafe { pipe.close(self.writable) },
+                FileType::Pipe { pipe } => pipe.inner().close(self.writable),
                 FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                     // TODO(rv6)
                     // The inode ip will be dropped by drop(ip). Deallocation

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -5,7 +5,7 @@ use crate::{
     fs::RcInode,
     kernel::kernel,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
-    pipe::{Pipe, AllocatedPipe},
+    pipe::AllocatedPipe,
     proc::{myproc, Proc},
     spinlock::Spinlock,
     stat::Stat,
@@ -95,7 +95,7 @@ impl File {
         }
 
         match &self.typ {
-            FileType::Pipe { pipe } => Pipe::read(pipe.inner(), addr, usize::try_from(n).unwrap_or(0)),
+            FileType::Pipe { pipe } => pipe.inner().read(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
                 let mut ip = ip.deref().lock();
                 let curr_off = *off.get();
@@ -122,7 +122,7 @@ impl File {
         }
 
         match &self.typ {
-            FileType::Pipe { pipe } => Pipe::write(pipe.inner(), addr, usize::try_from(n).unwrap_or(0)),
+            FileType::Pipe { pipe } => pipe.inner().write(addr, usize::try_from(n).unwrap_or(0)),
             FileType::Inode { ip, off } => {
                 // write a few blocks at a time to avoid exceeding
                 // the maximum log transaction size, including

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -60,8 +60,6 @@ pub struct Kernel {
 
     /// Memory for virtio descriptors `&c` for queue 0.
     ///
-    /// This is a global instead of allocated because it must be multiple contiguous pages, which
-    /// `kernel().alloc()` doesn't support, and page aligned.
     // TODO(efenniht): I moved out pages from Disk. Did I changed semantics (pointer indirection?)
     virtqueue: [RawPage; 2],
 

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -61,3 +61,5 @@ extern crate array_macro;
 extern crate static_assertions;
 #[macro_use]
 extern crate itertools;
+#[macro_use]
+extern crate pin_project;

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -7,7 +7,7 @@ use crate::{
     spinlock::Spinlock,
     vm::UVAddr,
 };
-use core::{mem, ptr, pin::Pin};
+use core::{mem, pin::Pin, ptr};
 
 const PIPESIZE: usize = 512;
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -5,8 +5,8 @@ use core::{
     cmp,
     mem::{self, MaybeUninit},
     ops::{Deref, DerefMut},
-    ptr, slice, str,
     pin::Pin,
+    ptr, slice, str,
     sync::atomic::{AtomicBool, AtomicI32, Ordering},
 };
 
@@ -285,6 +285,7 @@ impl WaitChannel {
 
     /// Wake up all processes sleeping on waitchannel.
     /// Must be called without any p->lock.
+    /// TODO: `&self` -> `self: Pin<&Self>`.
     pub fn wakeup(&self) {
         kernel().procs.wakeup_pool(self)
     }

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -46,6 +46,7 @@ impl<T> Sleepablelock<T> {
             lock: unsafe {
                 // Safe since we maintain the `Pin` as long as the
                 // `SleepablelockGuard` is alive.
+                // TODO: Obtain a `Pin` from `self` instead of creating a new one.
                 Pin::new_unchecked(self)
             },
             _marker: PhantomData,

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -159,6 +159,7 @@ impl<T> Spinlock<T> {
         }
     }
 
+    // TODO: This should be removed.
     pub unsafe fn unlock(&self) {
         self.lock.release();
     }

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -317,7 +317,7 @@ impl Disk {
 
         // Wait for virtio_disk_intr() to say request has finished.
         while b.deref_mut_inner().disk {
-            (*b).vdisk_request_waitchannel.sleep(this);
+            (*b).get_waitchannel().sleep(this);
         }
         this.info[desc[0].idx].b = ptr::null_mut();
         IntoIter::new(desc).for_each(|desc| this.desc.free(desc));
@@ -348,7 +348,7 @@ impl Disk {
 
             // disk is done with buf
             buf.deref_mut_inner().disk = false;
-            buf.vdisk_request_waitchannel.wakeup();
+            buf.get_waitchannel().wakeup();
 
             self.used_idx += 1;
         }


### PR DESCRIPTION
이 Draft PR에서는 `Pin` API를 이용하여 특정 struct들이 move되지 못하도록 강제해보려 하였고, 몇몇 부분에서는 효과적이긴 하였으나, **한계 또한 확실한 듯 하여** 먼저 draft을 올려본 후 추가적인 제안을 해보고 싶습니다. (1번은 그냥 보충설명이므로, 2, 3번만 읽으셔도 무방합니다.)
## 1. 한계(+`Pin` API 정리)
* `Pin`관련 issue(https://github.com/rust-lang/rust/issues/55766#issuecomment-437374982) 에도 나와있듯이, `Pin` != `!Move` 입니다. 즉, **`Pin`은 그저 또다른 pointer일 뿐이며, `Pin`을 이용한다고 해서 특정 struct을 `!Move`로 표시하는게 아니고 그저 `Pin`만을 가지고서는 move를 할 수 없는 것** 뿐입니다. 예로, 다음과 같은 코드는 compile error가 발생하지 않습니다. (즉, move가 가능합니다.)
```rust
fn move_pinned_ref<T>(mut a: T, mut b: T) {
    unsafe {
        let p: Pin<&mut T> = Pin::new_unchecked(&mut a);
        // This should mean the pointee `a` can never move again.
    }
    mem::swap(&mut a, &mut b);
    // The address of `a` changed to `b`'s stack slot, so `a` got moved even
    // though we have previously pinned it! We have violated the pinning API contract.
}
```
* 만약 **`Pin<&mut T>`밖에 없다면** (즉, `&mut T`는 가지고 있지 않고 얻을 수도 없다면), `T`를 move할 방법이 없으므로 move를 근본적으로 방지할 수 있습니다.
	* 다만, 이러기 위해서는 `T`를 stack이나 다른 struct의 field이 아니라, heap에 저장해야 합니다. 그렇지 않으면 safe code에서도 `&mut T`를 얻을 수 있기에, **프로그래머가 직접 조심해야 됩니다.** (macro를 쓰면 조금 더 편해지긴 하지만, 그래도 마찬가지입니다.) 그리고 **`Pin`된 상태를 계속 유지해야 합니다.**
	* rv6에서는 struct을 `kernel().alloc()`으로 page의 주소값을 받아서 거기에 struct을 저장하는 경우에는, move를 근본적으로 방지할 수 있습니다. (즉, heap에 저장하는 경우와 유사한 예입니다.) 다만, 이런 struct는 `Pipe`하나 뿐입니다.
	* **rv6의 나머지 struct들은 모두 또다른 더 큰 struct의 field로 저장되기 때문에, 그 (더 큰) struct 내부에서는 자유롭게 `&mut T`를 얻을 수 있고, 내부 struct를 move할 수 있으며, 조심하지 않으면 그 `&mut T`를 외부로 내보낼 수도 있습니다.**

## 2. 이 Draft에서의 변경사항
* **`Pin`덕분에, 이제는 `Pipe`을 move할 수 있는 방법이 없습니다. 추가적으로, `Pipe`의 `Copy`, `Clone` trait을 없앴으며, `Pipe::Drop` trait을 추가했습니다.**
* WaitChannel을 이용하는 코드들의 경우, `&WaitChannel` -> `Pin<&WaitChannel>`로 변경했습니다. 다만, 임시적으로 `Pin<&WaitChannel>`을 만들고 바로 drop하는 부분들도 많으므로, 큰 의미가 없는 곳도 많습니다.
* 아직 TODO로 표시된 미완성 부분들이 많습니다.

## 3. 제안사항
* 현재 목표는 최대한 xv6과 비슷한 구조를 유지하는 것입니다. 그러므로, **위에서 설명한 한계를 피할 방법은 없어 보입니다.**
* 일단은, `T`가 move되어서는 안되는 struct라면, `&mut T` -> `Pin<&mut T>`로 바꿔서 `&mut T`가 노출되지 않도록 하고 있습니다.
### * 다만, 추가로, **`T` 자체는 `Unsafecell`안에 넣고 `Pin<&mut T>`만을 노출시키는 건 어떨지 제안해봅니다.**
 즉,
```Rust
struct blah {
	...
	waitchannel: WaitChannel, //should not move!
}
```
를
```Rust
struct blah {
	...
	_waitchannel: Unsafecell<WaitChannel>, //should not move!
	waitchannel: Pin<&mut WaitChannel>,
}
```
로 바꾸는 겁니다. (다만, 이러면 const fn안에서 initialize할 수 없을 것 같습니다.) 이러면, `_waitchannel`을 직접 접근하거나 move하지만 않으면 되므로 더 안전하고 훨씬 간단할 것 같습니다.)