### PR TITLE
[Sub-issue of #378] Add `PinnedKernel`, and use `Pin` in locks, `MruArena`, and `MruEntry`

### DIFF
--- a/kernel-rs/Cargo.lock
+++ b/kernel-rs/Cargo.lock
@@ -92,6 +92,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rv6-kernel"
 version = "0.1.0"
 dependencies = [
@@ -101,6 +139,7 @@ dependencies = [
  "cstr_core",
  "itertools",
  "num-iter",
+ "pin-project",
  "scopeguard",
  "spin",
  "static_assertions",
@@ -123,3 +162,20 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "syn"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"

--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -29,7 +29,7 @@ spin = { version = "0.7.1", default-features = false }
 array-macro = "2.0.0"
 static_assertions = "1.1.0"
 itertools = { version = "0.10.0", default-features = false }
-pin-project = "1.0.4"
+pin-project = "1"
 
 # Compiler options for sysroot packages.
 # Cargo currently warns following packages are not dependencies.

--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -29,6 +29,7 @@ spin = { version = "0.7.1", default-features = false }
 array-macro = "2.0.0"
 static_assertions = "1.1.0"
 itertools = { version = "0.10.0", default-features = false }
+pin-project = "1.0.4"
 
 # Compiler options for sysroot packages.
 # Cargo currently warns following packages are not dependencies.

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -253,7 +253,7 @@ impl<T> MruEntry<T> {
         Self {
             refcnt: 0,
             data,
-            list_entry: ListEntry::new(),
+            list_entry: unsafe { ListEntry::new() },
         }
     }
 }
@@ -263,7 +263,7 @@ impl<T, const CAPACITY: usize> MruArena<T, CAPACITY> {
     pub const fn new(entries: [MruEntry<T>; CAPACITY]) -> Self {
         Self {
             entries,
-            head: ListEntry::new(),
+            head: unsafe { ListEntry::new() },
         }
     }
 

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -3,8 +3,8 @@ use crate::spinlock::{Spinlock, SpinlockGuard};
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
 use core::ops::Deref;
-use core::ptr::{self, NonNull};
 use core::pin::Pin;
+use core::ptr::{self, NonNull};
 use pin_project::pin_project;
 
 /// A homogeneous memory allocator, equipped with the box type representing an allocation.
@@ -161,7 +161,9 @@ impl<T> Drop for ArrayPtr<'_, T> {
     }
 }
 
-impl<T: 'static + ArenaObject + Unpin, const CAPACITY: usize> Arena for Spinlock<ArrayArena<T, CAPACITY>> {
+impl<T: 'static + ArenaObject + Unpin, const CAPACITY: usize> Arena
+    for Spinlock<ArrayArena<T, CAPACITY>>
+{
     type Data = T;
     type Handle<'s> = ArrayPtr<'s, T>;
     type Guard<'s> = SpinlockGuard<'s, ArrayArena<T, CAPACITY>>;

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -22,6 +22,7 @@ use crate::{
 use array_macro::array;
 use core::mem::{self, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
 
 pub struct BufEntry {
     dev: u32,
@@ -91,7 +92,12 @@ impl BufInner {
     }
 }
 
-pub type Bcache = Spinlock<MruArena<BufEntry, NBUF>>;
+/// Type that actually stores the buffer cache.
+pub type BcacheInner = MruArena<BufEntry, NBUF>;
+/// Type that provides a pinned mutable reference of the buffer cache
+/// to the outside.
+// TODO: 'static?
+pub type Bcache = Spinlock<Pin<&'static mut MruArena<BufEntry, NBUF>>>;
 
 /// We can consider it as BufEntry.
 pub type BufUnlocked<'s> = Rc<'s, Bcache, &'s Bcache>;
@@ -141,19 +147,16 @@ impl Drop for Buf<'_> {
     }
 }
 
-impl Bcache {
+impl BcacheInner {
     /// # Safety
     ///
     /// The caller should make sure that `Bcache` never gets moved.
     pub const unsafe fn zero() -> Self {
-        unsafe {
-            Spinlock::new_unchecked(
-                "BCACHE",
-                MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF]),
-            )
-        }
+        MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF])
     }
+}
 
