### PR TITLE
[Closes #374] Make `File` auto impl `Send` trait.

### DIFF
--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -84,8 +84,9 @@ pub struct ArrayPtr<'s, T> {
     _marker: PhantomData<&'s T>,
 }
 
-// `ArrayPtr` is `Send` because it does not impl `DerefMut`
-// and because it does not point to thread-local data.
+// `ArrayPtr` is `Send` because it does not impl `DerefMut`, and when we access
+// the inner `ArrayEntry`, we do it after acquring `ArrayArena`'s lock.
+// Also, `ArrayPtr` does not point to thread-local data.
 unsafe impl<T: Send> Send for ArrayPtr<'_, T> {}
 
 impl<'s, T> ArrayPtr<'s, T> {

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -84,6 +84,10 @@ pub struct ArrayPtr<'s, T> {
     _marker: PhantomData<&'s T>,
 }
 
+// `ArrayPtr` is `Send` since it does not impl `DerefMut`,
+// and does not point to thread-local data.
+unsafe impl<T: Send> Send for ArrayPtr<'_, T> {}
+
 impl<'s, T> ArrayPtr<'s, T> {
     /// # Safety
     ///

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -84,8 +84,8 @@ pub struct ArrayPtr<'s, T> {
     _marker: PhantomData<&'s T>,
 }
 
-// `ArrayPtr` is `Send` since it does not impl `DerefMut`,
-// and does not point to thread-local data.
+// `ArrayPtr` is `Send` because it does not impl `DerefMut`
+// and because it does not point to thread-local data.
 unsafe impl<T: Send> Send for ArrayPtr<'_, T> {}
 
 impl<'s, T> ArrayPtr<'s, T> {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -46,10 +46,6 @@ pub struct Devsw {
 
 pub type RcFile<'s> = Rc<'s, FileTable, &'s FileTable>;
 
-// TODO(https://github.com/kaist-cp/rv6/issues/374)
-// will be infered as we wrap *mut Pipe and *mut Inode.
-unsafe impl Send for File {}
-
 impl Default for FileType {
     fn default() -> Self {
         Self::None

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -117,8 +117,8 @@ pub struct AllocatedPipe {
     ptr: NonNull<Pipe>,
 }
 
-// `AllocatedPipe` is `Send` because we access `PipeInner` only after acquring a lock,
-// `AllocatedPipe` does not point to thread-local data.
+// `AllocatedPipe` is `Send` because we access `PipeInner` only after acquring a lock
+// and because `AllocatedPipe` does not point to thread-local data.
 unsafe impl Send for AllocatedPipe {}
 
 impl Deref for AllocatedPipe {

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -117,6 +117,10 @@ pub struct AllocatedPipe {
     ptr: NonNull<Pipe>,
 }
 
+// `AllocatedPipe` is `Send` because we access `PipeInner` only after acquring a lock,
+// `AllocatedPipe` does not point to thread-local data.
+unsafe impl Send for AllocatedPipe {}
+
 impl Deref for AllocatedPipe {
     type Target = Pipe;
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
Closes #374 
* `ArrayPtr`와 `AllocatedPipe`이 `Send`를 impl하도록 바꿨습니다. 이러면 `File`는 `Send`이 자동으로 `impl`됩니다. (docs로 확인했습니다.)
![file_send_trait](https://user-images.githubusercontent.com/31153867/106710214-eddfc900-6638-11eb-8a0d-6c047dadc4a3.png)

* `Send`이여도 괜찮다고 생각하는 이유를 간단히 적어놨습니다.