### PR TITLE
[closes #354, #258] myproc()의 사용을 줄이고, usertrap()에서 syscall 함수로 proc전달

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -61,7 +61,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if unsafe { kernel().myexproc().killed() } {
+                if unsafe { kernel().myexproc().proc().killed() } {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -61,7 +61,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if kernel().current_proc().killed() {
+                if kernel().current_proc().expect("No current proc").killed() {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -61,7 +61,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if kernel().myexproc().proc().killed() {
+                if kernel().myexproc().killed() {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -61,7 +61,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if unsafe { kernel().myexproc().proc().killed() } {
+                if kernel().myexproc().proc().killed() {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -61,7 +61,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if kernel().myexproc().killed() {
+                if kernel().current_proc().killed() {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -1,4 +1,4 @@
-use crate::{file::Devsw, kernel::kernel, param::NDEV, proc::myexproc, sleepablelock::SleepablelockGuard, uart::Uart, vm::{UVAddr, VAddr}};
+use crate::{file::Devsw, kernel::kernel, param::NDEV, sleepablelock::SleepablelockGuard, uart::Uart, vm::{UVAddr, VAddr}};
 use core::fmt;
 
 const CONSOLE_IN_DEVSW: usize = 1;
@@ -54,7 +54,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if unsafe { myexproc().killed() } {
+                if unsafe { kernel().myexproc().killed() } {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -1,12 +1,4 @@
-use crate::{
-    file::Devsw,
-    kernel::kernel,
-    param::NDEV,
-    proc::myproc,
-    sleepablelock::SleepablelockGuard,
-    uart::Uart,
-    vm::{UVAddr, VAddr},
-};
+use crate::{file::Devsw, kernel::kernel, param::NDEV, proc::myexproc, sleepablelock::SleepablelockGuard, uart::Uart, vm::{UVAddr, VAddr}};
 use core::fmt;
 
 const CONSOLE_IN_DEVSW: usize = 1;
@@ -62,7 +54,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
-                if unsafe { (*myproc()).killed() } {
+                if unsafe { myexproc().killed() } {
                     return -1;
                 }
                 this.sleep();

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -1,4 +1,11 @@
-use crate::{file::Devsw, kernel::kernel, param::NDEV, sleepablelock::SleepablelockGuard, uart::Uart, vm::{UVAddr, VAddr}};
+use crate::{
+    file::Devsw,
+    kernel::kernel,
+    param::NDEV,
+    sleepablelock::SleepablelockGuard,
+    uart::Uart,
+    vm::{UVAddr, VAddr},
+};
 use core::fmt;
 
 const CONSOLE_IN_DEVSW: usize = 1;

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::Kernel,
     page::Page,
     param::MAXARG,
-    proc::ProcData,
+    proc::CurrentProc,
     riscv::{pgroundup, PGSIZE},
     vm::{PAddr, UVAddr, UserMemory, VAddr},
 };
@@ -90,7 +90,7 @@ impl ProgHdr {
 }
 
 impl Kernel {
-    pub fn exec(&self, path: &Path, args: &[Page], proc_data: &mut ProcData) -> Result<usize, ()> {
+    pub fn exec(&self, path: &Path, args: &[Page], proc: &CurrentProc<'_>) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }
@@ -101,7 +101,7 @@ impl Kernel {
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let tx = self.file_system.begin_transaction();
-        let ptr = path.namei(proc_data)?;
+        let ptr = path.namei(proc)?;
         let mut ip = ptr.lock();
 
         // Check ELF header
@@ -113,7 +113,7 @@ impl Kernel {
             return Err(());
         }
 
-        let trap_frame = PAddr::new(proc_data.trap_frame() as *const _ as _);
+        let trap_frame = PAddr::new(proc.trap_frame() as *const _ as _);
         let mut mem = UserMemory::new(trap_frame, None).ok_or(())?;
 
         // Load program into memory.
@@ -175,6 +175,8 @@ impl Kernel {
         // It is safe because any byte can be considered as a valid u8.
         let (_, ustack, _) = unsafe { ustack.align_to::<u8>() };
         mem.copy_out(UVAddr::new(sp), &ustack[..argv_size])?;
+
+        let proc_data = proc.deref_mut_data();
 
         // Save program name for debugging.
         let path_str = path.as_bytes();

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -90,7 +90,7 @@ impl ProgHdr {
 }
 
 impl Kernel {
-    pub fn exec(&self, path: &Path, args: &[Page], p: &mut Proc) -> Result<usize, ()> {
+    pub fn exec(&self, path: &Path, args: &[Page], p: &Proc) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }
@@ -183,7 +183,7 @@ impl Kernel {
             .rposition(|c| *c == b'/')
             .map(|i| &path_str[(i + 1)..])
             .unwrap_or(path_str);
-        let p_name = &mut p.name;
+        let p_name = &mut p.deref_mut_data().name;
         let len = cmp::min(p_name.len(), name.len());
         p_name[..len].copy_from_slice(&name[..len]);
         if len < p_name.len() {
@@ -191,18 +191,18 @@ impl Kernel {
         }
 
         // Commit to the user image.
-        p.memory = mem;
+        p.deref_mut_data().memory = mem;
 
         // arguments to user main(argc, argv)
         // argc is returned via the system call return
         // value, which goes in a0.
-        p.trap_frame_mut().a1 = sp;
+        p.deref_mut_data().trap_frame_mut().a1 = sp;
 
         // initial program counter = main
-        p.trap_frame_mut().epc = elf.entry;
+        p.deref_mut_data().trap_frame_mut().epc = elf.entry;
 
         // initial stack pointer
-        p.trap_frame_mut().sp = sp;
+        p.deref_mut_data().trap_frame_mut().sp = sp;
 
         // this ends up in a0, the first argument to main(argc, argv)
         Ok(argc)

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -101,7 +101,7 @@ impl Kernel {
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let tx = self.file_system.begin_transaction();
-        let ptr = path.namei()?;
+        let ptr = path.namei(p)?;
         let mut ip = ptr.lock();
 
         // Check ELF header

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -183,7 +183,7 @@ impl Kernel {
             .rposition(|c| *c == b'/')
             .map(|i| &path_str[(i + 1)..])
             .unwrap_or(path_str);
-        let p_name = &mut p.proc().name;
+        let p_name = &mut p.name;
         let len = cmp::min(p_name.len(), name.len());
         p_name[..len].copy_from_slice(&name[..len]);
         if len < p_name.len() {

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -112,7 +112,7 @@ impl Kernel {
             return Err(());
         }
 
-        let mut p = unsafe { kernel().myexproc() };
+        let p = unsafe { kernel().myexproc() };
         let ptr = p.ptr;
         let mut data = p.deref_mut_data();
         let trap_frame = PAddr::new(data.trap_frame() as *const _ as _);

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -90,7 +90,7 @@ impl ProgHdr {
 }
 
 impl Kernel {
-    pub fn exec(&self, path: &Path, args: &[Page], p: &ExecutingProc) -> Result<usize, ()> {
+    pub fn exec(&self, path: &Path, args: &[Page], p: &mut ExecutingProc) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }
@@ -113,8 +113,8 @@ impl Kernel {
             return Err(());
         }
 
-        let mut data = p.deref_mut_data();
-        let trap_frame = PAddr::new(data.trap_frame() as *const _ as _);
+        // let data = p.deref_mut_data();
+        let trap_frame = PAddr::new(p.deref_mut_data().trap_frame() as *const _ as _);
         let mut mem = UserMemory::new(trap_frame, None).ok_or(())?;
 
         // Load program into memory.
@@ -191,6 +191,7 @@ impl Kernel {
             p_name[len] = 0;
         }
 
+        let data = p.deref_mut_data();
         // Commit to the user image.
         data.memory = mem;
 

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -113,7 +113,7 @@ impl Kernel {
             return Err(());
         }
 
-        let trap_frame = PAddr::new(p.deref_mut_data().trap_frame() as *const _ as _);
+        let trap_frame = PAddr::new(p.trap_frame() as *const _ as _);
         let mut mem = UserMemory::new(trap_frame, None).ok_or(())?;
 
         // Load program into memory.
@@ -190,20 +190,19 @@ impl Kernel {
             p_name[len] = 0;
         }
 
-        let data = p.deref_mut_data();
         // Commit to the user image.
-        data.memory = mem;
+        p.memory = mem;
 
         // arguments to user main(argc, argv)
         // argc is returned via the system call return
         // value, which goes in a0.
-        data.trap_frame_mut().a1 = sp;
+        p.trap_frame_mut().a1 = sp;
 
         // initial program counter = main
-        data.trap_frame_mut().epc = elf.entry;
+        p.trap_frame_mut().epc = elf.entry;
 
         // initial stack pointer
-        data.trap_frame_mut().sp = sp;
+        p.trap_frame_mut().sp = sp;
 
         // this ends up in a0, the first argument to main(argc, argv)
         Ok(argc)

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -114,7 +114,7 @@ impl Kernel {
         }
 
         let p = unsafe { &mut *myproc() };
-        let mut data = unsafe { &mut *p.data.get() };
+        let mut data = p.data.get_mut();
         let trap_frame = PAddr::new(data.trap_frame() as *const _ as _);
         let mut mem = UserMemory::new(trap_frame, None).ok_or(())?;
 

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -183,11 +183,11 @@ impl Kernel {
             .rposition(|c| *c == b'/')
             .map(|i| &path_str[(i + 1)..])
             .unwrap_or(path_str);
-        let p_name = &mut proc_data.name;
-        let len = cmp::min(p_name.len(), name.len());
-        p_name[..len].copy_from_slice(&name[..len]);
-        if len < p_name.len() {
-            p_name[len] = 0;
+        let proc_name = &mut proc_data.name;
+        let len = cmp::min(proc_name.len(), name.len());
+        proc_name[..len].copy_from_slice(&name[..len]);
+        if len < proc_name.len() {
+            proc_name[len] = 0;
         }
 
         // Commit to the user image.

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -2,9 +2,10 @@
 
 use crate::{
     fs::Path,
-    kernel::{kernel, Kernel},
+    kernel::Kernel,
     page::Page,
     param::MAXARG,
+    proc::ExecutingProc,
     riscv::{pgroundup, PGSIZE},
     vm::{PAddr, UVAddr, UserMemory, VAddr},
 };
@@ -89,7 +90,7 @@ impl ProgHdr {
 }
 
 impl Kernel {
-    pub fn exec(&self, path: &Path, args: &[Page]) -> Result<usize, ()> {
+    pub fn exec(&self, path: &Path, args: &[Page], p: &ExecutingProc) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }
@@ -112,7 +113,6 @@ impl Kernel {
             return Err(());
         }
 
-        let p = unsafe { kernel().myexproc() };
         let ptr = p.ptr;
         let mut data = p.deref_mut_data();
         let trap_frame = PAddr::new(data.trap_frame() as *const _ as _);

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -113,7 +113,6 @@ impl Kernel {
             return Err(());
         }
 
-        let ptr = p.ptr;
         let mut data = p.deref_mut_data();
         let trap_frame = PAddr::new(data.trap_frame() as *const _ as _);
         let mut mem = UserMemory::new(trap_frame, None).ok_or(())?;
@@ -185,7 +184,7 @@ impl Kernel {
             .rposition(|c| *c == b'/')
             .map(|i| &path_str[(i + 1)..])
             .unwrap_or(path_str);
-        let p_name = unsafe { &mut (*ptr).name };
+        let p_name = &mut p.proc().name;
         let len = cmp::min(p_name.len(), name.len());
         p_name[..len].copy_from_slice(&name[..len]);
         if len < p_name.len() {

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::Kernel,
     page::Page,
     param::MAXARG,
-    proc::Proc,
+    proc::ProcData,
     riscv::{pgroundup, PGSIZE},
     vm::{PAddr, UVAddr, UserMemory, VAddr},
 };
@@ -90,7 +90,7 @@ impl ProgHdr {
 }
 
 impl Kernel {
-    pub fn exec(&self, path: &Path, args: &[Page], p: &Proc) -> Result<usize, ()> {
+    pub fn exec(&self, path: &Path, args: &[Page], data: &mut ProcData) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }
@@ -101,7 +101,7 @@ impl Kernel {
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let tx = self.file_system.begin_transaction();
-        let ptr = path.namei(p)?;
+        let ptr = path.namei(data)?;
         let mut ip = ptr.lock();
 
         // Check ELF header
@@ -113,7 +113,7 @@ impl Kernel {
             return Err(());
         }
 
-        let trap_frame = PAddr::new(p.trap_frame() as *const _ as _);
+        let trap_frame = PAddr::new(data.trap_frame() as *const _ as _);
         let mut mem = UserMemory::new(trap_frame, None).ok_or(())?;
 
         // Load program into memory.
@@ -183,7 +183,7 @@ impl Kernel {
             .rposition(|c| *c == b'/')
             .map(|i| &path_str[(i + 1)..])
             .unwrap_or(path_str);
-        let p_name = &mut p.deref_mut_data().name;
+        let p_name = &mut data.name;
         let len = cmp::min(p_name.len(), name.len());
         p_name[..len].copy_from_slice(&name[..len]);
         if len < p_name.len() {
@@ -191,18 +191,18 @@ impl Kernel {
         }
 
         // Commit to the user image.
-        p.deref_mut_data().memory = mem;
+        data.memory = mem;
 
         // arguments to user main(argc, argv)
         // argc is returned via the system call return
         // value, which goes in a0.
-        p.deref_mut_data().trap_frame_mut().a1 = sp;
+        data.trap_frame_mut().a1 = sp;
 
         // initial program counter = main
-        p.deref_mut_data().trap_frame_mut().epc = elf.entry;
+        data.trap_frame_mut().epc = elf.entry;
 
         // initial stack pointer
-        p.deref_mut_data().trap_frame_mut().sp = sp;
+        data.trap_frame_mut().sp = sp;
 
         // this ends up in a0, the first argument to main(argc, argv)
         Ok(argc)

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::Kernel,
     page::Page,
     param::MAXARG,
-    proc::CurrentProc,
+    proc::Proc,
     riscv::{pgroundup, PGSIZE},
     vm::{PAddr, UVAddr, UserMemory, VAddr},
 };
@@ -90,7 +90,7 @@ impl ProgHdr {
 }
 
 impl Kernel {
-    pub fn exec(&self, path: &Path, args: &[Page], p: &mut CurrentProc) -> Result<usize, ()> {
+    pub fn exec(&self, path: &Path, args: &[Page], p: &mut Proc) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -113,7 +113,6 @@ impl Kernel {
             return Err(());
         }
 
-        // let data = p.deref_mut_data();
         let trap_frame = PAddr::new(p.deref_mut_data().trap_frame() as *const _ as _);
         let mut mem = UserMemory::new(trap_frame, None).ok_or(())?;
 

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -5,7 +5,7 @@ use crate::{
     kernel::Kernel,
     page::Page,
     param::MAXARG,
-    proc::ExecutingProc,
+    proc::CurrentProc,
     riscv::{pgroundup, PGSIZE},
     vm::{PAddr, UVAddr, UserMemory, VAddr},
 };
@@ -90,7 +90,7 @@ impl ProgHdr {
 }
 
 impl Kernel {
-    pub fn exec(&self, path: &Path, args: &[Page], p: &mut ExecutingProc) -> Result<usize, ()> {
+    pub fn exec(&self, path: &Path, args: &[Page], p: &mut CurrentProc) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -6,7 +6,7 @@ use crate::{
     kernel::kernel,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
     pipe::AllocatedPipe,
-    proc::CurrentProc,
+    proc::{Proc, ProcData},
     spinlock::Spinlock,
     stat::Stat,
     vm::UVAddr,
@@ -67,12 +67,12 @@ impl File {
 
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
-    pub unsafe fn stat(&self, addr: UVAddr, p: &mut CurrentProc) -> Result<(), ()> {
+    pub unsafe fn stat(&self, addr: UVAddr, data: &mut ProcData) -> Result<(), ()> {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
                 unsafe {
-                    p.memory.copy_out(
+                    data.memory.copy_out(
                         addr,
                         slice::from_raw_parts_mut(
                             &mut st as *mut Stat as *mut u8,
@@ -87,7 +87,7 @@ impl File {
 
     /// Read from file self.
     /// addr is a user virtual address.
-    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &mut Proc) -> Result<usize, ()> {
         if !self.readable {
             return Err(());
         }
@@ -114,7 +114,7 @@ impl File {
     }
     /// Write to file self.
     /// addr is a user virtual address.
-    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &mut Proc) -> Result<usize, ()> {
         if !self.writable {
             return Err(());
         }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -87,7 +87,7 @@ impl File {
 
     /// Read from file self.
     /// addr is a user virtual address.
-    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &mut Proc) -> Result<usize, ()> {
+    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &Proc) -> Result<usize, ()> {
         if !self.readable {
             return Err(());
         }
@@ -97,7 +97,7 @@ impl File {
             FileType::Inode { ip, off } => {
                 let mut ip = ip.deref().lock();
                 let curr_off = unsafe { *off.get() };
-                let ret = ip.read_user(addr, curr_off, n as u32, proc);
+                let ret = ip.read_user(addr, curr_off, n as u32, proc.deref_mut_data());
                 if let Ok(v) = ret {
                     unsafe { *off.get() = curr_off.wrapping_add(v as u32) };
                 }
@@ -114,7 +114,7 @@ impl File {
     }
     /// Write to file self.
     /// addr is a user virtual address.
-    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &mut Proc) -> Result<usize, ()> {
+    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &Proc) -> Result<usize, ()> {
         if !self.writable {
             return Err(());
         }
@@ -141,7 +141,7 @@ impl File {
                             addr + bytes_written,
                             curr_off,
                             bytes_to_write as u32,
-                            proc,
+                            proc.deref_mut_data(),
                             &tx,
                         )
                         .map(|v| {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -67,7 +67,7 @@ impl File {
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
     pub unsafe fn stat(&self, addr: UVAddr) -> Result<(), ()> {
-        let p = unsafe { kernel().myexproc() };
+        let mut p = unsafe { kernel().myexproc() };
 
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -67,7 +67,7 @@ impl File {
 
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
-    pub unsafe fn stat(&self, addr: UVAddr, p: &ExecutingProc) -> Result<(), ()> {
+    pub unsafe fn stat(&self, addr: UVAddr, p: &mut ExecutingProc) -> Result<(), ()> {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
@@ -87,7 +87,7 @@ impl File {
 
     /// Read from file self.
     /// addr is a user virtual address.
-    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &mut ExecutingProc) -> Result<usize, ()> {
         if !self.readable {
             return Err(());
         }
@@ -114,7 +114,12 @@ impl File {
     }
     /// Write to file self.
     /// addr is a user virtual address.
-    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn write(
+        &self,
+        addr: UVAddr,
+        n: i32,
+        proc: &mut ExecutingProc,
+    ) -> Result<usize, ()> {
         if !self.writable {
             return Err(());
         }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -6,7 +6,7 @@ use crate::{
     kernel::kernel,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
     pipe::AllocatedPipe,
-    proc::ExecutingProc,
+    proc::CurrentProc,
     spinlock::Spinlock,
     stat::Stat,
     vm::UVAddr,
@@ -67,7 +67,7 @@ impl File {
 
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
-    pub unsafe fn stat(&self, addr: UVAddr, p: &mut ExecutingProc) -> Result<(), ()> {
+    pub unsafe fn stat(&self, addr: UVAddr, p: &mut CurrentProc) -> Result<(), ()> {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
@@ -87,7 +87,7 @@ impl File {
 
     /// Read from file self.
     /// addr is a user virtual address.
-    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &mut CurrentProc) -> Result<usize, ()> {
         if !self.readable {
             return Err(());
         }
@@ -114,12 +114,7 @@ impl File {
     }
     /// Write to file self.
     /// addr is a user virtual address.
-    pub unsafe fn write(
-        &self,
-        addr: UVAddr,
-        n: i32,
-        proc: &mut ExecutingProc,
-    ) -> Result<usize, ()> {
+    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &mut CurrentProc) -> Result<usize, ()> {
         if !self.writable {
             return Err(());
         }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -6,7 +6,6 @@ use crate::{
     kernel::kernel,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
     pipe::AllocatedPipe,
-    proc::myproc,
     spinlock::Spinlock,
     stat::Stat,
     vm::UVAddr,
@@ -68,13 +67,13 @@ impl File {
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
     pub unsafe fn stat(&self, addr: UVAddr) -> Result<(), ()> {
-        let p = unsafe { myproc() };
+        let p = unsafe { kernel().myexproc() };
 
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
                 unsafe {
-                    (*(*p).data.get()).memory.copy_out(
+                    p.deref_mut_data().memory.copy_out(
                         addr,
                         slice::from_raw_parts_mut(
                             &mut st as *mut Stat as *mut u8,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -72,7 +72,7 @@ impl File {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
                 unsafe {
-                    p.deref_mut_data().memory.copy_out(
+                    p.memory.copy_out(
                         addr,
                         slice::from_raw_parts_mut(
                             &mut st as *mut Stat as *mut u8,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -6,7 +6,7 @@ use crate::{
     kernel::kernel,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
     pipe::AllocatedPipe,
-    proc::{Proc, ProcData},
+    proc::{CurrentProc, ProcData},
     spinlock::Spinlock,
     stat::Stat,
     vm::UVAddr,
@@ -87,7 +87,7 @@ impl File {
 
     /// Read from file self.
     /// addr is a user virtual address.
-    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &Proc) -> Result<usize, ()> {
+    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         if !self.readable {
             return Err(());
         }
@@ -114,7 +114,7 @@ impl File {
     }
     /// Write to file self.
     /// addr is a user virtual address.
-    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &Proc) -> Result<usize, ()> {
+    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         if !self.writable {
             return Err(());
         }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -67,7 +67,7 @@ impl File {
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
     pub unsafe fn stat(&self, addr: UVAddr) -> Result<(), ()> {
-        let mut p = unsafe { kernel().myexproc() };
+        let p = unsafe { kernel().myexproc() };
 
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -67,12 +67,12 @@ impl File {
 
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
-    pub unsafe fn stat(&self, addr: UVAddr, data: &mut ProcData) -> Result<(), ()> {
+    pub unsafe fn stat(&self, addr: UVAddr, proc_data: &mut ProcData) -> Result<(), ()> {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
                 unsafe {
-                    data.memory.copy_out(
+                    proc_data.memory.copy_out(
                         addr,
                         slice::from_raw_parts_mut(
                             &mut st as *mut Stat as *mut u8,

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -97,7 +97,7 @@ impl File {
             FileType::Inode { ip, off } => {
                 let mut ip = ip.deref().lock();
                 let curr_off = unsafe { *off.get() };
-                let ret = ip.read_user(addr, curr_off, n as u32);
+                let ret = ip.read_user(addr, curr_off, n as u32, proc);
                 if let Ok(v) = ret {
                     unsafe { *off.get() = curr_off.wrapping_add(v as u32) };
                 }
@@ -137,7 +137,13 @@ impl File {
                     let mut ip = ip.deref().lock();
                     let curr_off = unsafe { *off.get() };
                     let r = ip
-                        .write_user(addr + bytes_written, curr_off, bytes_to_write as u32, &tx)
+                        .write_user(
+                            addr + bytes_written,
+                            curr_off,
+                            bytes_to_write as u32,
+                            proc,
+                            &tx,
+                        )
                         .map(|v| {
                             unsafe { *off.get() = curr_off.wrapping_add(v as u32) };
                             v

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -420,10 +420,10 @@ impl InodeGuard<'_> {
         dst: UVAddr,
         off: u32,
         n: u32,
-        data: &mut ProcData,
+        proc_data: &mut ProcData,
     ) -> Result<usize, ()> {
         self.read_internal(off, n, |off, src| {
-            data.memory.copy_out(dst + off as usize, src)
+            proc_data.memory.copy_out(dst + off as usize, src)
         })
     }
 
@@ -518,13 +518,13 @@ impl InodeGuard<'_> {
         src: UVAddr,
         off: u32,
         n: u32,
-        data: &mut ProcData,
+        proc_data: &mut ProcData,
         tx: &FsTransaction<'_>,
     ) -> Result<usize, ()> {
         self.write_internal(
             off,
             n,
-            |off, dst| data.memory.copy_in(dst, src + off as usize),
+            |off, dst| proc_data.memory.copy_in(dst, src + off as usize),
             tx,
         )
     }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -418,6 +418,7 @@ impl InodeGuard<'_> {
         self.read_internal(off, n, |off, src| {
             kernel()
                 .current_proc()
+                .expect("No current proc")
                 .memory
                 .copy_out(dst + off as usize, src)
         })
@@ -522,6 +523,7 @@ impl InodeGuard<'_> {
             |off, dst| {
                 kernel()
                     .current_proc()
+                    .expect("No current proc")
                     .memory
                     .copy_in(dst, src + off as usize)
             },

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -416,7 +416,8 @@ impl InodeGuard<'_> {
     /// accessing an invalid virtual address.
     pub fn read_user(&mut self, dst: UVAddr, off: u32, n: u32) -> Result<usize, ()> {
         self.read_internal(off, n, |off, src| {
-            kernel().current_proc()
+            kernel()
+                .current_proc()
                 .memory
                 .copy_out(dst + off as usize, src)
         })
@@ -519,7 +520,8 @@ impl InodeGuard<'_> {
             off,
             n,
             |off, dst| {
-                kernel().current_proc()
+                kernel()
+                    .current_proc()
                     .memory
                     .copy_in(dst, src + off as usize)
             },

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -77,7 +77,6 @@ use crate::{
     fs::FsTransaction,
     kernel::kernel,
     param::{BSIZE, NINODE},
-    proc::myproc,
     sleeplock::Sleeplock,
     spinlock::Spinlock,
     stat::Stat,
@@ -417,7 +416,7 @@ impl InodeGuard<'_> {
     /// accessing an invalid virtual address.
     pub fn read_user(&mut self, dst: UVAddr, off: u32, n: u32) -> Result<usize, ()> {
         self.read_internal(off, n, |off, src| {
-            unsafe { &mut *(*myproc()).data.get() }
+            kernel().current_proc()
                 .memory
                 .copy_out(dst + off as usize, src)
         })
@@ -520,7 +519,7 @@ impl InodeGuard<'_> {
             off,
             n,
             |off, dst| {
-                unsafe { &mut *(*myproc()).data.get() }
+                kernel().current_proc()
                     .memory
                     .copy_in(dst, src + off as usize)
             },

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -1,7 +1,7 @@
 use core::cmp;
 use cstr_core::CStr;
 
-use crate::{kernel::kernel, param::ROOTDEV, proc::ProcData};
+use crate::{kernel::kernel, param::ROOTDEV, proc::CurrentProc};
 
 use super::{InodeType, RcInode, DIRSIZ, ROOTINO};
 
@@ -66,12 +66,12 @@ impl Path {
         kernel().itable.get_inode(ROOTDEV, ROOTINO)
     }
 
-    pub fn namei(&self, proc_data: &ProcData) -> Result<RcInode<'static>, ()> {
-        Ok(self.namex(false, proc_data)?.0)
+    pub fn namei(&self, proc: &CurrentProc<'_>) -> Result<RcInode<'static>, ()> {
+        Ok(self.namex(false, proc)?.0)
     }
 
-    pub fn nameiparent(&self, proc_data: &ProcData) -> Result<(RcInode<'static>, &FileName), ()> {
-        let (ip, name_in_path) = self.namex(true, proc_data)?;
+    pub fn nameiparent(&self, proc: &CurrentProc<'_>) -> Result<(RcInode<'static>, &FileName), ()> {
+        let (ip, name_in_path) = self.namex(true, proc)?;
         let name_in_path = name_in_path.ok_or(())?;
         Ok((ip, name_in_path))
     }
@@ -143,12 +143,12 @@ impl Path {
     fn namex(
         &self,
         parent: bool,
-        proc_data: &ProcData,
+        proc: &CurrentProc<'_>,
     ) -> Result<(RcInode<'static>, Option<&FileName>), ()> {
         let mut ptr = if self.is_absolute() {
             Self::root()
         } else {
-            proc_data.cwd.clone().unwrap()
+            proc.cwd.clone().unwrap()
         };
 
         let mut path = self;

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -1,7 +1,7 @@
 use core::cmp;
 use cstr_core::CStr;
 
-use crate::{kernel::kernel, param::ROOTDEV, proc::ExecutingProc};
+use crate::{kernel::kernel, param::ROOTDEV, proc::CurrentProc};
 
 use super::{InodeType, RcInode, DIRSIZ, ROOTINO};
 
@@ -66,11 +66,11 @@ impl Path {
         kernel().itable.get_inode(ROOTDEV, ROOTINO)
     }
 
-    pub fn namei(&self, proc: &ExecutingProc) -> Result<RcInode<'static>, ()> {
+    pub fn namei(&self, proc: &CurrentProc) -> Result<RcInode<'static>, ()> {
         Ok(self.namex(false, proc)?.0)
     }
 
-    pub fn nameiparent(&self, proc: &ExecutingProc) -> Result<(RcInode<'static>, &FileName), ()> {
+    pub fn nameiparent(&self, proc: &CurrentProc) -> Result<(RcInode<'static>, &FileName), ()> {
         let (ip, name_in_path) = self.namex(true, proc)?;
         let name_in_path = name_in_path.ok_or(())?;
         Ok((ip, name_in_path))
@@ -143,7 +143,7 @@ impl Path {
     fn namex(
         &self,
         parent: bool,
-        proc: &ExecutingProc,
+        proc: &CurrentProc,
     ) -> Result<(RcInode<'static>, Option<&FileName>), ()> {
         let mut ptr = if self.is_absolute() {
             Self::root()

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -148,7 +148,7 @@ impl Path {
         let mut ptr = if self.is_absolute() {
             Self::root()
         } else {
-            proc.deref_data().cwd.clone().unwrap()
+            proc.cwd.clone().unwrap()
         };
 
         let mut path = self;

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -66,12 +66,12 @@ impl Path {
         kernel().itable.get_inode(ROOTDEV, ROOTINO)
     }
 
-    pub fn namei(&self, data: &ProcData) -> Result<RcInode<'static>, ()> {
-        Ok(self.namex(false, data)?.0)
+    pub fn namei(&self, proc_data: &ProcData) -> Result<RcInode<'static>, ()> {
+        Ok(self.namex(false, proc_data)?.0)
     }
 
-    pub fn nameiparent(&self, data: &ProcData) -> Result<(RcInode<'static>, &FileName), ()> {
-        let (ip, name_in_path) = self.namex(true, data)?;
+    pub fn nameiparent(&self, proc_data: &ProcData) -> Result<(RcInode<'static>, &FileName), ()> {
+        let (ip, name_in_path) = self.namex(true, proc_data)?;
         let name_in_path = name_in_path.ok_or(())?;
         Ok((ip, name_in_path))
     }
@@ -143,12 +143,12 @@ impl Path {
     fn namex(
         &self,
         parent: bool,
-        data: &ProcData,
+        proc_data: &ProcData,
     ) -> Result<(RcInode<'static>, Option<&FileName>), ()> {
         let mut ptr = if self.is_absolute() {
             Self::root()
         } else {
-            data.cwd.clone().unwrap()
+            proc_data.cwd.clone().unwrap()
         };
 
         let mut path = self;

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -1,7 +1,7 @@
 use core::cmp;
 use cstr_core::CStr;
 
-use crate::{kernel::kernel, param::ROOTDEV, proc::CurrentProc};
+use crate::{kernel::kernel, param::ROOTDEV, proc::ProcData};
 
 use super::{InodeType, RcInode, DIRSIZ, ROOTINO};
 
@@ -66,12 +66,12 @@ impl Path {
         kernel().itable.get_inode(ROOTDEV, ROOTINO)
     }
 
-    pub fn namei(&self, proc: &CurrentProc) -> Result<RcInode<'static>, ()> {
-        Ok(self.namex(false, proc)?.0)
+    pub fn namei(&self, data: &ProcData) -> Result<RcInode<'static>, ()> {
+        Ok(self.namex(false, data)?.0)
     }
 
-    pub fn nameiparent(&self, proc: &CurrentProc) -> Result<(RcInode<'static>, &FileName), ()> {
-        let (ip, name_in_path) = self.namex(true, proc)?;
+    pub fn nameiparent(&self, data: &ProcData) -> Result<(RcInode<'static>, &FileName), ()> {
+        let (ip, name_in_path) = self.namex(true, data)?;
         let name_in_path = name_in_path.ok_or(())?;
         Ok((ip, name_in_path))
     }
@@ -143,12 +143,12 @@ impl Path {
     fn namex(
         &self,
         parent: bool,
-        proc: &CurrentProc,
+        data: &ProcData,
     ) -> Result<(RcInode<'static>, Option<&FileName>), ()> {
         let mut ptr = if self.is_absolute() {
             Self::root()
         } else {
-            proc.cwd.clone().unwrap()
+            data.cwd.clone().unwrap()
         };
 
         let mut path = self;

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -1,7 +1,7 @@
 use core::cmp;
 use cstr_core::CStr;
 
-use crate::{kernel::kernel, param::ROOTDEV, proc::myproc};
+use crate::{kernel::kernel, param::ROOTDEV};
 
 use super::{InodeType, RcInode, DIRSIZ, ROOTINO};
 
@@ -146,7 +146,7 @@ impl Path {
         } else {
             // TODO(https://github.com/kaist-cp/rv6/issues/354)
             // Accessing proc.data should be safe after refactoring myproc()
-            unsafe { (*(*myproc()).data.get()).cwd.clone().unwrap() }
+            unsafe { kernel().myexproc().deref_data().cwd.clone().unwrap() }
         };
 
         let mut path = self;

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -35,6 +35,7 @@ pub fn kernel() -> &'static Kernel {
 ///
 /// The `Kernel` never moves `_bcache_inner` and the outside can only obtain
 /// a pinned mutable reference to it.
+/// `CurrentProc`'s existence is only valid while it's `inner` is stored in `cpus`'s `Cpu`.
 pub struct Kernel {
     panicked: AtomicBool,
 

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -36,7 +36,7 @@ pub fn kernel() -> &'static Kernel {
 /// The `Kernel` never moves `_bcache_inner` and the outside can only obtain
 /// a pinned mutable reference to it.
 /// If the `Cpu` executing the code has a non-null `Proc` pointer,
-/// the `Proc` pointer in `CurrentProc` is always valid while the `Kernel` is alive.
+/// the `Proc` in `CurrentProc` is always valid while the `Kernel` is alive.
 pub struct Kernel {
     panicked: AtomicBool,
 

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -35,7 +35,8 @@ pub fn kernel() -> &'static Kernel {
 ///
 /// The `Kernel` never moves `_bcache_inner` and the outside can only obtain
 /// a pinned mutable reference to it.
-/// `CurrentProc`'s existence is only valid while it's `inner` is stored in `cpus`'s `Cpu`.
+/// If the `Cpu` executing the code has a non-null `Proc` pointer,
+/// the `Proc` pointer in `CurrentProc` is always valid while the `Kernel` is alive.
 pub struct Kernel {
     panicked: AtomicBool,
 

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -2,7 +2,7 @@ use crate::{
     file::{FileType, RcFile},
     kernel::kernel,
     page::Page,
-    proc::{CurrentProc, WaitChannel},
+    proc::{Proc, WaitChannel},
     riscv::PGSIZE,
     spinlock::Spinlock,
     vm::UVAddr,
@@ -43,7 +43,7 @@ impl Pipe {
     /// If successfully read i > 0 bytes, wakeups the `write_waitchannel` and returns `Ok(i: usize)`.
     /// If the pipe was empty, sleeps at `read_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn read(&self, addr: UVAddr, n: usize, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub fn read(&self, addr: UVAddr, n: usize, proc: &mut Proc) -> Result<usize, ()> {
         let mut inner = self.inner.lock();
         loop {
             match inner.try_read(addr, n, proc) {
@@ -67,7 +67,7 @@ impl Pipe {
     /// Note that we may have i < `n` if an copy-in error happened.
     /// If the pipe was full, sleeps at `write_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn write(&self, addr: UVAddr, n: usize, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub fn write(&self, addr: UVAddr, n: usize, proc: &mut Proc) -> Result<usize, ()> {
         let mut written = 0;
         let mut inner = self.inner.lock();
         loop {
@@ -194,12 +194,7 @@ impl PipeInner {
     /// If the process was killed, returns `Err(InvalidStatus)`.
     /// If an copy-in error happened after successfully writing i >= 0 bytes, returns `Err(InvalidCopyIn(i))`.
     /// Otherwise, returns `Ok(i)` after successfully writing i >= 0 bytes.    
-    fn try_write(
-        &mut self,
-        addr: UVAddr,
-        n: usize,
-        proc: &mut CurrentProc,
-    ) -> Result<usize, PipeError> {
+    fn try_write(&mut self, addr: UVAddr, n: usize, proc: &mut Proc) -> Result<usize, PipeError> {
         let mut ch = [0u8];
         if !self.readopen || proc.killed() {
             return Err(PipeError::InvalidStatus);
@@ -222,12 +217,7 @@ impl PipeInner {
     /// If successful read i > 0 bytes, returns `Ok(i: usize)`.
     /// If the pipe was empty, returns `Err(WaitForIO)`.
     /// If the process was killed, returns `Err(InvalidStatus)`.
-    fn try_read(
-        &mut self,
-        addr: UVAddr,
-        n: usize,
-        proc: &mut CurrentProc,
-    ) -> Result<usize, PipeError> {
+    fn try_read(&mut self, addr: UVAddr, n: usize, proc: &mut Proc) -> Result<usize, PipeError> {
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {
             if proc.killed() {

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -199,7 +199,7 @@ impl PipeInner {
         if !self.readopen || unsafe { kernel().myexproc().killed() } {
             return Err(PipeError::InvalidStatus);
         }
-        let proc = unsafe { kernel().myexproc() };
+        let mut proc = unsafe { kernel().myexproc() };
         let data = proc.deref_mut_data();
         for i in 0..n {
             if self.nwrite == self.nread.wrapping_add(PIPESIZE as u32) {
@@ -228,7 +228,7 @@ impl PipeInner {
             return Err(PipeError::WaitForIO);
         }
 
-        let proc = unsafe { kernel().myexproc() };
+        let mut proc = unsafe { kernel().myexproc() };
         let data = proc.deref_mut_data();
 
         //DOC: piperead-copy

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -204,13 +204,12 @@ impl PipeInner {
         if !self.readopen || proc.killed() {
             return Err(PipeError::InvalidStatus);
         }
-        let data = proc.deref_mut_data();
         for i in 0..n {
             if self.nwrite == self.nread.wrapping_add(PIPESIZE as u32) {
                 //DOC: pipewrite-full
                 return Ok(i);
             }
-            if data.memory.copy_in(&mut ch, addr + i).is_err() {
+            if proc.memory.copy_in(&mut ch, addr + i).is_err() {
                 return Err(PipeError::InvalidCopyin(i));
             }
             self.data[self.nwrite as usize % PIPESIZE] = ch[0];
@@ -237,8 +236,6 @@ impl PipeInner {
             return Err(PipeError::WaitForIO);
         }
 
-        let data = proc.deref_mut_data();
-
         //DOC: piperead-copy
         for i in 0..n {
             if self.nread == self.nwrite {
@@ -246,7 +243,7 @@ impl PipeInner {
             }
             let ch = [self.data[self.nread as usize % PIPESIZE]];
             self.nread = self.nread.wrapping_add(1);
-            if data.memory.copy_out(addr + i, &ch).is_err() {
+            if proc.memory.copy_out(addr + i, &ch).is_err() {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -199,7 +199,7 @@ impl PipeInner {
         if !self.readopen || unsafe { kernel().myexproc().killed() } {
             return Err(PipeError::InvalidStatus);
         }
-        let mut proc = unsafe { kernel().myexproc() };
+        let proc = unsafe { kernel().myexproc() };
         let data = proc.deref_mut_data();
         for i in 0..n {
             if self.nwrite == self.nread.wrapping_add(PIPESIZE as u32) {
@@ -228,7 +228,7 @@ impl PipeInner {
             return Err(PipeError::WaitForIO);
         }
 
-        let mut proc = unsafe { kernel().myexproc() };
+        let proc = unsafe { kernel().myexproc() };
         let data = proc.deref_mut_data();
 
         //DOC: piperead-copy

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -2,7 +2,7 @@ use crate::{
     file::{FileType, RcFile},
     kernel::kernel,
     page::Page,
-    proc::{ExecutingProc, WaitChannel},
+    proc::{CurrentProc, WaitChannel},
     riscv::PGSIZE,
     spinlock::Spinlock,
     vm::UVAddr,
@@ -43,7 +43,7 @@ impl Pipe {
     /// If successfully read i > 0 bytes, wakeups the `write_waitchannel` and returns `Ok(i: usize)`.
     /// If the pipe was empty, sleeps at `read_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn read(&self, addr: UVAddr, n: usize, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub fn read(&self, addr: UVAddr, n: usize, proc: &mut CurrentProc) -> Result<usize, ()> {
         let mut inner = self.inner.lock();
         loop {
             match inner.try_read(addr, n, proc) {
@@ -67,7 +67,7 @@ impl Pipe {
     /// Note that we may have i < `n` if an copy-in error happened.
     /// If the pipe was full, sleeps at `write_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn write(&self, addr: UVAddr, n: usize, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub fn write(&self, addr: UVAddr, n: usize, proc: &mut CurrentProc) -> Result<usize, ()> {
         let mut written = 0;
         let mut inner = self.inner.lock();
         loop {
@@ -198,7 +198,7 @@ impl PipeInner {
         &mut self,
         addr: UVAddr,
         n: usize,
-        proc: &mut ExecutingProc,
+        proc: &mut CurrentProc,
     ) -> Result<usize, PipeError> {
         let mut ch = [0u8];
         if !self.readopen || proc.killed() {
@@ -227,7 +227,7 @@ impl PipeInner {
         &mut self,
         addr: UVAddr,
         n: usize,
-        proc: &mut ExecutingProc,
+        proc: &mut CurrentProc,
     ) -> Result<usize, PipeError> {
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -201,7 +201,7 @@ impl PipeInner {
         proc: &mut ExecutingProc,
     ) -> Result<usize, PipeError> {
         let mut ch = [0u8];
-        if !self.readopen || proc.proc().killed() {
+        if !self.readopen || proc.killed() {
             return Err(PipeError::InvalidStatus);
         }
         let data = proc.deref_mut_data();
@@ -231,7 +231,7 @@ impl PipeInner {
     ) -> Result<usize, PipeError> {
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {
-            if proc.proc().killed() {
+            if proc.killed() {
                 return Err(PipeError::InvalidStatus);
             }
             return Err(PipeError::WaitForIO);

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -43,7 +43,7 @@ impl Pipe {
     /// If successfully read i > 0 bytes, wakeups the `write_waitchannel` and returns `Ok(i: usize)`.
     /// If the pipe was empty, sleeps at `read_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn read(&self, addr: UVAddr, n: usize, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub fn read(&self, addr: UVAddr, n: usize, proc: &mut ExecutingProc) -> Result<usize, ()> {
         let mut inner = self.inner.lock();
         loop {
             match inner.try_read(addr, n, proc) {
@@ -67,7 +67,7 @@ impl Pipe {
     /// Note that we may have i < `n` if an copy-in error happened.
     /// If the pipe was full, sleeps at `write_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn write(&self, addr: UVAddr, n: usize, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub fn write(&self, addr: UVAddr, n: usize, proc: &mut ExecutingProc) -> Result<usize, ()> {
         let mut written = 0;
         let mut inner = self.inner.lock();
         loop {
@@ -198,7 +198,7 @@ impl PipeInner {
         &mut self,
         addr: UVAddr,
         n: usize,
-        proc: &ExecutingProc,
+        proc: &mut ExecutingProc,
     ) -> Result<usize, PipeError> {
         let mut ch = [0u8];
         if !self.readopen || proc.proc().killed() {
@@ -227,7 +227,7 @@ impl PipeInner {
         &mut self,
         addr: UVAddr,
         n: usize,
-        proc: &ExecutingProc,
+        proc: &mut ExecutingProc,
     ) -> Result<usize, PipeError> {
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -2,7 +2,7 @@ use crate::{
     file::{FileType, RcFile},
     kernel::kernel,
     page::Page,
-    proc::{CurrentProc, Proc, WaitChannel},
+    proc::{CurrentProc, WaitChannel},
     riscv::PGSIZE,
     spinlock::Spinlock,
     vm::UVAddr,
@@ -194,7 +194,12 @@ impl PipeInner {
     /// If the process was killed, returns `Err(InvalidStatus)`.
     /// If an copy-in error happened after successfully writing i >= 0 bytes, returns `Err(InvalidCopyIn(i))`.
     /// Otherwise, returns `Ok(i)` after successfully writing i >= 0 bytes.    
-    fn try_write(&mut self, addr: UVAddr, n: usize, proc: &Proc) -> Result<usize, PipeError> {
+    fn try_write(
+        &mut self,
+        addr: UVAddr,
+        n: usize,
+        proc: &CurrentProc<'_>,
+    ) -> Result<usize, PipeError> {
         let mut ch = [0u8];
         if !self.readopen || proc.killed() {
             return Err(PipeError::InvalidStatus);
@@ -222,7 +227,12 @@ impl PipeInner {
     /// If successful read i > 0 bytes, returns `Ok(i: usize)`.
     /// If the pipe was empty, returns `Err(WaitForIO)`.
     /// If the process was killed, returns `Err(InvalidStatus)`.
-    fn try_read(&mut self, addr: UVAddr, n: usize, proc: &Proc) -> Result<usize, PipeError> {
+    fn try_read(
+        &mut self,
+        addr: UVAddr,
+        n: usize,
+        proc: &CurrentProc<'_>,
+    ) -> Result<usize, PipeError> {
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {
             if proc.killed() {

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -201,7 +201,7 @@ impl PipeInner {
         proc: &ExecutingProc,
     ) -> Result<usize, PipeError> {
         let mut ch = [0u8];
-        if !self.readopen || proc.killed() {
+        if !self.readopen || proc.proc().killed() {
             return Err(PipeError::InvalidStatus);
         }
         let data = proc.deref_mut_data();
@@ -231,7 +231,7 @@ impl PipeInner {
     ) -> Result<usize, PipeError> {
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {
-            if proc.killed() {
+            if proc.proc().killed() {
                 return Err(PipeError::InvalidStatus);
             }
             return Err(PipeError::WaitForIO);

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -848,7 +848,7 @@ impl ProcessSystem {
             }
 
             // No point waiting if we don't have any children.
-            if !havekids || unsafe{ (*ptr).killed() } {
+            if !havekids || unsafe { (*ptr).killed() } {
                 return Err(());
             }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -354,9 +354,9 @@ pub struct Proc {
 ///
 /// # Safety
 ///
-/// `ptr` is always not null pointer, and Proc's state is Procstate::RUNNING.
+/// `inner` is always not null pointer, and Proc's state is Procstate::RUNNING.
 pub struct CurrentProc<'p> {
-    ptr: *const Proc,
+    inner: *const Proc,
     _marker: PhantomData<&'p Proc>,
 }
 
@@ -366,13 +366,13 @@ impl CurrentProc<'_> {
     /// `ptr` must not be null pointer.
     unsafe fn from_raw(ptr: *const Proc) -> Self {
         CurrentProc {
-            ptr,
+            inner: ptr,
             _marker: PhantomData,
         }
     }
 
     fn raw(&self) -> *const Proc {
-        self.ptr
+        self.inner
     }
 }
 
@@ -380,7 +380,7 @@ impl Deref for CurrentProc<'_> {
     type Target = Proc;
     fn deref(&self) -> &Self::Target {
         // Safe since `ptr` always refers to `Proc`.
-        unsafe { &*self.ptr }
+        unsafe { &*self.inner }
     }
 }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -239,11 +239,7 @@ impl WaitChannel {
     /// Atomically release lock and sleep on waitchannel.
     /// Reacquires lock when awakened.
     pub fn sleep<T: Waitable>(&self, lk: &mut T) {
-        let p = unsafe {
-            // TODO(https://github.com/kaist-cp/rv6/issues/354, 258)
-            // Remove this unsafe part after resolving #258, #354
-            kernel().myexproc()
-        };
+        let p = kernel().myexproc();
 
         // Must acquire p->lock in order to
         // change p->state and then call sched.
@@ -939,8 +935,8 @@ pub fn cpuid() -> usize {
 }
 
 impl Kernel {
-    /// Return ExecutingProc. This is safe because we checked if current struct Proc* exists.
-    pub unsafe fn myexproc(&self) -> ExecutingProc {
+    /// Return ExecutingProc. This is safe because we checked if current struct Proc * exists.
+    pub fn myexproc(&self) -> ExecutingProc {
         let p = unsafe { self.myproc() };
         assert!(!p.is_null(), "myexproc: No current proc");
         unsafe { ExecutingProc::from_raw(p) }
@@ -1006,7 +1002,7 @@ pub unsafe fn proc_yield(p: &ExecutingProc) {
 /// A fork child's very first scheduling by scheduler()
 /// will swtch to forkret.
 unsafe fn forkret() {
-    let p = unsafe { &kernel().myexproc() };
+    let p = &kernel().myexproc();
     // Still holding p->lock from scheduler.
     unsafe { p.proc().info.unlock() };
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -941,7 +941,7 @@ pub fn cpuid() -> usize {
 impl Kernel {
     /// Return ExecutingProc. This is safe because we checked if current struct Proc* exists.
     pub unsafe fn myexproc(&self) -> ExecutingProc {
-        let p = unsafe{ self.myproc() };
+        let p = unsafe { self.myproc() };
         assert!(!p.is_null(), "myexproc: No current proc");
         unsafe { ExecutingProc::from_raw(p) }
     }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -9,9 +9,21 @@ use core::{
     sync::atomic::{AtomicBool, AtomicI32, Ordering},
 };
 
-use crate::{file::RcFile, fs::{Path, RcInode}, kernel::{Kernel, kernel}, memlayout::kstack, page::Page, param::{MAXPROCNAME, NOFILE, NPROC, ROOTDEV}, println, riscv::{intr_get, intr_on, r_tp, PGSIZE}, spinlock::{
+use crate::{
+    file::RcFile,
+    fs::{Path, RcInode},
+    kernel::{kernel, Kernel},
+    memlayout::kstack,
+    page::Page,
+    param::{MAXPROCNAME, NOFILE, NPROC, ROOTDEV},
+    println,
+    riscv::{intr_get, intr_on, r_tp, PGSIZE},
+    spinlock::{
         pop_off, push_off, RawSpinlock, Spinlock, SpinlockProtected, SpinlockProtectedGuard,
-    }, trap::usertrapret, vm::{UVAddr, UserMemory, VAddr}};
+    },
+    trap::usertrapret,
+    vm::{UVAddr, UserMemory, VAddr},
+};
 
 extern "C" {
     // swtch.S
@@ -350,11 +362,14 @@ pub struct ExecutingProc {
 
 impl ExecutingProc {
     const fn zero() -> Self {
-        ExecutingProc{ ptr: ptr::null_mut(), guard: false }
+        ExecutingProc {
+            ptr: ptr::null_mut(),
+            guard: false,
+        }
     }
 
     fn from_raw(ptr: *mut Proc) -> Self {
-        ExecutingProc{ ptr, guard: false }
+        ExecutingProc { ptr, guard: false }
     }
 
     pub fn deref_data(&self) -> &ProcData {
@@ -366,7 +381,7 @@ impl ExecutingProc {
     }
 
     pub fn killed(&self) -> bool {
-        unsafe{ (*self.ptr).killed.load(Ordering::Acquire) }
+        unsafe { (*self.ptr).killed.load(Ordering::Acquire) }
     }
 }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -398,12 +398,12 @@ struct ProcGuard {
 
 impl ProcGuard {
     fn deref_info(&self) -> &ProcInfo {
-        unsafe { (*self.ptr).info.get_mut_unchecked() }
+        unsafe { self.info.get_mut_unchecked() }
     }
 
     #[allow(clippy::mut_from_ref)]
     fn deref_mut_info(&self) -> &mut ProcInfo {
-        unsafe { (*self.ptr).info.get_mut_unchecked() }
+        unsafe { self.info.get_mut_unchecked() }
     }
 
     unsafe fn from_raw(ptr: *const Proc) -> Self {
@@ -456,7 +456,7 @@ impl ProcGuard {
 
             // Clear the process's parent field.
             if let Some(mut guard) = parent_guard {
-                *(*self).parent.assume_init_ref().get_mut(&mut guard) = ptr::null_mut();
+                *self.parent.assume_init_ref().get_mut(&mut guard) = ptr::null_mut();
             }
 
             // Clear the `ProcInfo`.
@@ -486,7 +486,7 @@ impl Drop for ProcGuard {
             if self.deref_info().state == Procstate::USED && self.memory.size() == 0 {
                 self.clear(None);
             }
-            (*self.ptr).info.unlock();
+            self.info.unlock();
         }
     }
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -355,8 +355,7 @@ pub struct Proc {
 
 /// Assumption: `ptr` is `executingproc`, and guard indicates ptr->info's spinlock is held.
 pub struct ExecutingProc {
-    // TODO: ptr is temporary pub because of pid() and kill()
-    pub ptr: *mut Proc,
+    ptr: *mut Proc,
 }
 
 impl ExecutingProc {
@@ -364,8 +363,8 @@ impl ExecutingProc {
         ExecutingProc { ptr }
     }
 
-    pub fn proc(&self) -> &Proc {
-        unsafe { &*self.ptr }
+    pub fn proc(&self) -> &mut Proc {
+        unsafe { &mut *self.ptr }
     }
 
     pub fn deref_data(&self) -> &ProcData {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -239,7 +239,7 @@ impl WaitChannel {
     /// Atomically release lock and sleep on waitchannel.
     /// Reacquires lock when awakened.
     pub fn sleep<T: Waitable>(&self, lk: &mut T) {
-        let p = kernel().myexproc();
+        let p = kernel().current_proc();
 
         // Must acquire p->lock in order to
         // change p->state and then call sched.
@@ -349,14 +349,14 @@ pub struct Proc {
     pub name: [u8; MAXPROCNAME],
 }
 
-/// Assumption: `ptr` is `executingproc`, and guard indicates ptr->info's spinlock is held.
-pub struct ExecutingProc {
+/// Assumption: `ptr` is `CurrentProc`, and guard indicates ptr->info's spinlock is held.
+pub struct CurrentProc {
     ptr: *mut Proc,
 }
 
-impl ExecutingProc {
+impl CurrentProc {
     unsafe fn from_raw(ptr: *mut Proc) -> Self {
-        ExecutingProc { ptr }
+        CurrentProc { ptr }
     }
 
     pub fn deref_data(&self) -> &ProcData {
@@ -372,7 +372,7 @@ impl ExecutingProc {
     }
 }
 
-impl Deref for ExecutingProc {
+impl Deref for CurrentProc {
     type Target = Proc;
     fn deref(&self) -> &Self::Target {
         // Safe since `ptr` always refers to `Proc`.
@@ -380,7 +380,7 @@ impl Deref for ExecutingProc {
     }
 }
 
-impl DerefMut for ExecutingProc {
+impl DerefMut for CurrentProc {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // Safe since `ptr` always refers to `Proc`.
         unsafe { &mut *self.ptr }
@@ -764,7 +764,7 @@ impl ProcessSystem {
     /// Create a new process, copying the parent.
     /// Sets up child kernel stack to return as if from fork() system call.
     /// Returns Ok(new process id) on success, Err(()) on error.
-    pub unsafe fn fork(&self, p: &mut ExecutingProc) -> Result<i32, ()> {
+    pub unsafe fn fork(&self, p: &mut CurrentProc) -> Result<i32, ()> {
         let pdata = p.deref_mut_data();
 
         // Allocate trap frame.
@@ -813,7 +813,7 @@ impl ProcessSystem {
 
     /// Wait for a child process to exit and return its pid.
     /// Return Err(()) if this process has no children.
-    pub unsafe fn wait(&self, addr: UVAddr, p: &mut ExecutingProc) -> Result<i32, ()> {
+    pub unsafe fn wait(&self, addr: UVAddr, p: &mut CurrentProc) -> Result<i32, ()> {
         let ptr = p.ptr;
         let data = p.deref_mut_data();
 
@@ -867,7 +867,7 @@ impl ProcessSystem {
     /// Exit the current process.  Does not return.
     /// An exited process remains in the zombie state
     /// until its parent calls wait().
-    pub unsafe fn exit_current(&self, status: i32, p: &mut ExecutingProc) -> ! {
+    pub unsafe fn exit_current(&self, status: i32, p: &mut CurrentProc) -> ! {
         assert_ne!(p.ptr, self.initial_proc, "init exiting");
         let data = p.deref_mut_data();
 
@@ -986,7 +986,7 @@ pub unsafe fn scheduler() -> ! {
 }
 
 /// Give up the CPU for one scheduling round.
-pub unsafe fn proc_yield(p: &mut ExecutingProc) {
+pub unsafe fn proc_yield(p: &mut CurrentProc) {
     let mut guard = p.lock();
     guard.deref_mut_info().state = Procstate::RUNNABLE;
     unsafe { guard.sched() };
@@ -995,7 +995,7 @@ pub unsafe fn proc_yield(p: &mut ExecutingProc) {
 /// A fork child's very first scheduling by scheduler()
 /// will swtch to forkret.
 unsafe fn forkret() {
-    let p = &mut kernel().myexproc();
+    let p = &mut kernel().current_proc();
     // Still holding p->lock from scheduler.
     unsafe { p.info.unlock() };
 
@@ -1008,11 +1008,11 @@ unsafe fn forkret() {
 }
 
 impl Kernel {
-    /// Return ExecutingProc. This is safe because we checked if current struct Proc * exists.
-    pub fn myexproc(&self) -> ExecutingProc {
+    /// Return CurrentProc. This is safe because we checked if current struct Proc * exists.
+    pub fn current_proc(&self) -> CurrentProc {
         let p = unsafe { self.myproc() };
-        assert!(!p.is_null(), "myexproc: No current proc");
-        unsafe { ExecutingProc::from_raw(p) }
+        assert!(!p.is_null(), "current_proc: No current proc");
+        unsafe { CurrentProc::from_raw(p) }
     }
 
     /// Return the current struct Proc *, or zero if none.

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -340,7 +340,7 @@ pub struct Proc {
 
     info: Spinlock<ProcInfo>,
 
-    pub data: UnsafeCell<ProcData>,
+    data: UnsafeCell<ProcData>,
 
     /// If true, the process have been killed.
     killed: AtomicBool,

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -472,7 +472,7 @@ impl ProcGuard {
     /// Wake process from sleep().
     fn wakeup(&self) {
         if self.deref_info().state == Procstate::SLEEPING {
-            self.deref_mut_info().state = Procstate::RUNNABLE
+            self.deref_mut_info().state = Procstate::RUNNABLE;
         }
     }
 }
@@ -1018,11 +1018,11 @@ unsafe fn forkret() {
 impl Kernel {
     /// Returns `Some<CurrentProc<'_>>` if current proc exists.
     /// If current proc is null, return `None`.
-    /// If `(*c).proc` is non-null, returned `CurrentProc` lives during self's lifetime.
+    /// If `(*c).proc` is non-null, returned `CurrentProc`'s `inner` lives during `&self`'s lifetime
     pub fn current_proc(&self) -> Option<CurrentProc<'_>> {
         unsafe { push_off() };
-        let c = self.mycpu();
-        let proc = unsafe { (*c).proc };
+        let cpu = self.mycpu();
+        let proc = unsafe { (*cpu).proc };
         unsafe { pop_off() };
         if proc.is_null() {
             return None;

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -771,7 +771,7 @@ impl ProcessSystem {
         // User stack pointer.
         data.trap_frame_mut().sp = PGSIZE;
         let name = b"initcode\x00";
-        (&mut (*guard).deref_mut_data().name[..name.len()]).copy_from_slice(name);
+        (&mut data.name[..name.len()]).copy_from_slice(name);
         data.cwd = Some(Path::root());
         guard.deref_mut_info().state = Procstate::RUNNABLE;
     }
@@ -792,7 +792,7 @@ impl ProcessSystem {
 
         // Allocate process.
         let np = unsafe { self.alloc(scopeguard::ScopeGuard::into_inner(trap_frame), memory) }?;
-        let mut npdata = np.deref_mut_data();
+        let npdata = np.deref_mut_data();
 
         // Copy saved user registers.
         *npdata.trap_frame_mut() = *proc.trap_frame();
@@ -808,7 +808,7 @@ impl ProcessSystem {
         }
         npdata.cwd = Some(proc.cwd.clone().unwrap());
 
-        np.deref_mut_data().name.copy_from_slice(&proc.name);
+        npdata.name.copy_from_slice(&proc.name);
 
         let pid = np.deref_mut_info().pid;
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -349,12 +349,19 @@ pub struct Proc {
     pub name: [u8; MAXPROCNAME],
 }
 
-/// Assumption: `ptr` is `CurrentProc`, and guard indicates ptr->info's spinlock is held.
+/// CurrentProc wraps mutable pointer of current CPU's proc.
+///
+/// # Safety
+///
+/// `ptr` is always not null pointer, and Proc's state is Procstate::RUNNING.
 pub struct CurrentProc {
     ptr: *mut Proc,
 }
 
 impl CurrentProc {
+    /// # Safety
+    ///
+    /// `ptr` must not be null pointer.
     unsafe fn from_raw(ptr: *mut Proc) -> Self {
         CurrentProc { ptr }
     }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -363,10 +363,6 @@ impl ExecutingProc {
         ExecutingProc { ptr }
     }
 
-    fn raw(&self) -> *const Proc {
-        self.ptr as *const Proc
-    }
-
     pub fn proc(&self) -> &mut Proc {
         unsafe { &mut *self.ptr }
     }
@@ -377,6 +373,10 @@ impl ExecutingProc {
 
     pub fn deref_mut_data(&self) -> &mut ProcData {
         unsafe { &mut *(*self.ptr).data.get() }
+    }
+
+    pub fn deref_data_raw(&self) -> *mut ProcData {
+        unsafe { (*self.ptr).data.get() }
     }
 }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -1012,7 +1012,7 @@ unsafe fn forkret() {
     // be run from main().
     kernel().file_system.init(ROOTDEV);
 
-    unsafe { usertrapret(proc.deref_mut_data()) };
+    unsafe { usertrapret(proc) };
 }
 
 impl Kernel {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -1029,7 +1029,7 @@ impl Kernel {
         if p.is_null() {
             return None;
         }
-        // This is safe wecause p is non-null.
+        // This is safe because p is non-null.
         Some(unsafe { CurrentProc::from_raw(p) })
     }
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -364,11 +364,15 @@ impl ExecutingProc {
         ExecutingProc { ptr }
     }
 
+    pub unsafe fn proc(&self) -> &Proc {
+        unsafe { &*self.ptr }
+    }
+
     pub fn deref_data(&self) -> &ProcData {
         unsafe { &*(*self.ptr).data.get() }
     }
 
-    pub fn deref_mut_data(&mut self) -> &mut ProcData {
+    pub fn deref_mut_data(&self) -> &mut ProcData {
         unsafe { &mut *(*self.ptr).data.get() }
     }
 
@@ -754,8 +758,8 @@ impl ProcessSystem {
     /// Create a new process, copying the parent.
     /// Sets up child kernel stack to return as if from fork() system call.
     /// Returns Ok(new process id) on success, Err(()) on error.
-    pub unsafe fn fork(&self) -> Result<i32, ()> {
-        let mut p = unsafe { kernel().myexproc() };
+    pub unsafe fn fork(&self, p: &ExecutingProc) -> Result<i32, ()> {
+        // let mut p = unsafe { kernel().myexproc() };
         let pdata = p.deref_mut_data();
 
         // Allocate trap frame.
@@ -805,7 +809,7 @@ impl ProcessSystem {
     /// Wait for a child process to exit and return its pid.
     /// Return Err(()) if this process has no children.
     pub unsafe fn wait(&self, addr: UVAddr) -> Result<i32, ()> {
-        let mut p = unsafe { kernel().myexproc() };
+        let p = unsafe { kernel().myexproc() };
         let ptr = p.ptr;
         let data = p.deref_mut_data();
 
@@ -859,8 +863,8 @@ impl ProcessSystem {
     /// Exit the current process.  Does not return.
     /// An exited process remains in the zombie state
     /// until its parent calls wait().
-    pub unsafe fn exit_current(&self, status: i32) -> ! {
-        let mut p = unsafe { kernel().myexproc() };
+    pub unsafe fn exit_current(&self, status: i32, p: &ExecutingProc) -> ! {
+        // let p = unsafe { kernel().myexproc() };
         assert_ne!(p.ptr, self.initial_proc, "init exiting");
         let data = p.deref_mut_data();
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -808,8 +808,7 @@ impl ProcessSystem {
 
     /// Wait for a child process to exit and return its pid.
     /// Return Err(()) if this process has no children.
-    pub unsafe fn wait(&self, addr: UVAddr) -> Result<i32, ()> {
-        let p = unsafe { kernel().myexproc() };
+    pub unsafe fn wait(&self, addr: UVAddr, p: &ExecutingProc) -> Result<i32, ()> {
         let ptr = p.ptr;
         let data = p.deref_mut_data();
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -360,11 +360,11 @@ pub struct ExecutingProc {
 }
 
 impl ExecutingProc {
-    fn from_raw(ptr: *mut Proc) -> Self {
+    unsafe fn from_raw(ptr: *mut Proc) -> Self {
         ExecutingProc { ptr }
     }
 
-    pub unsafe fn proc(&self) -> &Proc {
+    pub fn proc(&self) -> &Proc {
         unsafe { &*self.ptr }
     }
 
@@ -374,10 +374,6 @@ impl ExecutingProc {
 
     pub fn deref_mut_data(&self) -> &mut ProcData {
         unsafe { &mut *(*self.ptr).data.get() }
-    }
-
-    pub fn killed(&self) -> bool {
-        unsafe { (*self.ptr).killed.load(Ordering::Acquire) }
     }
 }
 
@@ -759,7 +755,6 @@ impl ProcessSystem {
     /// Sets up child kernel stack to return as if from fork() system call.
     /// Returns Ok(new process id) on success, Err(()) on error.
     pub unsafe fn fork(&self, p: &ExecutingProc) -> Result<i32, ()> {
-        // let mut p = unsafe { kernel().myexproc() };
         let pdata = p.deref_mut_data();
 
         // Allocate trap frame.
@@ -863,7 +858,6 @@ impl ProcessSystem {
     /// An exited process remains in the zombie state
     /// until its parent calls wait().
     pub unsafe fn exit_current(&self, status: i32, p: &ExecutingProc) -> ! {
-        // let p = unsafe { kernel().myexproc() };
         assert_ne!(p.ptr, self.initial_proc, "init exiting");
         let data = p.deref_mut_data();
 
@@ -958,7 +952,7 @@ impl Kernel {
         let p = unsafe { (*c).proc };
         assert!(!p.is_null(), "myexproc: No current proc");
         unsafe { pop_off() };
-        ExecutingProc::from_raw(p)
+        unsafe { ExecutingProc::from_raw(p) }
     }
 
     // /// Return the shared reference of current proc's data.

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -964,6 +964,16 @@ impl Kernel {
         unsafe { pop_off() };
         p
     }
+
+    /// Return the shared reference of current proc's data.
+    pub unsafe fn myexprocdata<'a>(&self) -> &'a mut ProcData {
+        unsafe { push_off() };
+        let c = self.mycpu();
+        assert!(!unsafe{(*c).proc.ptr}.is_null(), "myexproc: No current proc");
+        let p = unsafe { (*c).proc.deref_mut_data() };
+        unsafe { pop_off() };
+        p
+    }
 }
 
 /// A user program that calls exec("/init").

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -352,9 +352,7 @@ pub struct Proc {
 ///
 /// # Safety
 ///
-/// `inner` is always not null pointer.
 /// `inner` is current Cpu's proc, this means it's state is `RUNNING`.
-/// `Proc` lives during lifetime `'p`.
 pub struct CurrentProc<'p> {
     inner: &'p Proc,
     _marker: PhantomData<&'p Proc>,
@@ -363,10 +361,10 @@ pub struct CurrentProc<'p> {
 impl<'p> CurrentProc<'p> {
     /// # Safety
     ///
-    /// `ptr` must not be null pointer, and should be current Cpu's proc.
-    unsafe fn from_raw(ptr: &'p Proc) -> Self {
+    /// `proc` should be current `Cpu`'s `proc`.
+    unsafe fn from_raw(proc: &'p Proc) -> Self {
         CurrentProc {
-            inner: ptr,
+            inner: proc,
             _marker: PhantomData,
         }
     }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -1017,7 +1017,7 @@ impl Kernel {
     /// Returns `Some<CurrentProc<'_>>` if current proc exists.
     /// If current proc is null, return `None`.
     /// If `(*c).proc` is non-null, returned `CurrentProc`'s `inner` lives during `&self`'s lifetime
-    pub fn current_proc<'p>(&'p self) -> Option<CurrentProc<'p>> {
+    pub fn current_proc(&self) -> Option<CurrentProc<'_>> {
         unsafe { push_off() };
         let cpu = self.mycpu();
         let proc = unsafe { (*cpu).proc };

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -354,7 +354,7 @@ pub struct Proc {
 ///
 /// `inner` is always not null pointer.
 /// `inner` is current Cpu's proc, this means it's state is `RUNNING`.
-/// `Proc` lives during lifetime `'p`
+/// `Proc` lives during lifetime `'p`.
 pub struct CurrentProc<'p> {
     inner: *const Proc,
     _marker: PhantomData<&'p Proc>,
@@ -391,7 +391,7 @@ impl Deref for CurrentProc<'_> {
     }
 }
 
-/// Assumption: `ptr` is `CurrentProc.ptr`, and ptr->info's spinlock is held.
+/// Assumption: ptr->info's spinlock is held.
 struct ProcGuard {
     ptr: *const Proc,
 }
@@ -1016,9 +1016,9 @@ unsafe fn forkret() {
 }
 
 impl Kernel {
-    /// Return Some<CurrentProc<'_'>> if current proc exists.
-    /// If current proc is null, return None.
-    /// This is safe because we checked if current struct Proc * exists.
+    /// Returns `Some<CurrentProc<'_>>` if current proc exists.
+    /// If current proc is null, return `None`.
+    /// If `(*c).proc` is non-null, returned `CurrentProc` lives during self's lifetime.
     pub fn current_proc(&self) -> Option<CurrentProc<'_>> {
         unsafe { push_off() };
         let c = self.mycpu();

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -1020,7 +1020,9 @@ unsafe fn forkret() {
 }
 
 impl Kernel {
-    /// Return CurrentProc. This is safe because we checked if current struct Proc * exists.
+    /// Return Some<CurrentProc<'_'>> if current proc exists.
+    /// If current proc is null, return None.
+    /// This is safe because we checked if current struct Proc * exists.
     pub fn current_proc(&self) -> Option<CurrentProc<'_>> {
         unsafe { push_off() };
         let c = self.mycpu();

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -1029,6 +1029,7 @@ impl Kernel {
         if p.is_null() {
             return None;
         }
+        // This is safe wecause p is non-null.
         Some(unsafe { CurrentProc::from_raw(p) })
     }
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -934,24 +934,6 @@ pub fn cpuid() -> usize {
     unsafe { r_tp() }
 }
 
-impl Kernel {
-    /// Return ExecutingProc. This is safe because we checked if current struct Proc * exists.
-    pub fn myexproc(&self) -> ExecutingProc {
-        let p = unsafe { self.myproc() };
-        assert!(!p.is_null(), "myexproc: No current proc");
-        unsafe { ExecutingProc::from_raw(p) }
-    }
-
-    /// Return the current struct Proc *, or zero if none.
-    pub unsafe fn myproc(&self) -> *mut Proc {
-        unsafe { push_off() };
-        let c = self.mycpu();
-        let p = unsafe { (*c).proc };
-        unsafe { pop_off() };
-        p
-    }
-}
-
 /// A user program that calls exec("/init").
 /// od -t xC initcode
 const INITCODE: [u8; 52] = [
@@ -1012,4 +994,22 @@ unsafe fn forkret() {
     kernel().file_system.init(ROOTDEV);
 
     unsafe { usertrapret(p) };
+}
+
+impl Kernel {
+    /// Return ExecutingProc. This is safe because we checked if current struct Proc * exists.
+    pub fn myexproc(&self) -> ExecutingProc {
+        let p = unsafe { self.myproc() };
+        assert!(!p.is_null(), "myexproc: No current proc");
+        unsafe { ExecutingProc::from_raw(p) }
+    }
+
+    /// Return the current struct Proc *, or zero if none.
+    pub unsafe fn myproc(&self) -> *mut Proc {
+        unsafe { push_off() };
+        let c = self.mycpu();
+        let p = unsafe { (*c).proc };
+        unsafe { pop_off() };
+        p
+    }
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -353,17 +353,15 @@ pub struct Proc {
     pub name: [u8; MAXPROCNAME],
 }
 
-#[derive(Copy, Clone)]
 /// Assumption: `ptr` is `executingproc`, and guard indicates ptr->info's spinlock is held.
 pub struct ExecutingProc {
     // TODO: ptr is temporary pub because of pid() and kill()
     pub ptr: *mut Proc,
-    guard: bool,
 }
 
 impl ExecutingProc {
     fn from_raw(ptr: *mut Proc) -> Self {
-        ExecutingProc { ptr, guard: false }
+        ExecutingProc { ptr }
     }
 
     pub fn deref_data(&self) -> &ProcData {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -3,7 +3,6 @@
 use array_macro::array;
 use core::{
     cell::UnsafeCell,
-    marker::PhantomData,
     mem::{self, MaybeUninit},
     ops::Deref,
     ptr, slice, str,
@@ -355,18 +354,14 @@ pub struct Proc {
 /// `inner` is current Cpu's proc, this means it's state is `RUNNING`.
 pub struct CurrentProc<'p> {
     inner: &'p Proc,
-    _marker: PhantomData<&'p Proc>,
 }
 
 impl<'p> CurrentProc<'p> {
     /// # Safety
     ///
     /// `proc` should be current `Cpu`'s `proc`.
-    unsafe fn from_raw(proc: &'p Proc) -> Self {
-        CurrentProc {
-            inner: proc,
-            _marker: PhantomData,
-        }
+    unsafe fn new(proc: &'p Proc) -> Self {
+        CurrentProc { inner: proc }
     }
 
     fn raw(&self) -> *const Proc {
@@ -384,7 +379,6 @@ impl<'p> CurrentProc<'p> {
 impl Deref for CurrentProc<'_> {
     type Target = Proc;
     fn deref(&self) -> &Self::Target {
-        // Safe since `inner` always refers to `Proc`.
         self.inner
     }
 }
@@ -1026,6 +1020,6 @@ impl Kernel {
             return None;
         }
         // This is safe because p is non-null and current Cpu's proc.
-        Some(unsafe { CurrentProc::from_raw(&(*proc)) })
+        Some(unsafe { CurrentProc::new(&(*proc)) })
     }
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -368,6 +368,18 @@ impl ExecutingProc {
     fn from_raw(ptr: *mut Proc) -> Self {
         ExecutingProc{ ptr, guard: false }
     }
+
+    fn deref_data(&self) -> &ProcData {
+        unsafe { &*(*self.ptr).data.get() }
+    }
+
+    fn deref_mut_data(&mut self) -> &mut ProcData {
+        unsafe { &mut *(*self.ptr).data.get() }
+    }
+
+    pub fn killed(&self) -> bool {
+        unsafe{ (*self.ptr).killed.load(Ordering::Acquire) }
+    }
 }
 
 /// Assumption: `ptr` is `myproc()`, and ptr->info's spinlock is held.
@@ -937,6 +949,15 @@ pub unsafe fn myproc() -> *mut Proc {
     let p = unsafe { (*c).proc };
     unsafe { pop_off() };
     p.ptr
+}
+
+/// Return the current struct Proc *, or zero if none.
+pub unsafe fn myexproc<'a>() -> &'a mut ExecutingProc {
+    unsafe { push_off() };
+    let c = kernel().mycpu();
+    let p = unsafe { &mut (*c).proc };
+    unsafe { pop_off() };
+    p
 }
 
 /// A user program that calls exec("/init").

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -624,6 +624,7 @@ impl Proc {
         self.data.get()
     }
 
+    #[allow(clippy::mut_from_ref)]
     pub fn deref_mut_data(&self) -> &mut ProcData {
         // Safety: Only current proc uses ProcData.
         unsafe { &mut *self.data.get() }
@@ -730,9 +731,7 @@ impl ProcessSystem {
     /// Wake up all processes in the pool sleeping on waitchannel.
     /// Must be called without any p->lock.
     pub fn wakeup_pool(&self, target: &WaitChannel) {
-        let myproc = kernel()
-            .current_proc()
-            .map_or(ptr::null_mut() as *const Proc, |p| p.raw() as *const Proc);
+        let myproc = kernel().current_proc().map_or(ptr::null(), |p| p.raw());
         for p in &self.process_pool {
             if p as *const Proc != myproc {
                 let mut guard = p.lock();

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -1,6 +1,9 @@
 //! Sleepable locks
-use crate::proc::{WaitChannel, Waitable};
 use crate::spinlock::RawSpinlock;
+use crate::{
+    kernel::kernel,
+    proc::{WaitChannel, Waitable},
+};
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
@@ -72,7 +75,9 @@ impl<T: Unpin> Sleepablelock<T> {
 
 impl<T> SleepablelockGuard<'_, T> {
     pub fn sleep(&mut self) {
-        self.lock.waitchannel.sleep(self);
+        self.lock
+            .waitchannel
+            .sleep(self, &kernel().current_proc().expect("No current proc"));
     }
 
     pub fn wakeup(&self) {

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -28,7 +28,7 @@ impl RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
-        *guard = unsafe { kernel().myexproc().proc().pid() };
+        *guard = unsafe { kernel().myexproc().pid() };
     }
 
     pub fn release(&self) {
@@ -39,7 +39,7 @@ impl RawSleeplock {
 
     pub fn holding(&self) -> bool {
         let guard = self.locked.lock();
-        *guard == unsafe { kernel().myexproc().proc().pid() }
+        *guard == unsafe { kernel().myexproc().pid() }
     }
 }
 

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -28,7 +28,7 @@ impl RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
-        *guard = unsafe { kernel().myexproc().pid() };
+        *guard = unsafe { kernel().current_proc().pid() };
     }
 
     pub fn release(&self) {
@@ -39,7 +39,7 @@ impl RawSleeplock {
 
     pub fn holding(&self) -> bool {
         let guard = self.locked.lock();
-        *guard == unsafe { kernel().myexproc().pid() }
+        *guard == unsafe { kernel().current_proc().pid() }
     }
 }
 

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -1,5 +1,5 @@
 //! Sleeping locks
-use crate::proc::myproc;
+use crate::kernel::kernel;
 use crate::sleepablelock::Sleepablelock;
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
@@ -28,7 +28,7 @@ impl RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
-        *guard = unsafe { (*myproc()).pid() };
+        *guard = unsafe { kernel().myexproc().proc().pid() };
     }
 
     pub fn release(&self) {
@@ -39,7 +39,7 @@ impl RawSleeplock {
 
     pub fn holding(&self) -> bool {
         let guard = self.locked.lock();
-        *guard == unsafe { (*myproc()).pid() }
+        *guard == unsafe { kernel().myexproc().proc().pid() }
     }
 }
 

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -28,7 +28,7 @@ impl RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
-        *guard = unsafe { kernel().current_proc().pid() };
+        *guard = unsafe { kernel().current_proc().expect("No current proc").pid() };
     }
 
     pub fn release(&self) {
@@ -39,7 +39,7 @@ impl RawSleeplock {
 
     pub fn holding(&self) -> bool {
         let guard = self.locked.lock();
-        *guard == unsafe { kernel().current_proc().pid() }
+        *guard == unsafe { kernel().current_proc().expect("No current proc").pid() }
     }
 }
 

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -84,7 +84,7 @@ impl Kernel {
             8 => unsafe { self.sys_fstat(proc) },
             9 => unsafe { self.sys_chdir(proc) },
             10 => unsafe { self.sys_dup(proc) },
-            11 => unsafe { self.sys_getpid() },
+            11 => unsafe { self.sys_getpid(proc) },
             12 => self.sys_sbrk(proc),
             13 => self.sys_sleep(proc),
             14 => self.sys_uptime(),

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -1,7 +1,7 @@
 use crate::{
     kernel::Kernel,
     println,
-    proc::{myproc, ExecutingProc},
+    proc::ExecutingProc,
     vm::{UVAddr, VAddr},
 };
 use core::{mem, slice, str};
@@ -73,8 +73,6 @@ pub unsafe fn argstr<'a>(n: usize, buf: &mut [u8], p: &ExecutingProc) -> Result<
 
 impl Kernel {
     pub unsafe fn syscall(&'static self, num: i32, proc: &ExecutingProc) -> Result<usize, ()> {
-        let p = unsafe { myproc() };
-
         match num {
             1 => unsafe { self.sys_fork(proc) },
             2 => unsafe { self.sys_exit(proc) },
@@ -88,7 +86,7 @@ impl Kernel {
             10 => unsafe { self.sys_dup(proc) },
             11 => unsafe { self.sys_getpid() },
             12 => self.sys_sbrk(proc),
-            13 => unsafe { self.sys_sleep(proc) },
+            13 => self.sys_sleep(proc),
             14 => self.sys_uptime(),
             15 => unsafe { self.sys_open(proc) },
             16 => unsafe { self.sys_write(proc) },
@@ -101,8 +99,8 @@ impl Kernel {
             _ => {
                 println!(
                     "{} {}: unknown sys call {}",
-                    unsafe { (*p).pid() },
-                    str::from_utf8(unsafe { &(*p).name }).unwrap_or("???"),
+                    unsafe { proc.proc().pid() },
+                    str::from_utf8(&proc.proc().name).unwrap_or("???"),
                     num
                 );
                 Err(())

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -1,4 +1,9 @@
-use crate::{kernel::{Kernel, kernel}, println, proc::myproc, vm::{UVAddr, VAddr}};
+use crate::{
+    kernel::{kernel, Kernel},
+    println,
+    proc::myproc,
+    vm::{UVAddr, VAddr},
+};
 use core::{mem, slice, str};
 use cstr_core::CStr;
 
@@ -35,7 +40,7 @@ pub unsafe fn fetchstr(addr: UVAddr, buf: &mut [u8]) -> Result<&CStr, ()> {
 /// This will be safe function after we refactor myproc()
 unsafe fn argraw(n: usize) -> usize {
     let p = unsafe { kernel().myexproc() };
-    let data =p.deref_data();
+    let data = p.deref_data();
     match n {
         0 => data.trap_frame().a0,
         1 => data.trap_frame().a1,

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -9,7 +9,7 @@ use cstr_core::CStr;
 
 /// Fetch the usize at addr from the current process.
 /// Returns Ok(fetched integer) on success, Err(()) on error.
-pub unsafe fn fetchaddr(addr: UVAddr, p: &ExecutingProc) -> Result<usize, ()> {
+pub unsafe fn fetchaddr(addr: UVAddr, p: &mut ExecutingProc) -> Result<usize, ()> {
     let data = p.deref_mut_data();
     let mut ip = 0;
     if addr.into_usize() >= data.memory.size()
@@ -31,7 +31,7 @@ pub unsafe fn fetchaddr(addr: UVAddr, p: &ExecutingProc) -> Result<usize, ()> {
 pub unsafe fn fetchstr<'a>(
     addr: UVAddr,
     buf: &mut [u8],
-    p: &ExecutingProc,
+    p: &mut ExecutingProc,
 ) -> Result<&'a CStr, ()> {
     p.deref_mut_data().memory.copy_in_str(buf, addr)?;
 
@@ -66,13 +66,13 @@ pub fn argaddr(n: usize, p: &ExecutingProc) -> Result<usize, ()> {
 /// Fetch the nth word-sized system call argument as a null-terminated string.
 /// Copies into buf, at most max.
 /// Returns reference to the string in the buffer.
-pub unsafe fn argstr<'a>(n: usize, buf: &mut [u8], p: &ExecutingProc) -> Result<&'a CStr, ()> {
+pub unsafe fn argstr<'a>(n: usize, buf: &mut [u8], p: &mut ExecutingProc) -> Result<&'a CStr, ()> {
     let addr = argaddr(n, p)?;
     unsafe { fetchstr(UVAddr::new(addr), buf, p) }
 }
 
 impl Kernel {
-    pub unsafe fn syscall(&'static self, num: i32, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn syscall(&'static self, num: i32, proc: &mut ExecutingProc) -> Result<usize, ()> {
         match num {
             1 => unsafe { self.sys_fork(proc) },
             2 => unsafe { self.sys_exit(proc) },

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -9,8 +9,7 @@ use cstr_core::CStr;
 
 /// Fetch the usize at addr from the current process.
 /// Returns Ok(fetched integer) on success, Err(()) on error.
-pub unsafe fn fetchaddr(addr: UVAddr, p: &mut CurrentProc) -> Result<usize, ()> {
-    let data = p.deref_mut_data();
+pub unsafe fn fetchaddr(addr: UVAddr, data: &mut CurrentProc) -> Result<usize, ()> {
     let mut ip = 0;
     if addr.into_usize() >= data.memory.size()
         || addr.into_usize().wrapping_add(mem::size_of::<usize>()) > data.memory.size()
@@ -33,13 +32,12 @@ pub unsafe fn fetchstr<'a>(
     buf: &mut [u8],
     p: &mut CurrentProc,
 ) -> Result<&'a CStr, ()> {
-    p.deref_mut_data().memory.copy_in_str(buf, addr)?;
+    p.memory.copy_in_str(buf, addr)?;
 
     Ok(unsafe { CStr::from_ptr(buf.as_ptr()) })
 }
 
-fn argraw(n: usize, p: &CurrentProc) -> usize {
-    let data = p.deref_data();
+fn argraw(n: usize, data: &CurrentProc) -> usize {
     match n {
         0 => data.trap_frame().a0,
         1 => data.trap_frame().a1,

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -1,7 +1,7 @@
 use crate::{
     kernel::Kernel,
     println,
-    proc::ExecutingProc,
+    proc::CurrentProc,
     vm::{UVAddr, VAddr},
 };
 use core::{mem, slice, str};
@@ -9,7 +9,7 @@ use cstr_core::CStr;
 
 /// Fetch the usize at addr from the current process.
 /// Returns Ok(fetched integer) on success, Err(()) on error.
-pub unsafe fn fetchaddr(addr: UVAddr, p: &mut ExecutingProc) -> Result<usize, ()> {
+pub unsafe fn fetchaddr(addr: UVAddr, p: &mut CurrentProc) -> Result<usize, ()> {
     let data = p.deref_mut_data();
     let mut ip = 0;
     if addr.into_usize() >= data.memory.size()
@@ -31,14 +31,14 @@ pub unsafe fn fetchaddr(addr: UVAddr, p: &mut ExecutingProc) -> Result<usize, ()
 pub unsafe fn fetchstr<'a>(
     addr: UVAddr,
     buf: &mut [u8],
-    p: &mut ExecutingProc,
+    p: &mut CurrentProc,
 ) -> Result<&'a CStr, ()> {
     p.deref_mut_data().memory.copy_in_str(buf, addr)?;
 
     Ok(unsafe { CStr::from_ptr(buf.as_ptr()) })
 }
 
-fn argraw(n: usize, p: &ExecutingProc) -> usize {
+fn argraw(n: usize, p: &CurrentProc) -> usize {
     let data = p.deref_data();
     match n {
         0 => data.trap_frame().a0,
@@ -52,27 +52,27 @@ fn argraw(n: usize, p: &ExecutingProc) -> usize {
 }
 
 /// Fetch the nth 32-bit system call argument.
-pub fn argint(n: usize, p: &ExecutingProc) -> Result<i32, ()> {
+pub fn argint(n: usize, p: &CurrentProc) -> Result<i32, ()> {
     Ok(argraw(n, p) as i32)
 }
 
 /// Retrieve an argument as a pointer.
 /// Doesn't check for legality, since
 /// copyin/copyout will do that.
-pub fn argaddr(n: usize, p: &ExecutingProc) -> Result<usize, ()> {
+pub fn argaddr(n: usize, p: &CurrentProc) -> Result<usize, ()> {
     Ok(argraw(n, p))
 }
 
 /// Fetch the nth word-sized system call argument as a null-terminated string.
 /// Copies into buf, at most max.
 /// Returns reference to the string in the buffer.
-pub unsafe fn argstr<'a>(n: usize, buf: &mut [u8], p: &mut ExecutingProc) -> Result<&'a CStr, ()> {
+pub unsafe fn argstr<'a>(n: usize, buf: &mut [u8], p: &mut CurrentProc) -> Result<&'a CStr, ()> {
     let addr = argaddr(n, p)?;
     unsafe { fetchstr(UVAddr::new(addr), buf, p) }
 }
 
 impl Kernel {
-    pub unsafe fn syscall(&'static self, num: i32, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn syscall(&'static self, num: i32, proc: &mut CurrentProc) -> Result<usize, ()> {
         match num {
             1 => unsafe { self.sys_fork(proc) },
             2 => unsafe { self.sys_exit(proc) },

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -70,11 +70,7 @@ pub unsafe fn argstr<'a>(n: usize, buf: &'a mut [u8], data: &mut ProcData) -> Re
 }
 
 impl Kernel {
-    pub unsafe fn syscall(
-        &'static self,
-        num: i32,
-        proc: &mut CurrentProc<'_>,
-    ) -> Result<usize, ()> {
+    pub unsafe fn syscall(&'static self, num: i32, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         match num {
             1 => unsafe { self.sys_fork(proc) },
             2 => unsafe { self.sys_exit(proc) },

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -85,7 +85,7 @@ impl Kernel {
             11 => unsafe { self.sys_getpid(proc) },
             12 => self.sys_sbrk(proc),
             13 => self.sys_sleep(proc),
-            14 => self.sys_uptime(),
+            14 => self.sys_uptime(proc),
             15 => unsafe { self.sys_open(proc) },
             16 => unsafe { self.sys_write(proc) },
             17 => unsafe { self.sys_mknod(proc) },

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -29,7 +29,7 @@ pub unsafe fn fetchaddr(addr: UVAddr, data: &mut ProcData) -> Result<usize, ()> 
 /// Returns reference to the string in the buffer.
 pub unsafe fn fetchstr<'a>(
     addr: UVAddr,
-    buf: &mut [u8],
+    buf: &'a mut [u8],
     data: &mut ProcData,
 ) -> Result<&'a CStr, ()> {
     data.memory.copy_in_str(buf, addr)?;
@@ -64,13 +64,17 @@ pub fn argaddr(n: usize, data: &ProcData) -> Result<usize, ()> {
 /// Fetch the nth word-sized system call argument as a null-terminated string.
 /// Copies into buf, at most max.
 /// Returns reference to the string in the buffer.
-pub unsafe fn argstr<'a>(n: usize, buf: &mut [u8], data: &mut ProcData) -> Result<&'a CStr, ()> {
+pub unsafe fn argstr<'a>(n: usize, buf: &'a mut [u8], data: &mut ProcData) -> Result<&'a CStr, ()> {
     let addr = argaddr(n, data)?;
     unsafe { fetchstr(UVAddr::new(addr), buf, data) }
 }
 
 impl Kernel {
-    pub unsafe fn syscall(&'static self, num: i32, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub unsafe fn syscall(
+        &'static self,
+        num: i32,
+        proc: &mut CurrentProc<'_>,
+    ) -> Result<usize, ()> {
         match num {
             1 => unsafe { self.sys_fork(proc) },
             2 => unsafe { self.sys_exit(proc) },

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -99,8 +99,8 @@ impl Kernel {
             _ => {
                 println!(
                     "{} {}: unknown sys call {}",
-                    unsafe { proc.proc().pid() },
-                    str::from_utf8(&proc.proc().name).unwrap_or("???"),
+                    unsafe { proc.pid() },
+                    str::from_utf8(&proc.name).unwrap_or("???"),
                     num
                 );
                 Err(())

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -1,5 +1,5 @@
 use crate::{
-    kernel::{kernel, Kernel},
+    kernel::Kernel,
     println,
     proc::{myproc, ExecutingProc},
     vm::{UVAddr, VAddr},
@@ -9,8 +9,7 @@ use cstr_core::CStr;
 
 /// Fetch the usize at addr from the current process.
 /// Returns Ok(fetched integer) on success, Err(()) on error.
-pub unsafe fn fetchaddr(addr: UVAddr) -> Result<usize, ()> {
-    let p = unsafe { kernel().myexproc() };
+pub unsafe fn fetchaddr(addr: UVAddr, p: &ExecutingProc) -> Result<usize, ()> {
     let data = p.deref_mut_data();
     let mut ip = 0;
     if addr.into_usize() >= data.memory.size()
@@ -29,8 +28,11 @@ pub unsafe fn fetchaddr(addr: UVAddr) -> Result<usize, ()> {
 
 /// Fetch the nul-terminated string at addr from the current process.
 /// Returns reference to the string in the buffer.
-pub unsafe fn fetchstr(addr: UVAddr, buf: &mut [u8]) -> Result<&CStr, ()> {
-    let p = unsafe { kernel().myexproc() };
+pub unsafe fn fetchstr<'a>(
+    addr: UVAddr,
+    buf: &mut [u8],
+    p: &ExecutingProc,
+) -> Result<&'a CStr, ()> {
     p.deref_mut_data().memory.copy_in_str(buf, addr)?;
 
     Ok(unsafe { CStr::from_ptr(buf.as_ptr()) })
@@ -38,8 +40,7 @@ pub unsafe fn fetchstr(addr: UVAddr, buf: &mut [u8]) -> Result<&CStr, ()> {
 
 /// TODO(https://github.com/kaist-cp/rv6/issues/354)
 /// This will be safe function after we refactor myproc()
-unsafe fn argraw(n: usize) -> usize {
-    let p = unsafe { kernel().myexproc() };
+unsafe fn argraw(n: usize, p: &ExecutingProc) -> usize {
     let data = p.deref_data();
     match n {
         0 => data.trap_frame().a0,
@@ -53,23 +54,23 @@ unsafe fn argraw(n: usize) -> usize {
 }
 
 /// Fetch the nth 32-bit system call argument.
-pub unsafe fn argint(n: usize) -> Result<i32, ()> {
-    Ok(unsafe { argraw(n) } as i32)
+pub unsafe fn argint(n: usize, p: &ExecutingProc) -> Result<i32, ()> {
+    Ok(unsafe { argraw(n, p) } as i32)
 }
 
 /// Retrieve an argument as a pointer.
 /// Doesn't check for legality, since
 /// copyin/copyout will do that.
-pub unsafe fn argaddr(n: usize) -> Result<usize, ()> {
-    Ok(unsafe { argraw(n) })
+pub unsafe fn argaddr(n: usize, p: &ExecutingProc) -> Result<usize, ()> {
+    Ok(unsafe { argraw(n, p) })
 }
 
 /// Fetch the nth word-sized system call argument as a null-terminated string.
 /// Copies into buf, at most max.
 /// Returns reference to the string in the buffer.
-pub unsafe fn argstr(n: usize, buf: &mut [u8]) -> Result<&CStr, ()> {
-    let addr = unsafe { argaddr(n) }?;
-    unsafe { fetchstr(UVAddr::new(addr), buf) }
+pub unsafe fn argstr<'a>(n: usize, buf: &mut [u8], p: &ExecutingProc) -> Result<&'a CStr, ()> {
+    let addr = unsafe { argaddr(n, p) }?;
+    unsafe { fetchstr(UVAddr::new(addr), buf, p) }
 }
 
 impl Kernel {
@@ -79,26 +80,26 @@ impl Kernel {
         match num {
             1 => unsafe { self.sys_fork(proc) },
             2 => unsafe { self.sys_exit(proc) },
-            3 => unsafe { self.sys_wait() },
-            4 => unsafe { self.sys_pipe() },
-            5 => unsafe { self.sys_read() },
-            6 => unsafe { self.sys_kill() },
-            7 => unsafe { self.sys_exec() },
-            8 => unsafe { self.sys_fstat() },
-            9 => unsafe { self.sys_chdir() },
-            10 => unsafe { self.sys_dup() },
+            3 => unsafe { self.sys_wait(proc) },
+            4 => unsafe { self.sys_pipe(proc) },
+            5 => unsafe { self.sys_read(proc) },
+            6 => unsafe { self.sys_kill(proc) },
+            7 => unsafe { self.sys_exec(proc) },
+            8 => unsafe { self.sys_fstat(proc) },
+            9 => unsafe { self.sys_chdir(proc) },
+            10 => unsafe { self.sys_dup(proc) },
             11 => unsafe { self.sys_getpid() },
-            12 => unsafe { self.sys_sbrk() },
-            13 => unsafe { self.sys_sleep() },
+            12 => unsafe { self.sys_sbrk(proc) },
+            13 => unsafe { self.sys_sleep(proc) },
             14 => self.sys_uptime(),
-            15 => unsafe { self.sys_open() },
-            16 => unsafe { self.sys_write() },
-            17 => unsafe { self.sys_mknod() },
-            18 => unsafe { self.sys_unlink() },
-            19 => unsafe { self.sys_link() },
-            20 => unsafe { self.sys_mkdir() },
-            21 => unsafe { self.sys_close() },
-            22 => unsafe { self.sys_poweroff() },
+            15 => unsafe { self.sys_open(proc) },
+            16 => unsafe { self.sys_write(proc) },
+            17 => unsafe { self.sys_mknod(proc) },
+            18 => unsafe { self.sys_unlink(proc) },
+            19 => unsafe { self.sys_link(proc) },
+            20 => unsafe { self.sys_mkdir(proc) },
+            21 => unsafe { self.sys_close(proc) },
+            22 => unsafe { self.sys_poweroff(proc) },
             _ => {
                 println!(
                     "{} {}: unknown sys call {}",

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -29,7 +29,7 @@ impl RcFile<'static> {
     fn fdalloc(self) -> Result<i32, Self> {
         // TODO(https://github.com/kaist-cp/rv6/issues/354)
         // These two unsafe blocks need to be safe after we refactor myproc()
-        let mut p = unsafe { kernel().myexproc() };
+        let p = unsafe { kernel().myexproc() };
         let mut data = p.deref_mut_data();
         for fd in 0..NOFILE {
             // user pointer to struct stat
@@ -248,7 +248,7 @@ impl Kernel {
     fn chdir(&self, dirname: &CStr) -> Result<(), ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/354)
         // These two unsafe blocks need to be safe after we refactor myproc()
-        let mut p = unsafe { kernel().myexproc() };
+        let p = unsafe { kernel().myexproc() };
         let mut data = p.deref_mut_data();
         // TODO(https://github.com/kaist-cp/rv6/issues/290)
         // The method namei can drop inodes. If namei succeeds, its return
@@ -271,7 +271,7 @@ impl Kernel {
     fn pipe(&self, fdarray: UVAddr) -> Result<(), ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/354)
         // These two unsafe blocks need to be safe after we refactor myproc()
-        let mut p = unsafe { kernel().myexproc() };
+        let p = unsafe { kernel().myexproc() };
         let mut data = p.deref_mut_data();
         let (pipereader, pipewriter) = AllocatedPipe::alloc()?;
 

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -13,7 +13,7 @@ use crate::{
     page::Page,
     param::{MAXARG, MAXPATH, NDEV, NOFILE},
     pipe::AllocatedPipe,
-    proc::CurrentProc,
+    proc::{CurrentProc, Proc, ProcData},
     some_or,
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
     vm::{UVAddr, VAddr},
@@ -26,7 +26,7 @@ use cstr_core::CStr;
 impl RcFile<'static> {
     /// Allocate a file descriptor for the given file.
     /// Takes over file reference from caller on success.
-    fn fdalloc(self, data: &mut CurrentProc) -> Result<i32, Self> {
+    fn fdalloc(self, data: &mut ProcData) -> Result<i32, Self> {
         for fd in 0..NOFILE {
             // user pointer to struct stat
             if data.open_files[fd].is_none() {
@@ -40,7 +40,7 @@ impl RcFile<'static> {
 
 /// Fetch the nth word-sized system call argument as a file descriptor
 /// and return both the descriptor and the corresponding struct file.
-unsafe fn argfd(n: usize, proc: &CurrentProc) -> Result<(i32, &'static RcFile<'static>), ()> {
+unsafe fn argfd(n: usize, proc: &Proc) -> Result<(i32, &'static RcFile<'static>), ()> {
     let fd = argint(n, proc)?;
     if fd < 0 || fd >= NOFILE as i32 {
         return Err(());
@@ -60,13 +60,13 @@ fn create<F, T>(
     path: &Path,
     typ: InodeType,
     tx: &FsTransaction<'_>,
-    p: &CurrentProc,
+    data: &ProcData,
     f: F,
 ) -> Result<(RcInode<'static>, T), ()>
 where
     F: FnOnce(&mut InodeGuard<'_>) -> T,
 {
-    let (ptr, name) = path.nameiparent(p)?;
+    let (ptr, name) = path.nameiparent(data)?;
     let mut dp = ptr.lock();
     if let Ok((ptr2, _)) = dp.dirlookup(&name) {
         drop(dp);
@@ -110,9 +110,9 @@ where
 impl Kernel {
     /// Create another name(newname) for the file oldname.
     /// Returns Ok(()) on success, Err(()) on error.
-    fn link(&self, oldname: &CStr, newname: &CStr, p: &CurrentProc) -> Result<(), ()> {
+    fn link(&self, oldname: &CStr, newname: &CStr, data: &ProcData) -> Result<(), ()> {
         let tx = self.file_system.begin_transaction();
-        let ptr = Path::new(oldname).namei(p)?;
+        let ptr = Path::new(oldname).namei(data)?;
         let mut ip = ptr.lock();
         if ip.deref_inner().typ == InodeType::Dir {
             return Err(());
@@ -121,7 +121,7 @@ impl Kernel {
         ip.update(&tx);
         drop(ip);
 
-        if let Ok((ptr2, name)) = Path::new(newname).nameiparent(p) {
+        if let Ok((ptr2, name)) = Path::new(newname).nameiparent(data) {
             let mut dp = ptr2.lock();
             if dp.dev != ptr.dev || dp.dirlink(name, ptr.inum, &tx).is_err() {
             } else {
@@ -137,10 +137,10 @@ impl Kernel {
 
     /// Remove a file(filename).
     /// Returns Ok(()) on success, Err(()) on error.
-    fn unlink(&self, filename: &CStr, p: &CurrentProc) -> Result<(), ()> {
+    fn unlink(&self, filename: &CStr, data: &ProcData) -> Result<(), ()> {
         let de: Dirent = Default::default();
         let tx = self.file_system.begin_transaction();
-        let (ptr, name) = Path::new(filename).nameiparent(p)?;
+        let (ptr, name) = Path::new(filename).nameiparent(data)?;
         let mut dp = ptr.lock();
 
         // Cannot unlink "." or "..".
@@ -175,14 +175,14 @@ impl Kernel {
         &'static self,
         name: &Path,
         omode: FcntlFlags,
-        p: &mut CurrentProc,
+        data: &mut ProcData,
     ) -> Result<usize, ()> {
         let tx = self.file_system.begin_transaction();
 
         let (ip, typ) = if omode.contains(FcntlFlags::O_CREATE) {
-            create(name, InodeType::File, &tx, p, |ip| ip.deref_inner().typ)?
+            create(name, InodeType::File, &tx, data, |ip| ip.deref_inner().typ)?
         } else {
-            let ptr = name.namei(p)?;
+            let ptr = name.namei(data)?;
             let ip = ptr.lock();
             let typ = ip.deref_inner().typ;
 
@@ -219,27 +219,27 @@ impl Kernel {
                 _ => panic!("sys_open : Not reach"),
             };
         }
-        let fd = f.fdalloc(p).map_err(|_| ())?;
+        let fd = f.fdalloc(data).map_err(|_| ())?;
         Ok(fd as usize)
     }
 
     /// Create a new directory.
     /// Returns Ok(()) on success, Err(()) on error.
-    fn mkdir(&self, dirname: &CStr, p: &CurrentProc) -> Result<(), ()> {
+    fn mkdir(&self, dirname: &CStr, data: &ProcData) -> Result<(), ()> {
         let tx = self.file_system.begin_transaction();
-        create(Path::new(dirname), InodeType::Dir, &tx, p, |_| ())?;
+        create(Path::new(dirname), InodeType::Dir, &tx, data, |_| ())?;
         Ok(())
     }
 
     /// Create a device file.
     /// Returns Ok(()) on success, Err(()) on error.
-    fn mknod(&self, filename: &CStr, major: u16, minor: u16, p: &CurrentProc) -> Result<(), ()> {
+    fn mknod(&self, filename: &CStr, major: u16, minor: u16, data: &ProcData) -> Result<(), ()> {
         let tx = self.file_system.begin_transaction();
         create(
             Path::new(filename),
             InodeType::Device { major, minor },
             &tx,
-            p,
+            data,
             |_| (),
         )?;
         Ok(())
@@ -247,36 +247,36 @@ impl Kernel {
 
     /// Change the current directory.
     /// Returns Ok(()) on success, Err(()) on error.
-    fn chdir(&self, dirname: &CStr, p: &mut CurrentProc) -> Result<(), ()> {
+    fn chdir(&self, dirname: &CStr, data: &mut ProcData) -> Result<(), ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/290)
         // The method namei can drop inodes. If namei succeeds, its return
         // value, ptr, will be dropped when this method returns. Deallocation
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let _tx = self.file_system.begin_transaction();
-        let ptr = Path::new(dirname).namei(p)?;
+        let ptr = Path::new(dirname).namei(data)?;
         let ip = ptr.lock();
         if ip.deref_inner().typ != InodeType::Dir {
             return Err(());
         }
         drop(ip);
-        p.cwd = Some(ptr);
+        data.cwd = Some(ptr);
         Ok(())
     }
 
     /// Create a pipe, put read/write file descriptors in fd0 and fd1.
     /// Returns Ok(()) on success, Err(()) on error.
-    fn pipe(&self, fdarray: UVAddr, p: &mut CurrentProc) -> Result<(), ()> {
+    fn pipe(&self, fdarray: UVAddr, data: &mut ProcData) -> Result<(), ()> {
         let (pipereader, pipewriter) = AllocatedPipe::alloc()?;
 
-        let mut fd0 = pipereader.fdalloc(p).map_err(|_| ())?;
+        let mut fd0 = pipereader.fdalloc(data).map_err(|_| ())?;
         let mut fd1 = pipewriter
-            .fdalloc(p)
-            .map_err(|_| p.open_files[fd0 as usize] = None)?;
+            .fdalloc(data)
+            .map_err(|_| data.open_files[fd0 as usize] = None)?;
 
         // It is safe because fdarray, fd0 is valid.
         if unsafe {
-            p.memory.copy_out(
+            data.memory.copy_out(
                 fdarray,
                 slice::from_raw_parts_mut(&mut fd0 as *mut i32 as *mut u8, mem::size_of::<i32>()),
             )
@@ -284,7 +284,7 @@ impl Kernel {
         .is_err()
             // It is safe because fdarray, fd1 is valid.
             || unsafe {
-                p.memory.copy_out(
+                data.memory.copy_out(
                     UVAddr::new(fdarray.into_usize().wrapping_add(mem::size_of::<i32>())),
                     slice::from_raw_parts_mut(
                         &mut fd1 as *mut i32 as *mut u8,
@@ -294,8 +294,8 @@ impl Kernel {
             }
             .is_err()
         {
-            p.open_files[fd0 as usize] = None;
-            p.open_files[fd1 as usize] = None;
+            data.open_files[fd0 as usize] = None;
+            data.open_files[fd1 as usize] = None;
             return Err(());
         }
         Ok(())

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -29,8 +29,8 @@ impl RcFile<'static> {
     fn fdalloc(self) -> Result<i32, Self> {
         // TODO(https://github.com/kaist-cp/rv6/issues/354)
         // These two unsafe blocks need to be safe after we refactor myproc()
-        let p = unsafe { myproc() };
-        let mut data = unsafe { &mut *(*p).data.get() };
+        let p = unsafe { kernel().myexproc() };
+        let mut data = p.deref_mut_data();
         for fd in 0..NOFILE {
             // user pointer to struct stat
             if data.open_files[fd].is_none() {
@@ -247,8 +247,8 @@ impl Kernel {
     fn chdir(&self, dirname: &CStr) -> Result<(), ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/354)
         // These two unsafe blocks need to be safe after we refactor myproc()
-        let p = unsafe { myproc() };
-        let mut data = unsafe { &mut *(*p).data.get() };
+        let p = unsafe { kernel().myexproc() };
+        let mut data = p.deref_mut_data();
         // TODO(https://github.com/kaist-cp/rv6/issues/290)
         // The method namei can drop inodes. If namei succeeds, its return
         // value, ptr, will be dropped when this method returns. Deallocation
@@ -270,8 +270,8 @@ impl Kernel {
     fn pipe(&self, fdarray: UVAddr) -> Result<(), ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/354)
         // These two unsafe blocks need to be safe after we refactor myproc()
-        let p = unsafe { myproc() };
-        let mut data = unsafe { &mut *(*p).data.get() };
+        let p = unsafe { kernel().myexproc() };
+        let mut data = p.deref_mut_data();
         let (pipereader, pipewriter) = AllocatedPipe::alloc()?;
 
         let mut fd0 = pipereader.fdalloc().map_err(|_| ())?;

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -443,7 +443,7 @@ impl Kernel {
         }
 
         let ret = if success {
-            self.exec(Path::new(path), &args, proc)
+            self.exec(Path::new(path), &args, proc.deref_mut_data())
         } else {
             Err(())
         };

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -13,7 +13,7 @@ use crate::{
     page::Page,
     param::{MAXARG, MAXPATH, NDEV, NOFILE},
     pipe::AllocatedPipe,
-    proc::{myproc, ExecutingProc},
+    proc::ExecutingProc,
     some_or,
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
     vm::{UVAddr, VAddr},
@@ -47,9 +47,8 @@ unsafe fn argfd(n: usize, proc: &ExecutingProc) -> Result<(i32, &'static RcFile<
         return Err(());
     }
 
-    let p = unsafe { myproc() };
     let f = some_or!(
-        unsafe { &(*(*p).data.get()).open_files[fd as usize] },
+        unsafe { &(*proc.deref_data_raw()).open_files[fd as usize] },
         return Err(())
     );
 

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -315,7 +315,7 @@ impl Kernel {
         let (_, f) = unsafe { argfd(0, proc)? };
         let n = argint(2, proc)?;
         let p = argaddr(1, proc)?;
-        unsafe { f.read(UVAddr::new(p), n) }
+        unsafe { f.read(UVAddr::new(p), n, proc) }
     }
 
     /// Write n bytes from buf to given file descriptor fd.
@@ -324,7 +324,7 @@ impl Kernel {
         let (_, f) = unsafe { argfd(0, proc)? };
         let n = argint(2, proc)?;
         let p = argaddr(1, proc)?;
-        unsafe { f.write(UVAddr::new(p), n) }
+        unsafe { f.write(UVAddr::new(p), n, proc) }
     }
 
     /// Release open file fd.
@@ -341,7 +341,7 @@ impl Kernel {
         let (_, f) = unsafe { argfd(0, proc)? };
         // user pointer to struct stat
         let st = argaddr(1, proc)?;
-        unsafe { f.stat(UVAddr::new(st))? };
+        unsafe { f.stat(UVAddr::new(st), proc)? };
         Ok(0)
     }
 
@@ -434,7 +434,7 @@ impl Kernel {
         }
 
         let ret = if success {
-            self.exec(Path::new(path), &args)
+            self.exec(Path::new(path), &args, proc)
         } else {
             Err(())
         };

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -13,7 +13,6 @@ use crate::{
     page::Page,
     param::{MAXARG, MAXPATH, NDEV, NOFILE},
     pipe::AllocatedPipe,
-    proc::myproc,
     some_or,
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
     vm::{UVAddr, VAddr},
@@ -51,7 +50,7 @@ unsafe fn argfd(n: usize) -> Result<(i32, &'static RcFile<'static>), ()> {
     }
 
     let f = some_or!(
-        unsafe { &(*(*myproc()).data.get()).open_files[fd as usize] },
+        unsafe { &(kernel().myexproc().deref_mut_data().open_files[fd as usize]) },
         return Err(())
     );
 
@@ -341,7 +340,7 @@ impl Kernel {
         let (fd, _) = unsafe { argfd(0)? };
         // TODO(https://github.com/kaist-cp/rv6/issues/354)
         // This line should be safe after we refactor myporc()
-        unsafe { (*(*myproc()).data.get()).open_files[fd as usize] = None };
+        unsafe { kernel().myexproc().deref_mut_data().open_files[fd as usize] = None };
         Ok(0)
     }
 

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -42,7 +42,7 @@ impl RcFile<'static> {
 /// Fetch the nth word-sized system call argument as a file descriptor
 /// and return both the descriptor and the corresponding struct file.
 unsafe fn argfd(n: usize, proc: &ExecutingProc) -> Result<(i32, &'static RcFile<'static>), ()> {
-    let fd = unsafe { argint(n, proc)? };
+    let fd = argint(n, proc)?;
     if fd < 0 || fd >= NOFILE as i32 {
         return Err(());
     }
@@ -313,8 +313,8 @@ impl Kernel {
     /// Returns Ok(number read) on success, Err(()) on error.
     pub unsafe fn sys_read(&self, proc: &ExecutingProc) -> Result<usize, ()> {
         let (_, f) = unsafe { argfd(0, proc)? };
-        let n = unsafe { argint(2, proc)? };
-        let p = unsafe { argaddr(1, proc)? };
+        let n = argint(2, proc)?;
+        let p = argaddr(1, proc)?;
         unsafe { f.read(UVAddr::new(p), n) }
     }
 
@@ -322,8 +322,8 @@ impl Kernel {
     /// Returns Ok(n) on success, Err(()) on error.
     pub unsafe fn sys_write(&self, proc: &ExecutingProc) -> Result<usize, ()> {
         let (_, f) = unsafe { argfd(0, proc)? };
-        let n = unsafe { argint(2, proc)? };
-        let p = unsafe { argaddr(1, proc)? };
+        let n = argint(2, proc)?;
+        let p = argaddr(1, proc)?;
         unsafe { f.write(UVAddr::new(p), n) }
     }
 
@@ -340,7 +340,7 @@ impl Kernel {
     pub unsafe fn sys_fstat(&self, proc: &ExecutingProc) -> Result<usize, ()> {
         let (_, f) = unsafe { argfd(0, proc)? };
         // user pointer to struct stat
-        let st = unsafe { argaddr(1, proc)? };
+        let st = argaddr(1, proc)?;
         unsafe { f.stat(UVAddr::new(st))? };
         Ok(0)
     }
@@ -371,7 +371,7 @@ impl Kernel {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = unsafe { argstr(0, &mut path, proc)? };
         let path = Path::new(path);
-        let omode = unsafe { argint(1, proc)? };
+        let omode = argint(1, proc)?;
         let omode = FcntlFlags::from_bits_truncate(omode);
         self.open(path, omode, proc)
     }
@@ -390,8 +390,8 @@ impl Kernel {
     pub unsafe fn sys_mknod(&self, proc: &ExecutingProc) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = unsafe { argstr(0, &mut path, proc)? };
-        let major = unsafe { argint(1, proc)? } as u16;
-        let minor = unsafe { argint(2, proc)? } as u16;
+        let major = argint(1, proc)? as u16;
+        let minor = argint(2, proc)? as u16;
         self.mknod(path, major, minor)?;
         Ok(0)
     }
@@ -411,7 +411,7 @@ impl Kernel {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let mut args = ArrayVec::<[Page; MAXARG]>::new();
         let path = unsafe { argstr(0, &mut path, proc)? };
-        let uargv = unsafe { argaddr(1, proc)? };
+        let uargv = argaddr(1, proc)?;
 
         let mut success = false;
         for i in 0..MAXARG {
@@ -448,9 +448,9 @@ impl Kernel {
 
     /// Create a pipe.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub unsafe fn sys_pipe(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub fn sys_pipe(&self, proc: &ExecutingProc) -> Result<usize, ()> {
         // user pointer to array of two integers
-        let fdarray = UVAddr::new(unsafe { argaddr(0, proc)? });
+        let fdarray = UVAddr::new(argaddr(0, proc)?);
         self.pipe(fdarray, proc)?;
         Ok(0)
     }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,7 +1,7 @@
 use crate::{
     kernel::Kernel,
     poweroff,
-    proc::{myproc, ExecutingProc},
+    proc::ExecutingProc,
     syscall::{argaddr, argint},
     vm::{UVAddr, VAddr},
 };
@@ -14,8 +14,8 @@ impl Kernel {
     }
 
     /// Return the current process’s PID.
-    pub unsafe fn sys_getpid(&self) -> Result<usize, ()> {
-        Ok(unsafe { (*myproc()).pid() } as _)
+    pub unsafe fn sys_getpid(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        Ok(unsafe { proc.proc().pid() } as _)
     }
 
     /// Create a process.

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,4 +1,10 @@
-use crate::{kernel::{Kernel, kernel}, poweroff, proc::myproc, syscall::{argaddr, argint}, vm::{UVAddr, VAddr}};
+use crate::{
+    kernel::{kernel, Kernel},
+    poweroff,
+    proc::myproc,
+    syscall::{argaddr, argint},
+    vm::{UVAddr, VAddr},
+};
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -8,39 +8,39 @@ use crate::{
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
-    pub unsafe fn sys_exit(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub unsafe fn sys_exit(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         unsafe { self.procs.exit_current(n, proc) };
     }
 
     /// Return the current process’s PID.
-    pub unsafe fn sys_getpid(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub unsafe fn sys_getpid(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         Ok(unsafe { proc.pid() } as _)
     }
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_fork(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub unsafe fn sys_fork(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         Ok(unsafe { self.procs.fork(proc) }? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_wait(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub unsafe fn sys_wait(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let p = argaddr(0, proc)?;
         Ok(unsafe { self.procs.wait(UVAddr::new(p), proc) }? as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
-    pub fn sys_sbrk(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub fn sys_sbrk(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         proc.memory.resize(n)
     }
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_sleep(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
+    pub fn sys_sleep(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
@@ -55,7 +55,7 @@ impl Kernel {
 
     /// Terminate process PID.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_kill(&self, proc: &CurrentProc) -> Result<usize, ()> {
+    pub fn sys_kill(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         let pid = argint(0, proc)?;
         self.procs.kill(pid)?;
         Ok(0)
@@ -63,12 +63,12 @@ impl Kernel {
 
     /// Return how many clock tick interrupts have occurred
     /// since start.
-    pub fn sys_uptime(&self, _proc: &CurrentProc) -> Result<usize, ()> {
+    pub fn sys_uptime(&self, _proc: &CurrentProc<'_>) -> Result<usize, ()> {
         Ok(*self.ticks.lock() as usize)
     }
 
     /// Shutdowns this machine, discarding all unsaved data. No return.
-    pub fn sys_poweroff(&self, proc: &CurrentProc) -> Result<usize, ()> {
+    pub fn sys_poweroff(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         let exitcode = argint(0, proc)?;
         poweroff::machine_poweroff(exitcode as _);
     }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,4 +1,4 @@
-use crate::{kernel::Kernel, poweroff, proc::{myexproc, myproc}, syscall::{argaddr, argint}, vm::{UVAddr, VAddr}};
+use crate::{kernel::{Kernel, kernel}, poweroff, proc::myproc, syscall::{argaddr, argint}, vm::{UVAddr, VAddr}};
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
@@ -41,7 +41,7 @@ impl Kernel {
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
-            if unsafe { myexproc().killed() } {
+            if unsafe { kernel().myexproc().killed() } {
                 return Err(());
             }
             ticks.sleep();

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -8,39 +8,39 @@ use crate::{
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
-    pub unsafe fn sys_exit(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn sys_exit(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         unsafe { self.procs.exit_current(n, proc) };
     }
 
     /// Return the current process’s PID.
-    pub unsafe fn sys_getpid(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn sys_getpid(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         Ok(unsafe { proc.pid() } as _)
     }
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_fork(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn sys_fork(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         Ok(unsafe { self.procs.fork(proc) }? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_wait(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn sys_wait(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         let p = argaddr(0, proc)?;
         Ok(unsafe { self.procs.wait(UVAddr::new(p), proc) }? as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
-    pub fn sys_sbrk(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_sbrk(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
-        proc.memory.resize(n)
+        proc.deref_mut_data().memory.resize(n)
     }
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_sleep(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_sleep(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -35,8 +35,8 @@ impl Kernel {
     /// Returns Ok(start of new memory) on success, Err(()) on error.
     pub unsafe fn sys_sbrk(&self) -> Result<usize, ()> {
         let n = unsafe { argint(0) }?;
-
-        let data = unsafe{kernel().myexprocdata()};
+        let mut p = unsafe { kernel().myexproc() };
+        let data = p.deref_mut_data();
         data.memory.resize(n)
     }
 

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -8,32 +8,32 @@ use crate::{
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
-    pub unsafe fn sys_exit(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn sys_exit(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         unsafe { self.procs.exit_current(n, proc) };
     }
 
     /// Return the current process’s PID.
-    pub unsafe fn sys_getpid(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn sys_getpid(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
         Ok(unsafe { proc.proc().pid() } as _)
     }
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_fork(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn sys_fork(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
         Ok(unsafe { self.procs.fork(proc) }? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_wait(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn sys_wait(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
         let p = argaddr(0, proc)?;
         Ok(unsafe { self.procs.wait(UVAddr::new(p), proc) }? as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
-    pub fn sys_sbrk(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub fn sys_sbrk(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         let data = proc.deref_mut_data();
         data.memory.resize(n)
@@ -41,7 +41,7 @@ impl Kernel {
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_sleep(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub fn sys_sleep(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -35,8 +35,7 @@ impl Kernel {
     /// Returns Ok(start of new memory) on success, Err(()) on error.
     pub fn sys_sbrk(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
         let n = argint(0, proc)?;
-        let data = proc.deref_mut_data();
-        data.memory.resize(n)
+        proc.memory.resize(n)
     }
 
     /// Pause for n clock ticks.

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,10 +1,4 @@
-use crate::{
-    kernel::Kernel,
-    poweroff,
-    proc::myproc,
-    syscall::{argaddr, argint},
-    vm::{UVAddr, VAddr},
-};
+use crate::{kernel::Kernel, poweroff, proc::{myexproc, myproc}, syscall::{argaddr, argint}, vm::{UVAddr, VAddr}};
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
@@ -47,7 +41,7 @@ impl Kernel {
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
-            if unsafe { (*myproc()).killed() } {
+            if unsafe { myexproc().killed() } {
                 return Err(());
             }
             ticks.sleep();

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    kernel::{kernel, Kernel},
+    kernel::Kernel,
     poweroff,
     proc::{myproc, ExecutingProc},
     syscall::{argaddr, argint},
@@ -41,12 +41,12 @@ impl Kernel {
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub unsafe fn sys_sleep(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub fn sys_sleep(&self, proc: &ExecutingProc) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
-            if unsafe { kernel().myexproc().killed() } {
+            if proc.proc().killed() {
                 return Err(());
             }
             ticks.sleep();

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -35,8 +35,8 @@ impl Kernel {
     /// Returns Ok(start of new memory) on success, Err(()) on error.
     pub unsafe fn sys_sbrk(&self) -> Result<usize, ()> {
         let n = unsafe { argint(0) }?;
-        let p = unsafe { myproc() };
-        let data = unsafe { &mut *(*p).data.get() };
+
+        let data = unsafe{kernel().myexprocdata()};
         data.memory.resize(n)
     }
 

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -9,7 +9,7 @@ use crate::{
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
     pub unsafe fn sys_exit(&self, proc: &ExecutingProc) -> Result<usize, ()> {
-        let n = unsafe { argint(0, proc) }?;
+        let n = argint(0, proc)?;
         unsafe { self.procs.exit_current(n, proc) };
     }
 
@@ -27,14 +27,14 @@ impl Kernel {
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub unsafe fn sys_wait(&self, proc: &ExecutingProc) -> Result<usize, ()> {
-        let p = unsafe { argaddr(0, proc) }?;
+        let p = argaddr(0, proc)?;
         Ok(unsafe { self.procs.wait(UVAddr::new(p), proc) }? as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
-    pub unsafe fn sys_sbrk(&self, proc: &ExecutingProc) -> Result<usize, ()> {
-        let n = unsafe { argint(0, proc) }?;
+    pub fn sys_sbrk(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        let n = argint(0, proc)?;
         let data = proc.deref_mut_data();
         data.memory.resize(n)
     }
@@ -42,7 +42,7 @@ impl Kernel {
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
     pub unsafe fn sys_sleep(&self, proc: &ExecutingProc) -> Result<usize, ()> {
-        let n = unsafe { argint(0, proc) }?;
+        let n = argint(0, proc)?;
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
@@ -56,8 +56,8 @@ impl Kernel {
 
     /// Terminate process PID.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub unsafe fn sys_kill(&self, proc: &ExecutingProc) -> Result<usize, ()> {
-        let pid = unsafe { argint(0, proc) }?;
+    pub fn sys_kill(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        let pid = argint(0, proc)?;
         self.procs.kill(pid)?;
         Ok(0)
     }
@@ -69,8 +69,8 @@ impl Kernel {
     }
 
     /// Shutdowns this machine, discarding all unsaved data. No return.
-    pub unsafe fn sys_poweroff(&self, proc: &ExecutingProc) -> Result<usize, ()> {
-        let exitcode = unsafe { argint(0, proc) }?;
+    pub fn sys_poweroff(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        let exitcode = argint(0, proc)?;
         poweroff::machine_poweroff(exitcode as _);
     }
 }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -63,7 +63,7 @@ impl Kernel {
 
     /// Return how many clock tick interrupts have occurred
     /// since start.
-    pub fn sys_uptime(&self) -> Result<usize, ()> {
+    pub fn sys_uptime(&self, _proc: &CurrentProc) -> Result<usize, ()> {
         Ok(*self.ticks.lock() as usize)
     }
 

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -1,39 +1,39 @@
 use crate::{
     kernel::Kernel,
     poweroff,
-    proc::ExecutingProc,
+    proc::CurrentProc,
     syscall::{argaddr, argint},
     vm::{UVAddr, VAddr},
 };
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
-    pub unsafe fn sys_exit(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn sys_exit(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         unsafe { self.procs.exit_current(n, proc) };
     }
 
     /// Return the current process’s PID.
-    pub unsafe fn sys_getpid(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn sys_getpid(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
         Ok(unsafe { proc.pid() } as _)
     }
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_fork(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn sys_fork(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
         Ok(unsafe { self.procs.fork(proc) }? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_wait(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub unsafe fn sys_wait(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
         let p = argaddr(0, proc)?;
         Ok(unsafe { self.procs.wait(UVAddr::new(p), proc) }? as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
-    pub fn sys_sbrk(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub fn sys_sbrk(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         let data = proc.deref_mut_data();
         data.memory.resize(n)
@@ -41,7 +41,7 @@ impl Kernel {
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_sleep(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
+    pub fn sys_sleep(&self, proc: &mut CurrentProc) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
@@ -56,7 +56,7 @@ impl Kernel {
 
     /// Terminate process PID.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_kill(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub fn sys_kill(&self, proc: &CurrentProc) -> Result<usize, ()> {
         let pid = argint(0, proc)?;
         self.procs.kill(pid)?;
         Ok(0)
@@ -69,7 +69,7 @@ impl Kernel {
     }
 
     /// Shutdowns this machine, discarding all unsaved data. No return.
-    pub fn sys_poweroff(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+    pub fn sys_poweroff(&self, proc: &CurrentProc) -> Result<usize, ()> {
         let exitcode = argint(0, proc)?;
         poweroff::machine_poweroff(exitcode as _);
     }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -9,7 +9,7 @@ use crate::{
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
     pub unsafe fn sys_exit(&self, proc: &ExecutingProc) -> Result<usize, ()> {
-        let n = unsafe { argint(0) }?;
+        let n = unsafe { argint(0, proc) }?;
         unsafe { self.procs.exit_current(n, proc) };
     }
 
@@ -26,24 +26,23 @@ impl Kernel {
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_wait(&self) -> Result<usize, ()> {
-        let p = unsafe { argaddr(0) }?;
-        Ok(unsafe { self.procs.wait(UVAddr::new(p)) }? as _)
+    pub unsafe fn sys_wait(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        let p = unsafe { argaddr(0, proc) }?;
+        Ok(unsafe { self.procs.wait(UVAddr::new(p), proc) }? as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
-    pub unsafe fn sys_sbrk(&self) -> Result<usize, ()> {
-        let n = unsafe { argint(0) }?;
-        let p = unsafe { kernel().myexproc() };
-        let data = p.deref_mut_data();
+    pub unsafe fn sys_sbrk(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        let n = unsafe { argint(0, proc) }?;
+        let data = proc.deref_mut_data();
         data.memory.resize(n)
     }
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub unsafe fn sys_sleep(&self) -> Result<usize, ()> {
-        let n = unsafe { argint(0) }?;
+    pub unsafe fn sys_sleep(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        let n = unsafe { argint(0, proc) }?;
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
@@ -57,8 +56,8 @@ impl Kernel {
 
     /// Terminate process PID.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub unsafe fn sys_kill(&self) -> Result<usize, ()> {
-        let pid = unsafe { argint(0) }?;
+    pub unsafe fn sys_kill(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        let pid = unsafe { argint(0, proc) }?;
         self.procs.kill(pid)?;
         Ok(0)
     }
@@ -70,8 +69,8 @@ impl Kernel {
     }
 
     /// Shutdowns this machine, discarding all unsaved data. No return.
-    pub unsafe fn sys_poweroff(&self) -> Result<usize, ()> {
-        let exitcode = unsafe { argint(0) }?;
+    pub unsafe fn sys_poweroff(&self, proc: &ExecutingProc) -> Result<usize, ()> {
+        let exitcode = unsafe { argint(0, proc) }?;
         poweroff::machine_poweroff(exitcode as _);
     }
 }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -15,7 +15,7 @@ impl Kernel {
 
     /// Return the current process’s PID.
     pub unsafe fn sys_getpid(&self, proc: &mut ExecutingProc) -> Result<usize, ()> {
-        Ok(unsafe { proc.proc().pid() } as _)
+        Ok(unsafe { proc.pid() } as _)
     }
 
     /// Create a process.
@@ -46,7 +46,7 @@ impl Kernel {
         let mut ticks = self.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
-            if proc.proc().killed() {
+            if proc.killed() {
                 return Err(());
             }
             ticks.sleep();

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -66,13 +66,8 @@ pub unsafe extern "C" fn usertrap() {
         // An interrupt will change sstatus &c registers,
         // so don't enable until done with those registers.
         unsafe { intr_on() };
-        data.trap_frame_mut().a0 = ok_or!(
-            unsafe {
-                kernel().syscall(
-                    data.trap_frame_mut().a7 as i32,
-                    &mut kernel().current_proc(),
-                )
-            },
+        p.deref_mut_data().trap_frame_mut().a0 = ok_or!(
+            unsafe { kernel().syscall(data.trap_frame_mut().a7 as i32, p) },
             usize::MAX
         );
     } else {

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn usertrap() {
     if unsafe { r_scause() } == 8 {
         // system call
 
-        if p.killed() {
+        if p.proc().killed() {
             unsafe { kernel().procs.exit_current(-1, p) };
         }
 
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn usertrap() {
         }
     }
 
-    if p.killed() {
+    if p.proc().killed() {
         unsafe { kernel().procs.exit_current(-1, p) };
     }
 

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -76,14 +76,14 @@ pub unsafe extern "C" fn usertrap() {
             println!(
                 "usertrap(): unexpected scause {:018p} pid={}",
                 unsafe { r_scause() } as *const u8,
-                unsafe { (*p.ptr).pid() }
+                unsafe { p.proc().pid() }
             );
             println!(
                 "            sepc={:018p} stval={:018p}",
                 unsafe { r_sepc() } as *const u8,
                 unsafe { r_stval() } as *const u8
             );
-            unsafe { (*p.ptr).kill() };
+            p.proc().kill();
         }
     }
 

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn usertrap() {
     if unsafe { r_scause() } == 8 {
         // system call
 
-        if p.proc().killed() {
+        if p.killed() {
             unsafe { kernel().procs.exit_current(-1, p) };
         }
 
@@ -76,18 +76,18 @@ pub unsafe extern "C" fn usertrap() {
             println!(
                 "usertrap(): unexpected scause {:018p} pid={}",
                 unsafe { r_scause() } as *const u8,
-                unsafe { p.proc().pid() }
+                unsafe { p.pid() }
             );
             println!(
                 "            sepc={:018p} stval={:018p}",
                 unsafe { r_sepc() } as *const u8,
                 unsafe { r_stval() } as *const u8
             );
-            p.proc().kill();
+            p.kill();
         }
     }
 
-    if p.proc().killed() {
+    if p.killed() {
         unsafe { kernel().procs.exit_current(-1, p) };
     }
 
@@ -188,7 +188,7 @@ pub unsafe fn kerneltrap() {
     // Give up the CPU if this is a timer interrupt.
     if which_dev == 2
         && !unsafe { kernel().myproc() }.is_null()
-        && unsafe { kernel().myexproc().proc().state() } == Procstate::RUNNING
+        && unsafe { kernel().myexproc().state() } == Procstate::RUNNING
     {
         unsafe { proc_yield(&mut kernel().myexproc()) };
     }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -184,7 +184,7 @@ pub unsafe fn kerneltrap() {
     // Give up the CPU if this is a timer interrupt.
     let p = kernel().current_proc();
     if which_dev == 2 && p.is_some() {
-        let p = p.expect("No current proc.");
+        let p = p.expect("No current proc");
         if unsafe { p.state() } == Procstate::RUNNING {
             unsafe { proc_yield(&p) };
         }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -4,7 +4,7 @@ use crate::{
     ok_or,
     plic::{plic_claim, plic_complete},
     println,
-    proc::{cpuid, proc_yield, CurrentProc, Procstate},
+    proc::{cpuid, proc_yield, ProcData, Procstate},
     riscv::{
         intr_get, intr_off, intr_on, r_satp, r_scause, r_sepc, r_sip, r_stval, r_tp, w_sepc, w_sip,
         w_stvec, Sstatus, PGSIZE,
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn usertrap() {
 }
 
 /// Return to user space.
-pub unsafe fn usertrapret(data: &mut CurrentProc) {
+pub unsafe fn usertrapret(data: &mut ProcData) {
     // We're about to switch the destination of traps from
     // kerneltrap() to usertrap(), so turn off interrupts until
     // we're back in user space, where usertrap() is correct.

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -184,9 +184,9 @@ pub unsafe fn kerneltrap() {
     // Give up the CPU if this is a timer interrupt.
     let p = kernel().current_proc();
     if which_dev == 2 && p.is_some() {
-        let mut p = p.expect("No current proc.");
+        let p = p.expect("No current proc.");
         if unsafe { p.state() } == Procstate::RUNNING {
-            unsafe { proc_yield(&mut p) };
+            unsafe { proc_yield(&p) };
         }
     }
 

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -4,7 +4,7 @@ use crate::{
     ok_or,
     plic::{plic_claim, plic_complete},
     println,
-    proc::{cpuid, proc_yield, ExecutingProc, Procstate},
+    proc::{cpuid, proc_yield, CurrentProc, Procstate},
     riscv::{
         intr_get, intr_off, intr_on, r_satp, r_scause, r_sepc, r_sip, r_stval, r_tp, w_sepc, w_sip,
         w_stvec, Sstatus, PGSIZE,
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn usertrap() {
     // since we're now in the kernel.
     unsafe { w_stvec(kernelvec as _) };
 
-    let p = &mut kernel().myexproc();
+    let p = &mut kernel().current_proc();
     let data = p.deref_mut_data();
 
     // Save user program counter.
@@ -67,7 +67,12 @@ pub unsafe extern "C" fn usertrap() {
         // so don't enable until done with those registers.
         unsafe { intr_on() };
         data.trap_frame_mut().a0 = ok_or!(
-            unsafe { kernel().syscall(data.trap_frame_mut().a7 as i32, &mut kernel().myexproc()) },
+            unsafe {
+                kernel().syscall(
+                    data.trap_frame_mut().a7 as i32,
+                    &mut kernel().current_proc(),
+                )
+            },
             usize::MAX
         );
     } else {
@@ -100,7 +105,7 @@ pub unsafe extern "C" fn usertrap() {
 }
 
 /// Return to user space.
-pub unsafe fn usertrapret(p: &mut ExecutingProc) {
+pub unsafe fn usertrapret(p: &mut CurrentProc) {
     let data = p.deref_mut_data();
 
     // We're about to switch the destination of traps from
@@ -188,9 +193,9 @@ pub unsafe fn kerneltrap() {
     // Give up the CPU if this is a timer interrupt.
     if which_dev == 2
         && !unsafe { kernel().myproc() }.is_null()
-        && unsafe { kernel().myexproc().state() } == Procstate::RUNNING
+        && unsafe { kernel().current_proc().state() } == Procstate::RUNNING
     {
-        unsafe { proc_yield(&mut kernel().myexproc()) };
+        unsafe { proc_yield(&mut kernel().current_proc()) };
     }
 
     // The yield() may have caused some traps to occur,

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn usertrap() {
     // since we're now in the kernel.
     unsafe { w_stvec(kernelvec as _) };
 
-    let p = unsafe { &kernel().myexproc() };
+    let p = &kernel().myexproc();
     let data = p.deref_mut_data();
 
     // Save user program counter.

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -4,7 +4,7 @@ use crate::{
     ok_or,
     plic::{plic_claim, plic_complete},
     println,
-    proc::{cpuid, myproc, proc_yield, ExecutingProc, Procstate},
+    proc::{cpuid, proc_yield, ExecutingProc, Procstate},
     riscv::{
         intr_get, intr_off, intr_on, r_satp, r_scause, r_sepc, r_sip, r_stval, r_tp, w_sepc, w_sip,
         w_stvec, Sstatus, PGSIZE,
@@ -187,7 +187,7 @@ pub unsafe fn kerneltrap() {
 
     // Give up the CPU if this is a timer interrupt.
     if which_dev == 2
-        && !unsafe { myproc() }.is_null()
+        && !unsafe { kernel().myproc() }.is_null()
         && unsafe { kernel().myexproc().proc().state() } == Procstate::RUNNING
     {
         unsafe { proc_yield(&kernel().myexproc()) };

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -4,7 +4,7 @@ use crate::{
     ok_or,
     plic::{plic_claim, plic_complete},
     println,
-    proc::{cpuid, myproc, proc_yield, Proc, Procstate},
+    proc::{cpuid, myproc, proc_yield, Procstate},
     riscv::{
         intr_get, intr_off, intr_on, r_satp, r_scause, r_sepc, r_sip, r_stval, r_tp, w_sepc, w_sip,
         w_stvec, Sstatus, PGSIZE,
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn usertrap() {
     // since we're now in the kernel.
     unsafe { w_stvec(kernelvec as _) };
 
-    let p: *mut Proc = unsafe { myproc() };
+    let p = unsafe { myproc() };
     let data = unsafe { &mut *(*p).data.get() };
 
     // Save user program counter.
@@ -100,8 +100,8 @@ pub unsafe extern "C" fn usertrap() {
 
 /// Return to user space.
 pub unsafe fn usertrapret() {
-    let p: *mut Proc = unsafe { myproc() };
-    let data = unsafe { &mut *(*p).data.get() };
+    let data = unsafe { kernel().myexprocdata() };
+    // let data = unsafe { &mut *(*p).data.get() };
 
     // We're about to switch the destination of traps from
     // kerneltrap() to usertrap(), so turn off interrupts until

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -100,8 +100,8 @@ pub unsafe extern "C" fn usertrap() {
 
 /// Return to user space.
 pub unsafe fn usertrapret() {
-    let data = unsafe { kernel().myexprocdata() };
-    // let data = unsafe { &mut *(*p).data.get() };
+    let mut p = unsafe { kernel().myexproc() };
+    let data = p.deref_mut_data();
 
     // We're about to switch the destination of traps from
     // kerneltrap() to usertrap(), so turn off interrupts until

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -376,7 +376,8 @@ impl Disk {
 
         // Wait for virtio_disk_intr() to say request has finished.
         while b.deref_inner().disk {
-            (*b).vdisk_request_waitchannel.sleep(this);
+            (*b).vdisk_request_waitchannel
+                .sleep(this, &kernel().current_proc().expect("No current proc"));
         }
         // As it assigns null, the invariant of inflight is maintained even if
         // b: &mut Buf becomes invalid after this method returns.

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -126,11 +126,19 @@ impl VAddr for UVAddr {
     }
 
     unsafe fn copy_in(self, dst: &mut [u8]) -> Result<(), ()> {
-        kernel().current_proc().memory.copy_in(dst, self)
+        kernel()
+            .current_proc()
+            .expect("No current proc")
+            .memory
+            .copy_in(dst, self)
     }
 
     unsafe fn copy_out(self, src: &[u8]) -> Result<(), ()> {
-        kernel().current_proc().memory.copy_out(self, src)
+        kernel()
+            .current_proc()
+            .expect("No current proc")
+            .memory
+            .copy_out(self, src)
     }
 }
 

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -1,15 +1,7 @@
-use crate::{
-    fs::InodeGuard,
-    kernel::kernel,
-    memlayout::{kstack, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, TRAPFRAME, UART0, VIRTIO0},
-    page::Page,
-    param::NPROC,
-    proc::myproc,
-    riscv::{
+use crate::{fs::InodeGuard, kernel::kernel, memlayout::{kstack, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, TRAPFRAME, UART0, VIRTIO0}, page::Page, param::NPROC, riscv::{
         make_satp, pa2pte, pgrounddown, pgroundup, pte2pa, px, sfence_vma, w_satp, PteFlags, MAXVA,
         PGSIZE,
-    },
-};
+    }};
 use core::{cmp, marker::PhantomData, mem, ops::Add, ptr, slice};
 
 extern "C" {
@@ -127,13 +119,13 @@ impl VAddr for UVAddr {
     }
 
     unsafe fn copy_in(self, dst: &mut [u8]) -> Result<(), ()> {
-        unsafe { &mut *(*myproc()).data.get() }
+        unsafe { kernel().myexproc().deref_mut_data() }
             .memory
             .copy_in(dst, self)
     }
 
     unsafe fn copy_out(self, src: &[u8]) -> Result<(), ()> {
-        unsafe { &mut *(*myproc()).data.get() }
+        unsafe { kernel().myexproc().deref_mut_data() }
             .memory
             .copy_out(self, src)
     }

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -1,7 +1,14 @@
-use crate::{fs::InodeGuard, kernel::kernel, memlayout::{kstack, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, TRAPFRAME, UART0, VIRTIO0}, page::Page, param::NPROC, riscv::{
+use crate::{
+    fs::InodeGuard,
+    kernel::kernel,
+    memlayout::{kstack, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, TRAPFRAME, UART0, VIRTIO0},
+    page::Page,
+    param::NPROC,
+    riscv::{
         make_satp, pa2pte, pgrounddown, pgroundup, pte2pa, px, sfence_vma, w_satp, PteFlags, MAXVA,
         PGSIZE,
-    }};
+    },
+};
 use core::{cmp, marker::PhantomData, mem, ops::Add, ptr, slice};
 
 extern "C" {

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -129,6 +129,7 @@ impl VAddr for UVAddr {
         kernel()
             .current_proc()
             .expect("No current proc")
+            .deref_mut_data()
             .memory
             .copy_in(dst, self)
     }
@@ -137,6 +138,7 @@ impl VAddr for UVAddr {
         kernel()
             .current_proc()
             .expect("No current proc")
+            .deref_mut_data()
             .memory
             .copy_out(self, src)
     }

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -127,7 +127,7 @@ impl VAddr for UVAddr {
 
     unsafe fn copy_in(self, dst: &mut [u8]) -> Result<(), ()> {
         kernel()
-            .myexproc()
+            .current_proc()
             .deref_mut_data()
             .memory
             .copy_in(dst, self)
@@ -135,7 +135,7 @@ impl VAddr for UVAddr {
 
     unsafe fn copy_out(self, src: &[u8]) -> Result<(), ()> {
         kernel()
-            .myexproc()
+            .current_proc()
             .deref_mut_data()
             .memory
             .copy_out(self, src)

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -126,19 +126,11 @@ impl VAddr for UVAddr {
     }
 
     unsafe fn copy_in(self, dst: &mut [u8]) -> Result<(), ()> {
-        kernel()
-            .current_proc()
-            .deref_mut_data()
-            .memory
-            .copy_in(dst, self)
+        kernel().current_proc().memory.copy_in(dst, self)
     }
 
     unsafe fn copy_out(self, src: &[u8]) -> Result<(), ()> {
-        kernel()
-            .current_proc()
-            .deref_mut_data()
-            .memory
-            .copy_out(self, src)
+        kernel().current_proc().memory.copy_out(self, src)
     }
 }
 

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -126,13 +126,17 @@ impl VAddr for UVAddr {
     }
 
     unsafe fn copy_in(self, dst: &mut [u8]) -> Result<(), ()> {
-        unsafe { kernel().myexproc().deref_mut_data() }
+        kernel()
+            .myexproc()
+            .deref_mut_data()
             .memory
             .copy_in(dst, self)
     }
 
     unsafe fn copy_out(self, src: &[u8]) -> Result<(), ()> {
-        unsafe { kernel().myexproc().deref_mut_data() }
+        kernel()
+            .myexproc()
+            .deref_mut_data()
             .memory
             .copy_out(self, src)
     }


### PR DESCRIPTION
- closes #354 , closes #258

주요 변경사항입니다.
- `myproc()` 을 `Kernel`의 메소드로 이동
- `struct ExecutingProc` 추가: `*mut Proc`을 감싸는 struct
  - `kernel().myexproc()` 추가: `myproc()`에서 `Proc`이 존재함을 확인하고 `ExecutingProc`을 리턴
  - `usertrap()`에서 sys_* 함수들에 `ExecutingProc`을 전달
- proc이 null이 아니어야 하는 경우에는 `myproc()`의 사용을 모두 `myexproc()`으로 수정했습니다.
