### PR TITLE
[Closes #383] Refactoring bio.rs and log.rs

### DIFF
--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! On-disk file system format used for both kernel and user programs are also included here.
 
-use core::{cmp, mem, ptr};
+use core::{cmp, mem};
 use spin::Once;
 
 use crate::{
@@ -69,7 +69,7 @@ impl FileSystem {
     pub fn init(&self, dev: u32) {
         let _ = self
             .superblock
-            .call_once(|| unsafe { Superblock::new(&self.disk.read(dev, 1)) });
+            .call_once(|| Superblock::new(&self.disk.read(dev, 1)));
         let _ = self.log.call_once(|| {
             Sleepablelock::new(
                 "LOG",
@@ -113,9 +113,7 @@ impl Drop for FsTransaction<'_> {
     fn drop(&mut self) {
         // Called at the end of each FS system call.
         // Commits if this was the last outstanding operation.
-        unsafe {
-            Log::end_op(self.fs.log());
-        }
+        Log::end_op(self.fs.log());
     }
 }
 
@@ -128,30 +126,30 @@ impl FsTransaction<'_> {
     ///   bp = kernel().file_system.disk.read(...)
     ///   modify bp->data[]
     ///   write(bp)
-    unsafe fn write(&self, b: Buf<'static>) {
+    fn write(&self, b: Buf<'static>) {
         self.fs.log().lock().write(b);
     }
 
     /// Zero a block.
-    unsafe fn bzero(&self, dev: u32, bno: u32) {
+    fn bzero(&self, dev: u32, bno: u32) {
         let mut buf = kernel().bcache.get_buf(dev, bno).lock();
-        unsafe { ptr::write_bytes(buf.deref_mut_inner().data.as_mut_ptr(), 0, BSIZE) };
-        buf.deref_mut_inner().valid = true;
-        unsafe { self.write(buf) };
+        buf.deref_inner_mut().data.fill(0);
+        buf.deref_inner_mut().valid = true;
+        self.write(buf);
     }
 
     /// Blocks.
     /// Allocate a zeroed disk block.
-    unsafe fn balloc(&self, dev: u32) -> u32 {
-        for b in num_iter::range_step(0, self.fs.superblock().size, BPB) {
+    fn balloc(&self, dev: u32) -> u32 {
+        for b in num_iter::range_step(0, self.fs.superblock().size, BPB as u32) {
             let mut bp = self.fs.disk.read(dev, self.fs.superblock().bblock(b));
-            for bi in 0..cmp::min(BPB, self.fs.superblock().size - b) {
+            for bi in 0..cmp::min(BPB as u32, self.fs.superblock().size - b) {
                 let m = 1 << (bi % 8);
-                if bp.deref_mut_inner().data[(bi / 8) as usize] & m == 0 {
+                if bp.deref_inner_mut().data[(bi / 8) as usize] & m == 0 {
                     // Is block free?
-                    bp.deref_mut_inner().data[(bi / 8) as usize] |= m; // Mark block in use.
-                    unsafe { self.write(bp) };
-                    unsafe { self.bzero(dev, b + bi) };
+                    bp.deref_inner_mut().data[(bi / 8) as usize] |= m; // Mark block in use.
+                    self.write(bp);
+                    self.bzero(dev, b + bi);
                     return b + bi;
                 }
             }
@@ -161,16 +159,16 @@ impl FsTransaction<'_> {
     }
 
     /// Free a disk block.
-    unsafe fn bfree(&self, dev: u32, b: u32) {
+    fn bfree(&self, dev: u32, b: u32) {
         let mut bp = self.fs.disk.read(dev, self.fs.superblock().bblock(b));
-        let bi = b.wrapping_rem(BPB) as i32;
+        let bi = b as usize % BPB;
         let m = 1u8 << (bi % 8);
         assert_ne!(
-            bp.deref_mut_inner().data[(bi / 8) as usize] & m,
+            bp.deref_inner_mut().data[bi / 8] & m,
             0,
             "freeing free block"
         );
-        bp.deref_mut_inner().data[(bi / 8) as usize] &= !m;
-        unsafe { self.write(bp) };
+        bp.deref_inner_mut().data[bi / 8] &= !m;
+        self.write(bp);
     }
 }

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -218,7 +218,7 @@ impl Sleepablelock<Disk> {
         let mut buf = kernel().bcache.get_buf(dev, blockno).lock();
         if !buf.deref_inner().valid {
             Disk::rw(&mut self.lock(), &mut buf, false);
-            buf.deref_mut_inner().valid = true;
+            buf.deref_inner_mut().valid = true;
         }
         buf
     }
@@ -348,7 +348,7 @@ impl Disk {
         };
 
         // Record struct Buf for virtio_disk_intr().
-        b.deref_mut_inner().disk = true;
+        b.deref_inner_mut().disk = true;
         // It does not break the invariant because b is &mut Buf, which refers
         // to a valid Buf.
         this.info.inflight[desc[0].idx].b = b;
@@ -403,7 +403,7 @@ impl Disk {
             let buf = unsafe { self.info.inflight[id].b.as_mut() }.expect("Disk::intr");
 
             // disk is done with buf
-            buf.deref_mut_inner().disk = false;
+            buf.deref_inner_mut().disk = false;
             buf.vdisk_request_waitchannel.wakeup();
 
             self.info.used_idx += 1;


### PR DESCRIPTION
Closes #383

* `read_head`에서 `buf_unforget` 대신 `disk.read` 사용. `Arena::unforget` 삭제.
* `Buf`가 `ManuallyDrop<BufUnlocked>`를 가지게 있게 하여 `transmute` 없이 `unlock` 구현.
* 필요없는 `unsafe` 제거. `unsafe` 블록에 주석 추가.
* 가능한 경우 포인터 대신 slice 사용.