+impl Bcache {
     /// Return a unlocked buf with the contents of the indicated block.
     pub fn get_buf(&self, dev: u32, blockno: u32) -> BufUnlocked<'_> {
         self.find_or_alloc(

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -95,7 +95,7 @@ impl BufInner {
 /// Type that actually stores the buffer cache.
 pub type BcacheInner = MruArena<BufEntry, NBUF>;
 /// Type that provides a pinned mutable reference of the buffer cache
-/// to the outside.
+/// wrapped by a `Spinlock` to the outside.
 // TODO: 'static?
 pub type Bcache = Spinlock<Pin<&'static mut MruArena<BufEntry, NBUF>>>;
 

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -142,11 +142,16 @@ impl Drop for Buf<'_> {
 }
 
 impl Bcache {
-    pub const fn zero() -> Self {
-        Spinlock::new(
-            "BCACHE",
-            MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF]),
-        )
+    /// # Safety
+    ///
+    /// The caller should make sure that `Bcache` never gets moved.
+    pub const unsafe fn zero() -> Self {
+        unsafe {
+            Spinlock::new_unchecked(
+                "BCACHE",
+                MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF]),
+            )
+        }
     }
 
     /// Return a unlocked buf with the contents of the indicated block.

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -92,10 +92,11 @@ impl BufInner {
     }
 }
 
-/// Type that actually stores the buffer cache.
+/// Type that actually stores the memory of the buffer cache.
+/// Should never be moved.
 pub type BcacheInner = MruArena<BufEntry, NBUF>;
