### PR TITLE
[Closes #408] Use only one `Pin<&mut Kernel>` during `kernel_main()`

### DIFF
--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -252,7 +252,6 @@ pub unsafe fn kernel_main() -> ! {
         kernel.file_system.disk.get_mut().init();
 
         // First user process.
-        // Temporarily create one more `Pin<&mut Kernel>`, just to initialize the first user process.
         unsafe { procs.user_proc_init() };
         STARTED.store(true, Ordering::Release);
     } else {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -433,7 +433,7 @@ impl ProcGuard {
 
         let info = self.deref_mut_info();
         info.pid = pid;
-        assert!(info.state == Procstate::UNUSED);
+        debug_assert!(info.state == Procstate::UNUSED);
         info.state = Procstate::USED;
     }
 
@@ -660,18 +660,6 @@ impl Proc {
             data: UnsafeCell::new(ProcData::new()),
             child_waitchannel: WaitChannel::new(),
             killed: AtomicBool::new(false),
-        }
-    }
-
-    /// Initializes a `Proc`, using the given `pid`, `trap_frame`, and `memory`.
-    ///
-    /// # Safety
-    ///
-    /// Only use for `Proc`s whose state is `UNUSED`.
-    /// Otherwise, the assertion will fail.
-    unsafe fn init(&mut self, pid: Pid, trap_frame: Page, memory: UserMemory) {
-        unsafe {
-            ProcGuard::from_raw(self).init(pid, trap_frame, memory);
         }
     }
 


### PR DESCRIPTION
Closes #408

~~* `ProcessSystem`을 initialize하는 함수를 2개에서 3개로 늘렸습니다. 이유는 #408 과 같습니다.~~
~~* 이러면 `Pin<&'static mut ProcessSystem>`은 제일 마지막 함수에서만 필요하므로 mutable reference가 복수개 존재하는 문제는 생기지 않습니다. (이를 나타내기 위해, 일부러 `kernel`이라는 지역변수를 추가했습니다.)~~
~~* **다만, 이게 좋은 디자인인지는 잘 모르겠습니다.** xv6는 2개의 함수만으로 process system을 initialize하는데, 이러면 rv6에서는 3개가 되기 때문입니다. 차라리 `ProcessSystem::user_proc_init()`과 `ProcessSystem::init_proc_parent()`를 합친 후 새로운 이름을 붙이는게 나을지도 모르겠습니다.~~

* 기존에는, ProcessSystem::initial_proc을 user_proc_init()에서 write합니다.
* 변경 후에는,ProcessSystem::initial_proc을 init()에서 write하고 user_proc_init()에서는 read만 합니다.
  * 편의를 위해, ProcessSystem의 initial_proc은 process_pool의 첫번째 index에 저장되도록 했습니다. 이러면 굳이 alloc()을 init()에서 할 필요가 없습니다. (원하시지 않으시면, 이 부분은 alloc()을 사용하도록 변경 가능합니다.)

이렇게 하면 kernel_main()의 scope 내에서 Pin<&mut Kernel>이 한개만 존재하도록 할 수 있습니다. 그러면서, ProcessSystem의 초기화 과정은 function 2개로 충분합니다.