### PR TITLE
[Closes #398] use &mut CurrentProc, deref_data from CurrentProc

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -92,7 +92,12 @@ impl ProgHdr {
 }
 
 impl Kernel {
-    pub fn exec(&self, path: &Path, args: &[Page], proc: &CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn exec(
+        &self,
+        path: &Path,
+        args: &[Page],
+        proc: &mut CurrentProc<'_>,
+    ) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -111,11 +111,13 @@ impl File {
                 drop(ip);
                 ret
             }
-            FileType::Device { major, .. } => kernel()
-                .devsw
-                .get(*major as usize)
-                .and_then(|dev| Some(unsafe { dev.read?(addr, n) } as usize))
-                .ok_or(()),
+            FileType::Device { major, .. } => {
+                kernel()
+                    .devsw
+                    .get(*major as usize)
+                    .and_then(|dev| Some(unsafe { dev.read?(addr, n) } as usize))
+                    .ok_or(())
+            }
             FileType::None => panic!("File::read"),
         }
     }
@@ -172,11 +174,13 @@ impl File {
                 }
                 Ok(n as usize)
             }
-            FileType::Device { major, .. } => kernel()
-                .devsw
-                .get(*major as usize)
-                .and_then(|dev| Some(unsafe { dev.write?(addr, n) } as usize))
-                .ok_or(()),
+            FileType::Device { major, .. } => {
+                kernel()
+                    .devsw
+                    .get(*major as usize)
+                    .and_then(|dev| Some(unsafe { dev.write?(addr, n) } as usize))
+                    .ok_or(())
+            }
             FileType::None => panic!("File::read"),
         }
     }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -111,13 +111,11 @@ impl File {
                 drop(ip);
                 ret
             }
-            FileType::Device { major, .. } => {
-                kernel()
-                    .devsw
-                    .get(*major as usize)
-                    .and_then(|dev| Some(unsafe { dev.read?(addr, n) } as usize))
-                    .ok_or(())
-            }
+            FileType::Device { major, .. } => kernel()
+                .devsw
+                .get(*major as usize)
+                .and_then(|dev| Some(unsafe { dev.read?(addr, n) } as usize))
+                .ok_or(()),
             FileType::None => panic!("File::read"),
         }
     }
@@ -174,13 +172,11 @@ impl File {
                 }
                 Ok(n as usize)
             }
