### PR TITLE
[Closes #346, #363] Atomicpid, proc id type, state in procguard

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -101,7 +101,7 @@ impl Console {
         match cin {
             // Print process list.
             m if m == ctrl('P') => {
-                kernel().procs.dump();
+                unsafe { kernel().procs.dump() };
             }
 
             // Kill line.

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -208,7 +208,7 @@ pub enum Procstate {
     USED,
 }
 
-pub type Pid = i32;
+type Pid = i32;
 
 /// Represents lock guards that can be slept in a `WaitChannel`.
 pub trait Waitable {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -288,9 +288,9 @@ impl WaitChannel {
 }
 
 /// Proc::info's spinlock must be held when using these.
-struct ProcInfo {
+pub struct ProcInfo {
     /// Process state.
-    state: Procstate,
+    pub state: Procstate,
 
     /// If non-zero, sleeping on waitchannel.
     waitchannel: *const WaitChannel,
@@ -344,7 +344,7 @@ pub struct Proc {
     /// `SpinlockProtected::new(&procs.wait_lock, ptr::null_mut())`.
     parent: MaybeUninit<SpinlockProtected<*const Proc>>,
 
-    info: Spinlock<ProcInfo>,
+    pub info: Spinlock<ProcInfo>,
 
     data: UnsafeCell<ProcData>,
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -675,7 +675,7 @@ impl ProcessSystem {
         }
     }
 
-    fn allocpid(&self) -> i32 {
+    fn allocpid(&self) -> Pid {
         self.nextpid.fetch_add(1, Ordering::Relaxed)
     }
 

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -29,7 +29,7 @@ impl RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
-        *guard = unsafe { kernel().current_proc().expect("No current proc").pid() };
+        *guard = kernel().current_proc().expect("No current proc").pid();
     }
 
     pub fn release(&self) {
@@ -40,7 +40,7 @@ impl RawSleeplock {
 
     pub fn holding(&self) -> bool {
         let guard = self.locked.lock();
-        *guard == unsafe { kernel().current_proc().expect("No current proc").pid() }
+        *guard == kernel().current_proc().expect("No current proc").pid()
     }
 }
 

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -103,7 +103,7 @@ impl Kernel {
             _ => {
                 println!(
                     "{} {}: unknown sys call {}",
-                    unsafe { proc.pid() },
+                    proc.pid(),
                     str::from_utf8(&proc.name).unwrap_or("???"),
                     num
                 );

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -14,7 +14,7 @@ impl Kernel {
 
     /// Return the current process’s PID.
     pub unsafe fn sys_getpid(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
-        Ok(unsafe { proc.pid() } as _)
+        Ok(proc.pid() as _)
     }
 
     /// Create a process.

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -185,7 +185,7 @@ pub unsafe fn kerneltrap() {
     // Give up the CPU if this is a timer interrupt.
     if which_dev == 2 {
         if let Some(proc) = kernel().current_proc() {
-            if proc.lock().state() == Procstate::RUNNING {
+            if unsafe { proc.info.get_mut_unchecked().state } == Procstate::RUNNING {
                 unsafe { proc.proc_yield() };
             }
         }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -185,6 +185,8 @@ pub unsafe fn kerneltrap() {
     // Give up the CPU if this is a timer interrupt.
     if which_dev == 2 {
         if let Some(proc) = kernel().current_proc() {
+            // Reading state without lock is safe because `proc_yield` and `sched`
+            // is called after we check if current process is `RUNNING`.
             if unsafe { proc.info.get_mut_unchecked().state } == Procstate::RUNNING {
                 unsafe { proc.proc_yield() };
             }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn usertrap() {
             println!(
                 "usertrap(): unexpected scause {:018p} pid={}",
                 unsafe { r_scause() } as *const u8,
-                unsafe { proc.pid() }
+                proc.pid()
             );
             println!(
                 "            sepc={:018p} stval={:018p}",
@@ -185,7 +185,7 @@ pub unsafe fn kerneltrap() {
     // Give up the CPU if this is a timer interrupt.
     if which_dev == 2 {
         if let Some(proc) = kernel().current_proc() {
-            if unsafe { proc.state() } == Procstate::RUNNING {
+            if proc.lock().state() == Procstate::RUNNING {
                 unsafe { proc.proc_yield() };
             }
         }


### PR DESCRIPTION
- closes #346 , closes #363 

주요 변경점입니다.
- prod id type인 `Pid`를 만들었습니다.
- `ProcInfo`에 있던 `pid`를 `AtomicI32`로 바꾸고 `Proc`으로 옮겼습니다.
- `Proc`에서 unsafe하게 정의되어 있던 `state()`함수를 `ProcGuard`로 옮겼습니다.
  - `ProcGuard`없이 `state`에 접근하지 않습니다.