### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install gcc-riscv64-linux-gnu qemu-system-misc
+        run: sudo apt update && sudo apt-get install gcc-riscv64-linux-gnu qemu-system-misc
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
let's try this: https://github.community/t/sudo-apt-install-fails-with-failed-to-fetch-http-security-ubuntu-com-404-not-found-ip/17075