### PR TITLE
Unsafe reasoning in ArrayArena

### DIFF
--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -3,7 +3,7 @@ use crate::spinlock::{Spinlock, SpinlockGuard};
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
 use core::ops::Deref;
-use core::ptr;
+use core::ptr::{self, NonNull};
 
 /// A homogeneous memory allocator, equipped with the box type representing an allocation.
 pub trait Arena: Sized {
@@ -11,32 +11,51 @@ pub trait Arena: Sized {
     type Data;
 
     /// The object handle type of the allocator.
-    type Handle;
+    type Handle<'s>;
 
     /// The guard type for arena.
     type Guard<'s>;
 
     /// Find or alloc.
+    fn find_or_alloc_handle<C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
+        &self,
+        c: C,
+        n: N,
+    ) -> Option<Self::Handle<'_>>;
+
     fn find_or_alloc<C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
         &self,
         c: C,
         n: N,
-    ) -> Option<Self::Handle>;
+    ) -> Option<Rc<'_, Self, &Self>> {
+        let inner = self.find_or_alloc_handle(c, n)?;
+        // It is safe becuase inner has been allocated from self.
+        Some(unsafe { Rc::from_unchecked(self, inner) })
+    }
 
     /// Failable allocation.
-    fn alloc<F: FnOnce(&mut Self::Data)>(&self, f: F) -> Option<Self::Handle>;
+    fn alloc_handle<F: FnOnce(&mut Self::Data)>(&self, f: F) -> Option<Self::Handle<'_>>;
 
+    fn alloc<F: FnOnce(&mut Self::Data)>(&self, f: F) -> Option<Rc<'_, Self, &Self>> {
+        let inner = self.alloc_handle(f)?;
+        // It is safe becuase inner has been allocated from self.
+        Some(unsafe { Rc::from_unchecked(self, inner) })
+    }
+
+    /// Duplicate a given handle, and increase the reference count.
+    ///
     /// # Safety
     ///
     /// `handle` must be allocated from `self`.
-    unsafe fn dup(&self, handle: &Self::Handle) -> Self::Handle;
+    unsafe fn dup<'s>(&self, handle: &Self::Handle<'s>) -> Self::Handle<'s>;
 
+    /// Deallocate a given handle, and finalize the referred object if there are
+    /// no more handles.
+    ///
     /// # Safety
     ///