-            FileType::Device { major, .. } => {
-                kernel()
-                    .devsw
-                    .get(*major as usize)
-                    .and_then(|dev| Some(unsafe { dev.write?(addr, n) } as usize))
-                    .ok_or(())
-            }
+            FileType::Device { major, .. } => kernel()
+                .devsw
+                .get(*major as usize)
+                .and_then(|dev| Some(unsafe { dev.write?(addr, n) } as usize))
+                .ok_or(()),
             FileType::None => panic!("File::read"),
         }
     }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -69,7 +69,7 @@ impl File {
 
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
-    pub unsafe fn stat(&self, addr: UVAddr, proc: &CurrentProc<'_>) -> Result<(), ()> {
+    pub unsafe fn stat(&self, addr: UVAddr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
         match &self.typ {
             FileType::Inode { ip, .. } | FileType::Device { ip, .. } => {
                 let mut st = ip.stat();
@@ -89,7 +89,12 @@ impl File {
 
     /// Read from file self.
     /// addr is a user virtual address.
-    pub unsafe fn read(&self, addr: UVAddr, n: i32, proc: &CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn read(
+        &self,
+        addr: UVAddr,
+        n: i32,
+        proc: &mut CurrentProc<'_>,
+    ) -> Result<usize, ()> {
         if !self.readable {
             return Err(());
         }
@@ -119,7 +124,12 @@ impl File {
 
     /// Write to file self.
     /// addr is a user virtual address.
-    pub unsafe fn write(&self, addr: UVAddr, n: i32, proc: &CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn write(
+        &self,
+        addr: UVAddr,
+        n: i32,
+        proc: &mut CurrentProc<'_>,
+    ) -> Result<usize, ()> {
         if !self.writable {
             return Err(());
         }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -420,7 +420,7 @@ impl InodeGuard<'_> {
         dst: UVAddr,
         off: u32,
         n: u32,
-        proc: &CurrentProc<'_>,
+        proc: &mut CurrentProc<'_>,
     ) -> Result<usize, ()> {
         self.read_internal(off, n, |off, src| {
             proc.deref_mut_data()
@@ -520,7 +520,7 @@ impl InodeGuard<'_> {
         src: UVAddr,
         off: u32,
         n: u32,
-        proc: &CurrentProc<'_>,
+        proc: &mut CurrentProc<'_>,
         tx: &FsTransaction<'_>,
     ) -> Result<usize, ()> {
         self.write_internal(

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -390,7 +390,7 @@ impl<'p> CurrentProc<'p> {
     }
 
     pub fn deref_mut_data(&mut self) -> &mut ProcData {
-        // Safety: Only current proc uses ProcData.
+        // Safety: Only `CurrentProc` can use `ProcData` without lock.
         unsafe { &mut *self.data.get() }
     }
 }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -423,7 +423,7 @@ impl ProcGuard {
 
     #[allow(clippy::mut_from_ref)]
     pub fn deref_mut_data(&self) -> &mut ProcData {
-        // Safety: Only current proc uses ProcData.
+        // Safety: It is safe to access `ProcData` when lock is held.
         unsafe { &mut *self.data.get() }
     }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -684,7 +684,7 @@ impl ProcessSystem {
             let _ = p
                 .parent
                 .write(SpinlockProtected::new(&this.wait_lock, ptr::null_mut()));
-                unsafe { &mut *p.data.get() }.kstack = kstack(i);
+            unsafe { &mut *p.data.get() }.kstack = kstack(i);
         }
     }
 

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -205,10 +205,12 @@ impl Kernel {
                 };
                 FileType::Device { ip, major }
             }
-            _ => FileType::Inode {
-                ip,
-                off: UnsafeCell::new(0),
-            },
+            _ => {
+                FileType::Inode {
+                    ip,
+                    off: UnsafeCell::new(0),
+                }
+            }
         };
 
         let f = self.ftable.alloc_file(

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -205,12 +205,10 @@ impl Kernel {
                 };
                 FileType::Device { ip, major }
             }
-            _ => {
-                FileType::Inode {
-                    ip,
-                    off: UnsafeCell::new(0),
-                }
-            }
+            _ => FileType::Inode {
+                ip,
+                off: UnsafeCell::new(0),
+            },
         };
 
         let f = self.ftable.alloc_file(

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
-    pub unsafe fn sys_exit(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn sys_exit(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         unsafe { self.procs.exit_current(n, proc) };
     }
@@ -19,20 +19,20 @@ impl Kernel {
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_fork(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn sys_fork(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         Ok(unsafe { self.procs.fork(proc) }? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_wait(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
+    pub unsafe fn sys_wait(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let p = argaddr(0, proc)?;
         Ok(unsafe { self.procs.wait(p.into(), proc) }? as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
-    pub fn sys_sbrk(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_sbrk(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
         proc.deref_mut_data().memory.resize(n)
     }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn usertrap() {
     // since we're now in the kernel.
     unsafe { w_stvec(kernelvec as _) };
 
-    let proc = &kernel().current_proc().expect("No current proc");
+    let proc = &mut kernel().current_proc().expect("No current proc");
 
     // Save user program counter.
     proc.deref_mut_data().trap_frame_mut().epc = r_sepc();
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn usertrap() {
 }
 
 /// Return to user space.
-pub unsafe fn usertrapret(proc: &CurrentProc<'_>) {
+pub unsafe fn usertrapret(proc: &mut CurrentProc<'_>) {
     // We're about to switch the destination of traps from
     // kerneltrap() to usertrap(), so turn off interrupts until
     // we're back in user space, where usertrap() is correct.


### PR DESCRIPTION
- closes #398 

sync-up에서 논의했던 대로 `CurrentProc`을 사용하면, 관련 함수에 `CurrentProc`을 전달할때 move되는 문제가 있기 때문에 `deref_mut_data`를 사용하는 곳에 `&mut CurrentProc`을 전달했습니다.
- 기존에 `Proc`에 있던 `deref_mut_data`를 `CurrentProc`의 함수로 이동
- `ProcGuard`에 `deref_mut_data`함수 추가