-/// Type that provides a pinned mutable reference of the buffer cache
-/// wrapped by a `Spinlock` to the outside.
+
+/// The buffer cache type.
 // TODO: 'static?
 pub type Bcache = Spinlock<Pin<&'static mut MruArena<BufEntry, NBUF>>>;
 

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -132,7 +132,8 @@ impl FsTransaction<'_> {
 
     /// Zero a block.
     fn bzero(&self, dev: u32, bno: u32) {
-        let mut buf = kernel().get_bcache().get_buf(dev, bno).lock();
+        // Safe since the `Kernel` is initialized.
+        let mut buf = unsafe { kernel().bcache.assume_init_ref().get_buf(dev, bno).lock() };
         buf.deref_inner_mut().data.fill(0);
         buf.deref_inner_mut().valid = true;
         self.write(buf);

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -132,7 +132,7 @@ impl FsTransaction<'_> {
 
     /// Zero a block.
     fn bzero(&self, dev: u32, bno: u32) {
-        let mut buf = kernel().bcache.get_buf(dev, bno).lock();
+        let mut buf = unsafe { kernel().bcache.assume_init_ref().get_buf(dev, bno).lock() };
         buf.deref_inner_mut().data.fill(0);
         buf.deref_inner_mut().valid = true;
         self.write(buf);

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -132,7 +132,7 @@ impl FsTransaction<'_> {
 
     /// Zero a block.
     fn bzero(&self, dev: u32, bno: u32) {
-        let mut buf = unsafe { kernel().bcache.assume_init_ref().get_buf(dev, bno).lock() };
+        let mut buf = kernel().get_bcache().get_buf(dev, bno).lock();
         buf.deref_inner_mut().data.fill(0);
         buf.deref_inner_mut().valid = true;
         self.write(buf);

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -210,11 +210,16 @@ pub unsafe fn kernel_main() -> ! {
 
         // Buffer cache.
         unsafe {
-            KERNEL.bcache = MaybeUninit::new(Spinlock::new(
-                "BCACHE",
-                pinned_kernel().project().bcache_inner,
-            ));
-            KERNEL.bcache.assume_init_mut().get_mut().as_mut().init()
+            // Initialize the `KERNEL.bcache` field, and then initialize the `Bcache`.
+            KERNEL
+                .bcache
+                .write(Spinlock::new(
+                    "BCACHE",
+                    pinned_kernel().project().bcache_inner,
+                ))
+                .get_mut()
+                .as_mut()
+                .init()
         };
 
         // Emulated hard disk.

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -77,7 +77,8 @@ impl Kernel {
             ticks: Sleepablelock::new("time", 0),
             procs: ProcessSystem::zero(),
             cpus: [Cpu::new(); NCPU],
-            bcache: Bcache::zero(),
+            // Safe since the only way to access `bcache` is through `kernel()`, which is an immutable reference.
+            bcache: unsafe { Bcache::zero() },
             devsw: [Devsw {
                 read: None,
                 write: None,
@@ -204,7 +205,7 @@ pub unsafe fn kernel_main() -> ! {
         unsafe { plicinithart() };
 
         // Buffer cache.
-        unsafe { KERNEL.bcache.get_pin().init() };
+        unsafe { KERNEL.bcache.get_pin_mut().init() };
 
         // Emulated hard disk.
         unsafe { KERNEL.file_system.disk.get_mut().init() };

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -204,7 +204,7 @@ pub unsafe fn kernel_main() -> ! {
         unsafe { plicinithart() };
 
         // Buffer cache.
-        unsafe { KERNEL.bcache.get_mut().init() };
+        unsafe { KERNEL.bcache.get_pin().init() };
 
         // Emulated hard disk.
         unsafe { KERNEL.file_system.disk.get_mut().init() };

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -63,6 +63,7 @@ mod list;
 mod memlayout;
 mod page;
 mod param;
+mod pinned_kernel;
 mod pipe;
 mod plic;
 mod poweroff;

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -43,6 +43,7 @@
 #![feature(array_value_iter)]
 #![feature(const_fn)]
 #![feature(const_fn_union)]
+#![feature(const_mut_refs)]
 #![feature(maybe_uninit_extra)]
 #![feature(generic_associated_types)]
 #![feature(unsafe_block_in_unsafe_fn)]

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -10,7 +10,14 @@ pub struct ListEntry {
 }
 
 impl ListEntry {
-    pub const fn new() -> Self {
+    
+    /// Returns an uninitialized `ListEntry`,
+    ///
+    /// # Safety
+    ///
+    /// All `ListEntry` types must be used only after initializing it with
+    /// `ListEntry::init()`.
+    pub const unsafe fn new() -> Self {
         Self {
             prev: ptr::null_mut(),
             next: ptr::null_mut(),
@@ -64,7 +71,7 @@ impl ListEntry {
         self.init();
     }
 
-    pub fn list_pop_front(&self) -> &ListEntry {
+    pub fn list_pop_front(&mut self) -> &mut ListEntry {
         let result = unsafe { &mut *self.next };
         result.remove();
         result

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -14,9 +14,9 @@ pub struct ListEntry {
 }
 
 /// A list entry for doubly, circular, intrusive linked lists.
-/// 
+///
 /// # Safety
-/// 
+///
 /// All `ListEntry` types must be used only after initializing it with `ListEntry::init()`,
 /// or after appending/prepending it to another initialized `ListEntry`.
 /// After this, `ListEntry::{prev, next}` always refer to a valid, initialized `ListEntry`.

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -9,8 +9,7 @@ use core::ptr;
 pub struct ListEntry {
     next: *mut ListEntry,
     prev: *mut ListEntry,
-    // Add `PhantomPinned` to mark this struct as `!Unpin`, since `ListEntry`s must not move.
-    _marker: PhantomPinned,
+    _marker: PhantomPinned, //`ListEntry` is `!Unpin`.
 }
 
 /// A list entry for doubly, circular, intrusive linked lists.

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -2,9 +2,9 @@
 //! `ListEntry` types must be first initialized with init()
 //! before calling its member functions.
 
-use core::ptr;
-use core::pin::Pin;
 use core::marker::PhantomPinned;
+use core::pin::Pin;
+use core::ptr;
 
 pub struct ListEntry {
     next: *mut ListEntry,
@@ -14,7 +14,6 @@ pub struct ListEntry {
 }
 
 impl ListEntry {
-    
     /// Returns an uninitialized `ListEntry`,
     ///
     /// # Safety
@@ -63,7 +62,7 @@ impl ListEntry {
         // Safe since we don't move the inner data and don't leak the mutable reference.
         let this = unsafe { self.get_unchecked_mut() };
         let elem = unsafe { e.get_unchecked_mut() };
-        
+
         elem.next = this.next;
         elem.prev = this;
         unsafe {

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -13,13 +13,20 @@ pub struct ListEntry {
     _marker: PhantomPinned,
 }
 
+/// A list entry for doubly, circular, intrusive linked lists.
+/// 
+/// # Safety
+/// 
+/// All `ListEntry` types must be used only after initializing it with `ListEntry::init()`,
+/// or after appending/prepending it to another initialized `ListEntry`.
+/// After this, `ListEntry::{prev, next}` always refer to a valid, initialized `ListEntry`.
 impl ListEntry {
     /// Returns an uninitialized `ListEntry`,
     ///
     /// # Safety
     ///
-    /// All `ListEntry` types must be used only after initializing it with
-    /// `ListEntry::init()`.
+    /// All `ListEntry` types must be used only after initializing it with `ListEntry::init()`,
+    /// or after appending/prepending it to another initialized `ListEntry`.
     pub const unsafe fn new() -> Self {
         Self {
             prev: ptr::null_mut(),

--- a/kernel-rs/src/pinned_kernel.rs
+++ b/kernel-rs/src/pinned_kernel.rs
@@ -1,0 +1,35 @@
+use crate::bio::BcacheInner;
+use core::pin::Pin;
+use pin_project::pin_project;
+
+/// A static variable to safely store the kernel's structs
+/// that should never be moved.
+static mut PINNED_KERNEL: PinnedKernel = PinnedKernel::zero();
+
+/// A struct where we actually store the kernel's structs that are !Unpin.
+/// Using this struct, we can safely only provide pinned mutable references
+/// of this struct's fields to the outside.
+///
+/// # Safety
+///
+/// This struct should never be moved.
+#[pin_project]
+pub struct PinnedKernel {
+    #[pin]
+    pub bcache_inner: BcacheInner,
+    // TODO: move `KERNEL.procs` to here, and other !Unpin structs
+}
+
+impl PinnedKernel {
+    const fn zero() -> Self {
+        Self {
+            bcache_inner: unsafe { BcacheInner::zero() },
+        }
+    }
+}
+
+/// Returns a pinned mutable reference to the static `PinnedKernel`.
+/// This is the only way to access the `PinnedKernel` from outside.
+pub fn pinned_kernel() -> Pin<&'static mut PinnedKernel> {
+    unsafe { Pin::new_unchecked(&mut PINNED_KERNEL) }
+}

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -453,6 +453,7 @@ impl Deref for ProcGuard {
     }
 }
 
+// TODO(travis1829): Change &mut Target -> Pin<&mut Target>
 impl DerefMut for ProcGuard {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *(self.ptr as *mut _) }

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -43,7 +43,7 @@ impl<T> Sleepablelock<T> {
     }
 
     /// Returns a pinned mutable reference to the inner data.
-    pub fn get_pin(&mut self) -> Pin<&mut T> {
+    pub fn get_pin_mut(&mut self) -> Pin<&mut T> {
         // Safe since for `T: !Unpin`, we only provide pinned references and don't move `T`.
         unsafe { Pin::new_unchecked(&mut *self.data.get()) }
     }
@@ -80,7 +80,7 @@ impl<T> SleepablelockGuard<'_, T> {
     }
 
     /// Returns a pinned mutable reference to the inner data.
-    pub fn get_pin(&mut self) -> Pin<&mut T> {
+    pub fn get_pin_mut(&mut self) -> Pin<&mut T> {
         // Safe since for `T: !Unpin`, we only provide pinned references and don't move `T`.
         unsafe { Pin::new_unchecked(&mut *self.lock.data.get()) }
     }

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -80,7 +80,7 @@ impl<T> Sleeplock<T> {
     }
 
     /// Returns a pinned mutable reference to the inner data.
-    pub fn get_pin(&mut self) -> Pin<&mut T> {
+    pub fn get_pin_mut(&mut self) -> Pin<&mut T> {
         // Safe since for `T: !Unpin`, we only provide pinned references and don't move `T`.
         unsafe { Pin::new_unchecked(&mut *self.data.get()) }
     }
@@ -113,7 +113,7 @@ impl<T> SleeplockGuard<'_, T> {
     }
 
     /// Returns a pinned mutable reference to the inner data.
-    pub fn get_pin(&mut self) -> Pin<&mut T> {
+    pub fn get_pin_mut(&mut self) -> Pin<&mut T> {
         // Safe since for `T: !Unpin`, we only provide pinned references and don't move `T`.
         unsafe { Pin::new_unchecked(&mut *self.lock.data.get()) }
     }
@@ -133,7 +133,7 @@ impl<T> Deref for SleeplockGuard<'_, T> {
 }
 
 // We can mutably dereference the guard only when `T: Unpin`.
-// If `T: !Unpin`, use `SleeplockGuard::get_pin()` instead.
+// If `T: !Unpin`, use `SleeplockGuard::get_pin_mut()` instead.
 impl<T> DerefMut for SleeplockGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *self.lock.data.get() }

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -219,7 +219,7 @@ impl<T> Waitable for SpinlockGuard<'_, T> {
     unsafe fn raw_release(&mut self) {
         self.lock.lock.release();
     }
-    
+
     unsafe fn raw_acquire(&mut self) {
         self.lock.lock.acquire();
     }
@@ -270,7 +270,10 @@ impl<T> SpinlockProtected<T> {
 
     /// Returns a pinned mutable reference to the inner data.
     /// See `SpinlockProtected::get_mut()` for details.
-    pub fn get_pin<'a: 'b, 'b>(&'a self, guard: &'b mut SpinlockProtectedGuard<'a>) -> Pin<&'b mut T> {
+    pub fn get_pin<'a: 'b, 'b>(
+        &'a self,
+        guard: &'b mut SpinlockProtectedGuard<'a>,
+    ) -> Pin<&'b mut T> {
         assert!(ptr::eq(self.lock, guard.lock));
         unsafe { Pin::new_unchecked(&mut *self.data.get()) }
     }

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -7,8 +7,8 @@ use core::cell::UnsafeCell;
 use core::hint::spin_loop;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
-use core::ptr;
 use core::pin::Pin;
+use core::ptr;
 use core::sync::atomic::{AtomicPtr, Ordering};
 
 /// Mutual exclusion lock.
@@ -171,7 +171,7 @@ impl<T> Spinlock<T> {
     /// Returns a mutable reference to the inner data wrapped by a `Pin`.
     pub fn get_pin(&mut self) -> Pin<&mut T> {
         // Safe since for `T: !Unpin`, we only provide pinned references and don't move `T`.
-        unsafe { Pin::new_unchecked(&mut *self.data.get() ) }
+        unsafe { Pin::new_unchecked(&mut *self.data.get()) }
     }
 }
 

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -215,7 +215,7 @@ impl Sleepablelock<Disk> {
     /// Return a locked Buf with the `latest` contents of the indicated block.
     /// If buf.valid is true, we don't need to access Disk.
     pub fn read(&self, dev: u32, blockno: u32) -> Buf<'static> {
-        let mut buf = unsafe { kernel().bcache.assume_init_ref().get_buf(dev, blockno).lock() };
+        let mut buf = kernel().get_bcache().get_buf(dev, blockno).lock();
         if !buf.deref_inner().valid {
             Disk::rw(&mut self.lock(), &mut buf, false);
             buf.deref_inner_mut().valid = true;

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -215,7 +215,14 @@ impl Sleepablelock<Disk> {
     /// Return a locked Buf with the `latest` contents of the indicated block.
     /// If buf.valid is true, we don't need to access Disk.
     pub fn read(&self, dev: u32, blockno: u32) -> Buf<'static> {
-        let mut buf = kernel().get_bcache().get_buf(dev, blockno).lock();
+        // Safe since the `Kernel` is initialized.
+        let mut buf = unsafe {
+            kernel()
+                .bcache
+                .assume_init_ref()
+                .get_buf(dev, blockno)
+                .lock()
+        };
         if !buf.deref_inner().valid {
             Disk::rw(&mut self.lock(), &mut buf, false);
             buf.deref_inner_mut().valid = true;

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -215,7 +215,7 @@ impl Sleepablelock<Disk> {
     /// Return a locked Buf with the `latest` contents of the indicated block.
     /// If buf.valid is true, we don't need to access Disk.
     pub fn read(&self, dev: u32, blockno: u32) -> Buf<'static> {
-        let mut buf = kernel().bcache.get_buf(dev, blockno).lock();
+        let mut buf = unsafe { kernel().bcache.assume_init_ref().get_buf(dev, blockno).lock() };
         if !buf.deref_inner().valid {
             Disk::rw(&mut self.lock(), &mut buf, false);
             buf.deref_inner_mut().valid = true;


### PR DESCRIPTION
Partially resolves # 378.
* `T: Unpin`인 경우에만 (즉, `T`가 move되어도 상관없는 경우에만) `Spinlock`, `SpinlockGuard`와 같은 lock 및 guard들이 `get_mut()`, `get_mut_unchecked()`, `DerefMut`을 impl하도록 바꿨습니다. 그 대신, `get_pin()`을 추가했습니다.
  * 추가적으로 ,다른 PR에서 lock과 guard들을 더 정리할 계획입니다.
* `ListEntry` API가 `Pin`을 사용하게끔 바꿨습니다.
* `MruArena`, `MruEntry`에서 mutable reference가 필요할 때는 항상 `Pin<&mut ...>`을 사용하게끔 바꿨습니다.
  * 편의를 위해 pin_project crate를 사용했습니다. move되선 안되는 field에는 #[pin]을 붙여서 `Pin`으로만 접근하도록 제한했습니다. 다만 pin_project가 procedural macro를 사용해서인지 dependency를 약 10개나 늘려버립니다. 참고로, procedural macro를 쓰지 않는 pin_project_lite도 있기는 한데 이건 기능이 제한적입니다.

EDIT:
* 특히, `Pin`의 안전성을 깔끔하게 보장하기 위해서 `PinnedKernel`이라는 struct 및 static 변수를 추가했습니다. 지금은 `BcacheInner`만 들어있지만 추후 `Pin`이 필요한 struct들을 `Kernel`에서 여기로 옮길 계획입니다.
  * https://github.com/kaist-cp/rv6/pull/394#issuecomment-773093015