-    /// `pbox` must be allocated from the pool.
-    ///
-    /// Returns whether the object is finalized.
-    unsafe fn dealloc(&self, pbox: Self::Handle);
+    /// `handle` must be allocated from `self`.
+    unsafe fn dealloc(&self, handle: Self::Handle<'_>);
 
     fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R
     where
@@ -57,9 +76,24 @@ pub struct ArrayArena<T, const CAPACITY: usize> {
     entries: [ArrayEntry<T>; CAPACITY],
 }
 
-pub struct ArrayPtr<T> {
-    ptr: *mut ArrayEntry<T>,
-    _marker: PhantomData<T>,
+/// # Safety
+///
+/// `ptr` is a valid pointer to `ArrayEntry<T>` and has lifetime `'s`.
+pub struct ArrayPtr<'s, T> {
+    ptr: NonNull<ArrayEntry<T>>,
+    _marker: PhantomData<&'s T>,
+}
+
+impl<'s, T> ArrayPtr<'s, T> {
+    /// # Safety
+    ///
+    /// `ptr` should be a valid pointer to `ArrayEntry<T>` and have lifetime `'s`.
+    unsafe fn new(ptr: NonNull<ArrayEntry<T>>) -> ArrayPtr<'s, T> {
+        Self {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
 }
 
 #[repr(C)]
@@ -75,14 +109,20 @@ pub struct MruArena<T, const CAPACITY: usize> {
     head: ListEntry,
 }
 
+/// # Safety
+///
+/// TODO
 pub struct MruPtr<T> {
-    ptr: *mut MruEntry<T>,
+    ptr: NonNull<MruEntry<T>>,
     _marker: PhantomData<T>,
 }
 
-pub struct Rc<A: Arena, T: Deref<Target = A>> {
+/// # Safety
+///
+/// `inner` is allocated from `tag`
+pub struct Rc<'s, A: Arena, T: Deref<Target = A>> {
     tag: T,
-    inner: ManuallyDrop<<<T as Deref>::Target as Arena>::Handle>,
+    inner: ManuallyDrop<A::Handle<'s>>,
 }
 
 impl<T> ArrayEntry<T> {
@@ -98,15 +138,16 @@ impl<T, const CAPACITY: usize> ArrayArena<T, CAPACITY> {
     }
 }
 
-impl<T> Deref for ArrayPtr<T> {
+impl<T> Deref for ArrayPtr<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        unsafe { &(*self.ptr).data }
+        // It is safe because of the invariant.
+        unsafe { &self.ptr.as_ref().data }
     }
 }
 
-impl<T> Drop for ArrayPtr<T> {
+impl<T> Drop for ArrayPtr<'_, T> {
     fn drop(&mut self) {
         // HACK(@efenniht): we really need linear type here:
         // https://github.com/rust-lang/rfcs/issues/814
@@ -116,14 +157,14 @@ impl<T> Drop for ArrayPtr<T> {
 
 impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<ArrayArena<T, CAPACITY>> {
     type Data = T;
-    type Handle = ArrayPtr<T>;
+    type Handle<'s> = ArrayPtr<'s, T>;
     type Guard<'s> = SpinlockGuard<'s, ArrayArena<T, CAPACITY>>;
 
-    fn find_or_alloc<C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
+    fn find_or_alloc_handle<C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
         &self,
         c: C,
         n: N,
-    ) -> Option<Self::Handle> {
+    ) -> Option<Self::Handle<'_>> {
         let mut this = self.lock();
 
         let mut empty: *mut ArrayEntry<T> = ptr::null_mut();
@@ -131,10 +172,8 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<ArrayAr
             if entry.refcnt != 0 {
                 if c(&entry.data) {
                     entry.refcnt += 1;
-                    return Some(Self::Handle {
-                        ptr: entry,
-                        _marker: PhantomData,
-                    });
+                    // It is safe because entry is a part of self, whose lifetime is 's.
+                    return Some(unsafe { ArrayPtr::new(NonNull::from(entry)) });
                 }
             } else if empty.is_null() {
                 empty = entry;
@@ -146,39 +185,40 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<ArrayAr
             return None;
         }
 
+        // It is safe because empty is a one of this.entries.
         let entry = unsafe { &mut *empty };
         entry.refcnt = 1;
         n(&mut entry.data);
-        Some(Self::Handle {
-            ptr: entry,
-            _marker: PhantomData,
-        })
+        // It is safe because entry is a part of self, whose lifetime is 's.
+        Some(unsafe { ArrayPtr::new(NonNull::from(entry)) })
     }
 
-    fn alloc<F: FnOnce(&mut T)>(&self, f: F) -> Option<Self::Handle> {
+    fn alloc_handle<F: FnOnce(&mut Self::Data)>(&self, f: F) -> Option<Self::Handle<'_>> {
         let mut this = self.lock();
 
         for entry in &mut this.entries {
             if entry.refcnt == 0 {
                 entry.refcnt = 1;
                 f(&mut entry.data);
-                return Some(Self::Handle {
-                    ptr: entry,
-                    _marker: PhantomData,
-                });
+                // It is safe because entry is a part of self, whose lifetime is 's.
+                return Some(unsafe { ArrayPtr::new(NonNull::from(entry)) });
             }
         }
 
         None
     }
 
-    unsafe fn dup(&self, handle: &Self::Handle) -> Self::Handle {
+    /// # Safety
+    ///
+    /// `handle` must be allocated from `self`.
+    unsafe fn dup<'s>(&self, handle: &Self::Handle<'s>) -> Self::Handle<'s> {
         let mut _this = self.lock();
 
         // TODO(https://github.com/kaist-cp/rv6/issues/369)
         // Make a ArrayArena trait and move this there.
-        unsafe { (*handle.ptr).refcnt += 1 };
-        Self::Handle {
+        // It is safe becuase of the invariant of ArrayPtr.
+        unsafe { (*handle.ptr.as_ptr()).refcnt += 1 };
+        Self::Handle::<'s> {
             ptr: handle.ptr,
             _marker: PhantomData,
         }
@@ -186,16 +226,16 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<ArrayAr
 
     /// # Safety
     ///
-    /// `rc` must be allocated from `self`.
-    unsafe fn dealloc(&self, handle: Self::Handle) {
+    /// `handle` must be allocated from `self`.
+    unsafe fn dealloc(&self, mut handle: Self::Handle<'_>) {
         let mut this = self.lock();
 
-        let entry = unsafe { &mut *handle.ptr };
+        // It is safe becuase of the invariant of ArrayPtr.
+        let entry = unsafe { handle.ptr.as_mut() };
         if entry.refcnt == 1 {
             entry.data.finalize::<Self>(&mut this);
         }
 
-        let entry = unsafe { &mut *handle.ptr };
         entry.refcnt -= 1;
         mem::forget(handle);
     }
@@ -240,7 +280,7 @@ impl<T> Deref for MruPtr<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        unsafe { &(*self.ptr).data }
+        unsafe { &self.ptr.as_ref().data }
     }
 }
 
@@ -262,21 +302,16 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Spinlock<MruArena<T, CAPAC
 
 impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruArena<T, CAPACITY>> {
     type Data = T;
-    type Handle = MruPtr<T>;
+    type Handle<'s> = MruPtr<T>;
     type Guard<'s> = SpinlockGuard<'s, MruArena<T, CAPACITY>>;
 
-    fn find_or_alloc<C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
-        &self,
+    fn find_or_alloc_handle<'s, C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
+        &'s self,
         c: C,
         n: N,
-    ) -> Option<Self::Handle> {
-        // Look through buffer cache for block on device dev.
-        // If not found, allocate a buffer.
-        // In either case, return locked buffer.
-
+    ) -> Option<Self::Handle<'s>> {
         let this = self.lock();
 
-        // Is the block already cached?
         let mut list_entry = this.head.next();
         let mut empty = ptr::null_mut();
         while list_entry as *const _ != &this.head as *const _ {
@@ -286,8 +321,8 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
             };
             if c(&entry.data) {
                 entry.refcnt += 1;
-                return Some(Self::Handle {
-                    ptr: entry,
+                return Some(Self::Handle::<'s> {
+                    ptr: NonNull::from(entry),
                     _marker: PhantomData,
                 });
             } else if entry.refcnt == 0 {
@@ -303,13 +338,13 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
         let entry = unsafe { &mut *empty };
         entry.refcnt = 1;
         n(&mut entry.data);
-        Some(Self::Handle {
-            ptr: entry,
+        Some(Self::Handle::<'s> {
+            ptr: NonNull::from(entry),
             _marker: PhantomData,
         })
     }
 
-    fn alloc<F: FnOnce(&mut T)>(&self, f: F) -> Option<Self::Handle> {
+    fn alloc_handle<'s, F: FnOnce(&mut Self::Data)>(&'s self, f: F) -> Option<Self::Handle<'s>> {
         let this = self.lock();
 
         let mut list_entry = this.head.prev();
@@ -321,8 +356,8 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
             if entry.refcnt == 0 {
                 entry.refcnt = 1;
                 f(&mut entry.data);
-                return Some(Self::Handle {
-                    ptr: entry,
+                return Some(Self::Handle::<'s> {
+                    ptr: NonNull::from(entry),
                     _marker: PhantomData,
                 });
             }
@@ -332,13 +367,16 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
         None
     }
 
-    unsafe fn dup(&self, handle: &Self::Handle) -> Self::Handle {
+    /// # Safety
+    ///
+    /// `handle` must be allocated from `self`.
+    unsafe fn dup<'s>(&self, handle: &Self::Handle<'s>) -> Self::Handle<'s> {
         let mut _this = self.lock();
 
         // TODO(https://github.com/kaist-cp/rv6/issues/369)
         // Make a MruArena trait and move this there.
-        unsafe { (*handle.ptr).refcnt += 1 };
-        Self::Handle {
+        unsafe { (*handle.ptr.as_ptr()).refcnt += 1 };
+        Self::Handle::<'s> {
             ptr: handle.ptr,
             _marker: PhantomData,
         }
@@ -346,16 +384,15 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
 
     /// # Safety
     ///
-    /// `rc` must be allocated from `self`.
-    unsafe fn dealloc(&self, handle: Self::Handle) {
+    /// `handle` must be allocated from `self`.
+    unsafe fn dealloc(&self, mut handle: Self::Handle<'_>) {
         let mut this = self.lock();
 
-        let entry = unsafe { &mut *handle.ptr };
+        let entry = unsafe { handle.ptr.as_mut() };
         if entry.refcnt == 1 {
             entry.data.finalize::<Self>(&mut this);
         }
 
-        let entry = unsafe { &mut *handle.ptr };
         entry.refcnt -= 1;
 
         if entry.refcnt == 0 {
@@ -374,77 +411,36 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
     }
 }
 
-impl<A: Arena, T: Deref<Target = A>> Deref for Rc<A, T> {
-    type Target = <A as Arena>::Handle;
+impl<'s, A: Arena, T: Deref<Target = A>> Deref for Rc<'s, A, T> {
+    type Target = A::Handle<'s>;
 
     fn deref(&self) -> &Self::Target {
         self.inner.deref()
     }
 }
 
-impl<A: Arena, T: Deref<Target = A>> Drop for Rc<A, T> {
+impl<'s, A: Arena, T: Deref<Target = A>> Drop for Rc<'s, A, T> {
     fn drop(&mut self) {
-        // SAFETY: We can ensure the box is allocated from `self.tag` by the invariant of `Tag`.
-        //
-        // Drop AFTER the arena guard is dropped, as dropping val may cause the current thread
-        // sleep.
-        let _val = unsafe { self.tag.dealloc(ManuallyDrop::take(&mut self.inner)) };
+        // It is safe because inner is allocated from tag.
+        unsafe { self.tag.dealloc(ManuallyDrop::take(&mut self.inner)) };
     }
 }
 
-impl<A: Arena, T: Deref<Target = A>> Rc<A, T> {
-    pub unsafe fn from_unchecked(tag: T, inner: <<T as Deref>::Target as Arena>::Handle) -> Self {
+impl<'s, A: Arena, T: Deref<Target = A>> Rc<'s, A, T> {
+    /// # Safety
+    ///
+    /// `inner` must be allocated from `tag`
+    pub unsafe fn from_unchecked(tag: T, inner: A::Handle<'s>) -> Self {
         let inner = ManuallyDrop::new(inner);
         Self { tag, inner }
     }
 }
 
-impl<A: Arena, T: Clone + Deref<Target = A>> Clone for Rc<A, T> {
+impl<'s, A: Arena, T: Clone + Deref<Target = A>> Clone for Rc<'s, A, T> {
     fn clone(&self) -> Self {
         let tag = self.tag.clone();
-        let inner = ManuallyDrop::new(unsafe { tag.deref().dup(&self.inner) });
+        // It is safe because inner is allocated from tag.
+        let inner = ManuallyDrop::new(unsafe { tag.dup(&self.inner) });
         Self { tag, inner }
-    }
-}
-
-impl<A: Arena, T: Clone + Deref<Target = A>> Arena for T {
-    type Data = A::Data;
-    type Handle = Rc<A, T>;
-    type Guard<'s> = <A as Arena>::Guard<'s>;
-
-    fn find_or_alloc<C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
-        &self,
-        c: C,
-        n: N,
-    ) -> Option<Self::Handle> {
-        let tag = self.clone();
-        let inner = ManuallyDrop::new(tag.deref().find_or_alloc(c, n)?);
-        Some(Self::Handle { tag, inner })
-    }
-
-    fn alloc<F: FnOnce(&mut Self::Data)>(&self, f: F) -> Option<Self::Handle> {
-        let tag = self.clone();
-        let inner = ManuallyDrop::new(tag.deref().alloc(f)?);
-        Some(Self::Handle { tag, inner })
-    }
-
-    unsafe fn dup(&self, handle: &Self::Handle) -> Self::Handle {
-        let tag = self.clone();
-        let inner = ManuallyDrop::new(unsafe { self.deref().dup(&handle.inner) });
-        Self::Handle { tag, inner }
-    }
-
-    /// # Safety
-    ///
-    /// `pbox` must be allocated from the pool.
-    unsafe fn dealloc(&self, mut pbox: Self::Handle) {
-        unsafe { self.deref().dealloc(ManuallyDrop::take(&mut pbox.inner)) }
-    }
-
-    fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        A::reacquire_after(guard, f)
     }
 }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -44,7 +44,7 @@ pub struct Devsw {
     pub write: Option<unsafe fn(_: UVAddr, _: i32) -> i32>,
 }
 
-pub type RcFile<'s> = Rc<FileTable, &'s FileTable>;
+pub type RcFile<'s> = Rc<'s, FileTable, &'s FileTable>;
 
 // TODO(https://github.com/kaist-cp/rv6/issues/374)
 // will be infered as we wrap *mut Pipe and *mut Inode.
@@ -205,12 +205,9 @@ impl FileTable {
         writable: bool,
     ) -> Result<RcFile<'_>, ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/372): idiomatic initialization.
-        let inner = self
-            .alloc(|p| {
-                *p = File::new(typ, readable, writable);
-            })
-            .ok_or(())?;
-
-        Ok(unsafe { Rc::from_unchecked(self, inner) })
+        self.alloc(|p| {
+            *p = File::new(typ, readable, writable);
+        })
+        .ok_or(())
     }
 }


### PR DESCRIPTION
* ~`Arena`의 unsafe reasoning을 위한 PR입니다.~
* ~일단 `ArrayPtr`과 `MruPtr`이 가지고 있는 포인터를 `*mut`에서 `NonNull`로 바꾸었습니다.~
* ~코드를 보다 보니 `Arena` 구현에 관련된 질문이 몇 가지 생겼는데 해당 위치에 comment로 달아 두겠습니다.~

*edited*

`ArrayArena`의 unsafe reasoning을 위한 PR입니다.

* `ArrayPtr`과 `MruPtr`이 가지고 있는 포인터를 `*mut`에서 `NonNull`로 바꾸었습니다.
* 사용되지 않는 정의인 `impl<A: Arena, T: Clone + Deref<Target = A>> Arena for T`를 없애고 `Arena` 트레잇에 `Rc`를 반환하는 메서드를 추가했습니다.
* `ArrayPtr`이 해당 핸들을 만든 `ArrayArena`가 살아 있는 동안만 살아 있도록 `ArrayPtr`에 lifetime parameter를 추가했습니다. 이에 따라 `Rc`에도 lifetime parameter가 추가되었습니다.

`MruArena`는 이 PR에서 다루지 않습니다.