### PR TITLE
[Closes #402] Use `WeakPin<*mut T>` to reduce unsafe

### DIFF
--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -53,6 +53,7 @@
 #![feature(generic_associated_types)]
 #![feature(unsafe_block_in_unsafe_fn)]
 #![feature(variant_count)]
+#![feature(arbitrary_self_types)]
 
 mod arena;
 mod bio;
@@ -68,6 +69,7 @@ mod list;
 mod memlayout;
 mod page;
 mod param;
+mod pincell;
 mod pipe;
 mod plic;
 mod poweroff;

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -47,9 +47,9 @@ impl ListEntry {
         this.next = next;
     }
 
-    pub fn init(self: Pin<&mut Self>) {
+    pub fn init(mut self: Pin<&mut Self>) {
         // Safe since we don't move the inner data and don't leak the mutable reference.
-        let weak = WeakPin::from_pin(self.as_ref());
+        let weak = WeakPin::from_pin(self.as_mut());
         let this = unsafe { self.get_unchecked_mut() };
         this.next = weak;
         this.prev = weak;
@@ -64,10 +64,10 @@ impl ListEntry {
     }
 
     /// `e` <-> `this`
-    pub fn append(self: Pin<&mut Self>, e: Pin<&mut Self>) {
+    pub fn append(mut self: Pin<&mut Self>, mut e: Pin<&mut Self>) {
         // Safe since we don't move the inner data and don't leak the mutable reference.
-        let this = WeakPin::from_pin(self.as_ref());
-        let elem = WeakPin::from_pin(e.as_ref());
+        let this = WeakPin::from_pin(self.as_mut());
+        let elem = WeakPin::from_pin(e.as_mut());
 
         elem.set_next(this);
         elem.set_prev(this.prev);
@@ -76,10 +76,10 @@ impl ListEntry {
     }
 
     /// `this` <-> `e`
-    pub fn prepend(self: Pin<&mut Self>, e: Pin<&mut Self>) {
+    pub fn prepend(mut self: Pin<&mut Self>, mut e: Pin<&mut Self>) {
         // Safe since we don't move the inner data and don't leak the mutable reference.
-        let this = WeakPin::from_pin(self.as_ref());
-        let elem = WeakPin::from_pin(e.as_ref());
+        let this = WeakPin::from_pin(self.as_mut());
+        let elem = WeakPin::from_pin(e.as_mut());
 
         elem.set_next(this.next);
         elem.set_prev(this);
@@ -87,13 +87,13 @@ impl ListEntry {
         elem.prev.set_next(elem);
     }
 
-    pub fn is_empty(self: Pin<&Self>) -> bool {
-        let this = WeakPin::from_pin(self);
-        this.next == this
-    }
+    // pub fn is_empty(self: Pin<&Self>) -> bool {
+    //     let this = WeakPin::from_pin(self);
+    //     this.next == this
+    // }
 
-    pub fn remove(self: Pin<&mut Self>) {
-        let this = WeakPin::from_pin(self.as_ref());
+    pub fn remove(mut self: Pin<&mut Self>) {
+        let this = WeakPin::from_pin(self.as_mut());
         this.prev.set_next(this.next);
         this.next.set_prev(this.prev);
         self.init();

--- a/kernel-rs/src/pincell.rs
+++ b/kernel-rs/src/pincell.rs
@@ -23,10 +23,10 @@ impl<T> WeakPin<*mut T> {
         }
     }
 
-    /// Returns a `WeakPin<*mut T>` from a `Pin<&T>`.
+    /// Returns a `WeakPin<*mut T>` from a `Pin<&mut T>`.
     /// This is the only safe way to obtain a `WeakPin<*mut T>`.
     // TODO: Change it into `Pin::into_weak()` instead?
-    pub fn from_pin(pin: Pin<&T>) -> Self {
+    pub fn from_pin(pin: Pin<&mut T>) -> Self {
         Self {
             ptr: pin.as_ref().get_ref() as *const _ as *mut _,
         }

--- a/kernel-rs/src/pincell.rs
+++ b/kernel-rs/src/pincell.rs
@@ -4,20 +4,67 @@ use core::pin::Pin;
 use core::ptr;
 use pin_project::pin_project;
 
-/// `WeakPin<*mut T>`.
-/// A shared reference that points to a pinned data and acts like a `*mut T`.
-/// However, while dereferencing a `*mut T` is always unsafe, even when only immutably dereferencing it,
-/// we can safely immutably dereference the value and also mutate the value (but only with a restricted API)
-/// using `WeakPin<*mut T>`s, thanks to the `Pin` contract.
-/// Also, note that the `WeakPin<*mut T>` implements the `Clone`, `Copy`, and `PartialEq` trait.
+/// `WeakPin<*const T>` or `WeakPin<*mut T>`.
+///
+/// A shared reference that points to a pinned data and acts like a `*const T` or `*mut T`.
+/// However, while dereferencing a `const T`/`*mut T` is always unsafe (even when only immutably dereferencing it),
+/// we can safely immutably dereference `WeakPin`s, and especially for `WeakPin<*mut T>`,
+/// we can also mutate the value (but only with a restricted API), thanks to the `Pin` contract.
+///
+/// Also, note that the `WeakPin` implements the `Clone`, `Copy`, and `PartialEq` trait.
 #[derive(Clone, Copy)]
 pub struct WeakPin<P: Pointer> {
     ptr: P,
 }
 
+impl<T> WeakPin<*const T> {
+    /// Uninitialized `WeakPin<*const T>`. Never call methods with it.
+    pub const unsafe fn zero_ref() -> Self {
+        Self { ptr: ptr::null() }
+    }
+
+    /// Returns a `WeakPin<*const T>` from a `Pin<&T>`.
+    /// This is the only safe way to obtain a `WeakPin<*const T>`.
+    // TODO: Change it into `Pin::into_weak()` instead?
+    pub fn from_pin_ref(pin: Pin<&T>) -> Self {
+        Self {
+            ptr: pin.get_ref() as *const _,
+        }
+    }
+
+    pub fn get_ref(&self) -> &T {
+        // Safe because of the drop guarantee.
+        self.deref()
+    }
+
+    pub fn clone(&self) -> Self {
+        Self { ptr: self.ptr }
+    }
+}
+
+impl<T> Deref for WeakPin<*const T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        // Safe because of the drop guarantee.
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<T> PartialEq for WeakPin<*const T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ptr == other.ptr
+    }
+}
+
+impl<T> PartialEq<WeakPin<*mut T>> for WeakPin<*const T> {
+    fn eq(&self, other: &WeakPin<*mut T>) -> bool {
+        self.ptr == other.ptr as *const T
+    }
+}
+
 impl<T> WeakPin<*mut T> {
-    /// Uninitialized `WeakPin<T>`. Never call methods with it.
-    pub const unsafe fn zero() -> Self {
+    /// Uninitialized `WeakPin<*mut T>`. Never call methods with it.
+    pub const unsafe fn zero_mut() -> Self {
         Self {
             ptr: ptr::null_mut(),
         }
@@ -26,7 +73,7 @@ impl<T> WeakPin<*mut T> {
     /// Returns a `WeakPin<*mut T>` from a `Pin<&mut T>`.
     /// This is the only safe way to obtain a `WeakPin<*mut T>`.
     // TODO: Change it into `Pin::into_weak()` instead?
-    pub fn from_pin(pin: Pin<&mut T>) -> Self {
+    pub fn from_pin_mut(pin: Pin<&mut T>) -> Self {
         Self {
             ptr: pin.as_ref().get_ref() as *const _ as *mut _,
         }
@@ -63,6 +110,12 @@ impl<T> Deref for WeakPin<*mut T> {
 impl<T> PartialEq for WeakPin<*mut T> {
     fn eq(&self, other: &Self) -> bool {
         self.ptr == other.ptr
+    }
+}
+
+impl<T> PartialEq<WeakPin<*const T>> for WeakPin<*mut T> {
+    fn eq(&self, other: &WeakPin<*const T>) -> bool {
+        self.ptr as *const T == other.ptr
     }
 }
 

--- a/kernel-rs/src/pincell.rs
+++ b/kernel-rs/src/pincell.rs
@@ -33,6 +33,13 @@ impl<T> WeakPin<*const T> {
         }
     }
 
+    /// # Safety
+    ///
+    /// Only use if `T` is pinned.
+    pub unsafe fn from_raw(ptr: *const T) -> Self {
+        Self { ptr }
+    }
+
     pub fn get_ref(&self) -> &T {
         // Safe because of the drop guarantee.
         self.deref()

--- a/kernel-rs/src/pincell.rs
+++ b/kernel-rs/src/pincell.rs
@@ -1,0 +1,92 @@
+use core::fmt::Pointer;
+use core::ops::Deref;
+use core::pin::Pin;
+use core::ptr;
+use pin_project::pin_project;
+
+/// `WeakPin<*mut T>`.
+/// A shared reference that points to a pinned data and acts like a `*mut T`.
+/// However, while dereferencing a `*mut T` is always unsafe, even when only immutably dereferencing it,
+/// we can safely immutably dereference the value and also mutate the value (but only with a restricted API)
+/// using `WeakPin<*mut T>`s, thanks to the `Pin` contract.
+/// Also, note that the `WeakPin<*mut T>` implements the `Clone`, `Copy`, and `PartialEq` trait.
+#[derive(Clone, Copy)]
+pub struct WeakPin<P: Pointer> {
+    ptr: P,
+}
+
+impl<T> WeakPin<*mut T> {
+    /// Uninitialized `WeakPin<T>`. Never call methods with it.
+    pub const unsafe fn zero() -> Self {
+        Self {
+            ptr: ptr::null_mut(),
+        }
+    }
+
+    /// Returns a `WeakPin<*mut T>` from a `Pin<&T>`.
+    /// This is the only safe way to obtain a `WeakPin<*mut T>`.
+    // TODO: Change it into `Pin::into_weak()` instead?
+    pub fn from_pin(pin: Pin<&T>) -> Self {
+        Self {
+            ptr: pin.as_ref().get_ref() as *const _ as *mut _,
+        }
+    }
+
+    pub fn get_ref(&self) -> &T {
+        // Safe because of the drop guarantee.
+        self.deref()
+    }
+
+    /// Upgrades it into `Pin<&mut T>`.
+    pub unsafe fn get_unchecked_pin_mut(&mut self) -> Pin<&mut T> {
+        unsafe { Pin::new_unchecked(&mut *self.ptr) }
+    }
+
+    /// Upgrades it into `&mut T`.
+    pub unsafe fn get_unchecked_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.ptr }
+    }
+
+    pub fn clone(&self) -> Self {
+        Self { ptr: self.ptr }
+    }
+}
+
+impl<T> Deref for WeakPin<*mut T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        // Safe because of the drop guarantee.
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<T> PartialEq for WeakPin<*mut T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ptr == other.ptr
+    }
+}
+
+#[pin_project]
+pub struct PinCell<T> {
+    #[pin]
+    data: T,
+}
+
+/// A cell that wraps data that should be pinned.
+/// This wrapper can have one `Pin<&mut T>` AND/OR multiple shared `WeakPin<*mut T>`.
+impl<T> PinCell<T> {
+    pub const unsafe fn new_unchecked(data: T) -> Self {
+        Self { data }
+    }
+
+    // TODO: &mut self? &self?
+    pub fn get_mut_pin(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().data
+    }
+
+    pub fn get_weak_pin(&self) -> WeakPin<*mut T> {
+        WeakPin {
+            ptr: &self.data as *const _ as *mut _,
+        }
+    }
+}


### PR DESCRIPTION
* `WeakPin<*mut T>`라는 실험적인 type을 만들어봤습니다.
  * `*mut T`와 많이 비슷하지만, `*mut T`보다 더 safe하게 사용할 수 있습니다.
  * `Pin<&mut T>`와 비슷하게 제한적인 API만을 사용해 `T`를 mutate할 수 있지만, `Pin<&mut T>`보다도 사용할 수 있는 API가 더 제한적입니다.
  * 더 자세한 내용은 https://docs.google.com/document/d/1CmlScyuRpprcw7bLL4GGdsPCGq_SfiUsGimFhKAjv0s/edit# 을 참고하면 좋을 것 같습니다.
    * 오류나 지적사항을 적극적으로 말씀해주시면 감사하겠습니다. 또, 가독성이 너무 안좋으면 말씀해주세요.
* `WeakPin<*mut T>`를 이용해서 list.rs에 있던 상당수의 unsafe부분을 제거했습니다.
  * 비슷한걸 `&T`나 `Pin<&mut T>`로 하려면 lifetime 표시 문제때문에 힘든 것 같습니다. (현재 rv6의 arena가 `'static` lifetime을 가지고 있긴 하지만, 이건 arena의 특수성때문에 그런 것이고, 일반적으로 intrusive linked list은 `ListEntry`의 lifetime을 compile time에 표현할 수 없습니다.)
  * 다만, `WeakPin<*mut T>`는 intrusive linked list보다는 `Proc::parent` field를 다룰 때 더 유용하게 사용할 수 있을 것 같습니다. (애초에, 과거의 `ListEntry`가 `*mut ListEntry`를 외부로 노출시키지 않았던 것처럼, 지금의 `ListEntry`도 `WeakPin<*mut T>`를 외부로 노출시키지 않습니다.)