### PR TITLE
[Closes #410] Add `PinnedArray`

### DIFF
--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -120,7 +120,7 @@ pub struct MruEntry<T> {
 #[pin_project]
 pub struct MruArena<T, const CAPACITY: usize> {
     #[pin]
-    entries: [MruEntry<T>;CAPACITY],
+    entries: [MruEntry<T>; CAPACITY],
     #[pin]
     head: ListEntry,
 }

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -7,7 +7,7 @@ use core::ptr::{self, NonNull};
 use pin_project::pin_project;
 
 use crate::list::*;
-use crate::pinned_array::IterMut;
+use crate::pinned_array::IterPinMut;
 use crate::spinlock::{Spinlock, SpinlockGuard};
 
 /// A homogeneous memory allocator, equipped with the box type representing an allocation.
@@ -304,7 +304,8 @@ impl<T, const CAPACITY: usize> MruArena<T, CAPACITY> {
         let mut this = self.project();
 
         this.head.as_mut().init();
-        for entry in IterMut::from(this.entries) {
+        let iter: IterPinMut<'_, MruEntry<T>> = this.entries.into();
+        for entry in iter {
             this.head.as_mut().prepend(entry.project().list_entry);
         }
     }

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -68,6 +68,7 @@ mod list;
 mod memlayout;
 mod page;
 mod param;
+mod pinned_array;
 mod pipe;
 mod plic;
 mod poweroff;

--- a/kernel-rs/src/pinned_array.rs
+++ b/kernel-rs/src/pinned_array.rs
@@ -1,10 +1,12 @@
 use core::ops::Index;
+use core::slice;
 use core::pin::Pin;
 
 /// An array that holds pinned data, and hence, should also be pinned.
-/// From `&PinnedArray<T, N>`, you can get `&T` such as by `pinned_array[index]`.
-/// From `Pin<&mut Array<T, N>>`, you can get `Pin<&mut T>` such as by `pinned_array.index_mut(index)`.
+/// From `&PinnedArray<T, N>`, you can get `&T` such as by `pinned_array[index]` or iterating.
+/// From `Pin<&mut Array<T, N>>`, you can get `Pin<&mut T>` such as by `pinned_array.index_mut(index)` or iterating.
 /// However, there is no way to get an `&mut T` to the inner data.
+#[derive(Debug)]
 pub struct PinnedArray<T, const N: usize> {
     arr: [T; N],
 }
@@ -18,6 +20,10 @@ impl<T, const N: usize> PinnedArray<T, N> {
         // Safe since we're just projecting from `Pin<&mut PinnedArray<T, N>>` to one of its elements `Pin<&mut T>`.
         unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().arr[index]) }
     }
+
+    pub fn len(&self) -> usize {
+        self.arr.len()
+    }
 }
 
 impl<T, const N: usize> Index<usize> for PinnedArray<T, N> {
@@ -25,5 +31,39 @@ impl<T, const N: usize> Index<usize> for PinnedArray<T, N> {
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.arr[index]
+    }
+}
+
+impl<'s, T, const N: usize> IntoIterator for &'s PinnedArray<T, N> {
+    type Item = &'s T;
+    type IntoIter = slice::Iter<'s, T>;
+
+    fn into_iter(self) -> slice::Iter<'s, T> {
+        self.arr.iter()
+    }
+}
+
+impl<'s, T, const N: usize> IntoIterator for Pin<&'s mut PinnedArray<T, N>> {
+    type Item = Pin<&'s mut T>;
+    type IntoIter = IterMut<'s, T>;
+
+    fn into_iter(self) -> IterMut<'s, T> {
+        IterMut {
+            iter: unsafe { self.get_unchecked_mut() }.arr.iter_mut(),
+        }
+    }
+}
+
+/// An iterator for `PinnedArray` that gives pinned mutable references.
+#[derive(Debug)]
+pub struct IterMut<'s, T> {
+    iter: slice::IterMut<'s, T>,
+}
+
+impl<'s, T> Iterator for IterMut<'s, T> {
+    type Item = Pin<&'s mut T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|p| unsafe { Pin::new_unchecked(p) })
     }
 }

--- a/kernel-rs/src/pinned_array.rs
+++ b/kernel-rs/src/pinned_array.rs
@@ -1,63 +1,22 @@
-use core::ops::Index;
 use core::pin::Pin;
 use core::slice;
 
-/// An array that holds pinned data, and hence, should also be pinned.
-/// From `&PinnedArray<T, N>`, you can get `&T` such as by `pinned_array[index]` or iterating.
-/// From `Pin<&mut Array<T, N>>`, you can get `Pin<&mut T>` such as by `pinned_array.index_mut(index)` or iterating.
-/// However, there is no way to get an `&mut T` to the inner data.
-#[derive(Debug)]
-pub struct PinnedArray<T, const N: usize> {
-    arr: [T; N],
+pub fn index_mut<T, const N: usize>(arr: Pin<&mut [T; N]>, index: usize) -> Pin<&mut T> {
+    unsafe { Pin::new_unchecked(&mut arr.get_unchecked_mut()[index]) }
 }
 
-impl<T, const N: usize> PinnedArray<T, N> {
-    pub const fn new(arr: [T; N]) -> Self {
-        Self { arr }
-    }
-
-    pub fn index_mut(self: Pin<&mut Self>, index: usize) -> Pin<&mut T> {
-        // Safe since we're just projecting from `Pin<&mut PinnedArray<T, N>>` to one of its elements `Pin<&mut T>`.
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().arr[index]) }
-    }
-
-    pub fn len(&self) -> usize {
-        self.arr.len()
-    }
-}
-
-impl<T, const N: usize> Index<usize> for PinnedArray<T, N> {
-    type Output = T;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.arr[index]
-    }
-}
-
-impl<'s, T, const N: usize> IntoIterator for &'s PinnedArray<T, N> {
-    type IntoIter = slice::Iter<'s, T>;
-    type Item = &'s T;
-
-    fn into_iter(self) -> slice::Iter<'s, T> {
-        self.arr.iter()
-    }
-}
-
-impl<'s, T, const N: usize> IntoIterator for Pin<&'s mut PinnedArray<T, N>> {
-    type IntoIter = IterMut<'s, T>;
-    type Item = Pin<&'s mut T>;
-
-    fn into_iter(self) -> IterMut<'s, T> {
-        IterMut {
-            iter: unsafe { self.get_unchecked_mut() }.arr.iter_mut(),
-        }
-    }
-}
-
-/// An iterator for `PinnedArray` that gives pinned mutable references.
+/// An iterator that gives pinned mutable references to elements of a pinned array.
 #[derive(Debug)]
 pub struct IterMut<'s, T> {
     iter: slice::IterMut<'s, T>,
+}
+
+impl<'s, T, const N: usize> From<Pin<&'s mut [T; N]>> for IterMut<'s, T> {
+    fn from(arr: Pin<&'s mut [T; N]>) -> Self {
+        Self {
+            iter: unsafe { arr.get_unchecked_mut() }.into_iter()
+        }
+    }
 }
 
 impl<'s, T> Iterator for IterMut<'s, T> {

--- a/kernel-rs/src/pinned_array.rs
+++ b/kernel-rs/src/pinned_array.rs
@@ -2,6 +2,7 @@ use core::pin::Pin;
 use core::slice;
 
 pub fn index_mut<T, const N: usize>(arr: Pin<&mut [T; N]>, index: usize) -> Pin<&mut T> {
+    // Safe since we're just projecting from a pinned array to a pinned mutable reference of its elements.
     unsafe { Pin::new_unchecked(&mut arr.get_unchecked_mut()[index]) }
 }
 
@@ -14,6 +15,7 @@ pub struct IterMut<'s, T> {
 impl<'s, T, const N: usize> From<Pin<&'s mut [T; N]>> for IterMut<'s, T> {
     fn from(arr: Pin<&'s mut [T; N]>) -> Self {
         Self {
+            // Safe since we only provide pinned mutable references to the outside.
             iter: unsafe { arr.get_unchecked_mut() }.iter_mut(),
         }
     }
@@ -23,6 +25,7 @@ impl<'s, T> Iterator for IterMut<'s, T> {
     type Item = Pin<&'s mut T>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // Safe since this iterator just projects from a pinned array to a pinned mutable reference of its elements.
         self.iter.next().map(|p| unsafe { Pin::new_unchecked(p) })
     }
 }

--- a/kernel-rs/src/pinned_array.rs
+++ b/kernel-rs/src/pinned_array.rs
@@ -14,7 +14,7 @@ pub struct IterMut<'s, T> {
 impl<'s, T, const N: usize> From<Pin<&'s mut [T; N]>> for IterMut<'s, T> {
     fn from(arr: Pin<&'s mut [T; N]>) -> Self {
         Self {
-            iter: unsafe { arr.get_unchecked_mut() }.into_iter()
+            iter: unsafe { arr.get_unchecked_mut() }.iter_mut(),
         }
     }
 }

--- a/kernel-rs/src/pinned_array.rs
+++ b/kernel-rs/src/pinned_array.rs
@@ -1,18 +1,25 @@
 use core::pin::Pin;
 use core::slice;
 
-pub fn index_mut<T, const N: usize>(arr: Pin<&mut [T; N]>, index: usize) -> Pin<&mut T> {
-    // Safe since we're just projecting from a pinned array to a pinned mutable reference of its elements.
-    unsafe { Pin::new_unchecked(&mut arr.get_unchecked_mut()[index]) }
+/// Trys to return a pinned mutable reference of the array's element at index `index`.
+/// Returns `Some(pin_mut)` if index is not out of bounds.
+/// Otherwise, returns `None`.
+pub fn get_pin_mut<T, const N: usize>(arr: Pin<&mut [T; N]>, index: usize) -> Option<Pin<&mut T>> {
+    if index < N {
+        // Safe since we're just projecting from a pinned array to a pinned mutable reference of its elements.
+        Some(unsafe { Pin::new_unchecked(arr.get_unchecked_mut().get_unchecked_mut(index)) })
+    } else {
+        None
+    }
 }
 
 /// An iterator that gives pinned mutable references to elements of a pinned array.
 #[derive(Debug)]
-pub struct IterMut<'s, T> {
+pub struct IterPinMut<'s, T> {
     iter: slice::IterMut<'s, T>,
 }
 
-impl<'s, T, const N: usize> From<Pin<&'s mut [T; N]>> for IterMut<'s, T> {
+impl<'s, T, const N: usize> From<Pin<&'s mut [T; N]>> for IterPinMut<'s, T> {
     fn from(arr: Pin<&'s mut [T; N]>) -> Self {
         Self {
             // Safe since we only provide pinned mutable references to the outside.
@@ -21,7 +28,7 @@ impl<'s, T, const N: usize> From<Pin<&'s mut [T; N]>> for IterMut<'s, T> {
     }
 }
 
-impl<'s, T> Iterator for IterMut<'s, T> {
+impl<'s, T> Iterator for IterPinMut<'s, T> {
     type Item = Pin<&'s mut T>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/kernel-rs/src/pinned_array.rs
+++ b/kernel-rs/src/pinned_array.rs
@@ -1,6 +1,6 @@
 use core::ops::Index;
-use core::slice;
 use core::pin::Pin;
+use core::slice;
 
 /// An array that holds pinned data, and hence, should also be pinned.
 /// From `&PinnedArray<T, N>`, you can get `&T` such as by `pinned_array[index]` or iterating.
@@ -35,8 +35,8 @@ impl<T, const N: usize> Index<usize> for PinnedArray<T, N> {
 }
 
 impl<'s, T, const N: usize> IntoIterator for &'s PinnedArray<T, N> {
-    type Item = &'s T;
     type IntoIter = slice::Iter<'s, T>;
+    type Item = &'s T;
 
     fn into_iter(self) -> slice::Iter<'s, T> {
         self.arr.iter()
@@ -44,8 +44,8 @@ impl<'s, T, const N: usize> IntoIterator for &'s PinnedArray<T, N> {
 }
 
 impl<'s, T, const N: usize> IntoIterator for Pin<&'s mut PinnedArray<T, N>> {
-    type Item = Pin<&'s mut T>;
     type IntoIter = IterMut<'s, T>;
+    type Item = Pin<&'s mut T>;
 
     fn into_iter(self) -> IterMut<'s, T> {
         IterMut {

--- a/kernel-rs/src/pinned_array.rs
+++ b/kernel-rs/src/pinned_array.rs
@@ -1,0 +1,29 @@
+use core::ops::Index;
+use core::pin::Pin;
+
+/// An array that holds pinned data, and hence, should also be pinned.
+/// From `&PinnedArray<T, N>`, you can get `&T` such as by `pinned_array[index]`.
+/// From `Pin<&mut Array<T, N>>`, you can get `Pin<&mut T>` such as by `pinned_array.index_mut(index)`.
+/// However, there is no way to get an `&mut T` to the inner data.
+pub struct PinnedArray<T, const N: usize> {
+    arr: [T; N],
+}
+
+impl<T, const N: usize> PinnedArray<T, N> {
+    pub const fn new(arr: [T; N]) -> Self {
+        Self { arr }
+    }
+
+    pub fn index_mut(self: Pin<&mut Self>, index: usize) -> Pin<&mut T> {
+        // Safe since we're just projecting from `Pin<&mut PinnedArray<T, N>>` to one of its elements `Pin<&mut T>`.
+        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().arr[index]) }
+    }
+}
+
+impl<T, const N: usize> Index<usize> for PinnedArray<T, N> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.arr[index]
+    }
+}

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -665,6 +665,7 @@ impl Deref for Proc {
 #[pin_project]
 pub struct ProcessSystem {
     nextpid: AtomicI32,
+    #[pin]
     process_pool: [Proc; NPROC],
     initial_proc: *const Proc,
 
@@ -689,7 +690,6 @@ impl ProcessSystem {
     pub fn init(self: Pin<&'static mut Self>) {
         // Safe since we don't move the `ProcessSystem`.
         let this = unsafe { self.get_unchecked_mut() };
-        // TODO: Use pinned iteration instead.
         for (i, p) in this.process_pool.iter_mut().enumerate() {
             let _ = p
                 .parent

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -689,7 +689,7 @@ impl ProcessSystem {
     pub fn init(self: Pin<&'static mut Self>) {
         // Safe since we don't move the `ProcessSystem`.
         let this = unsafe { self.get_unchecked_mut() };
-        // TODO: Use `PinnedArray` instead.
+        // TODO: Use pinned iteration instead.
         for (i, p) in this.process_pool.iter_mut().enumerate() {
             let _ = p
                 .parent

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -689,6 +689,7 @@ impl ProcessSystem {
     pub fn init(self: Pin<&'static mut Self>) {
         // Safe since we don't move the `ProcessSystem`.
         let this = unsafe { self.get_unchecked_mut() };
+        // TODO: Use `PinnedArray` instead.
         for (i, p) in this.process_pool.iter_mut().enumerate() {
             let _ = p
                 .parent


### PR DESCRIPTION
Closes #410 
* `PinnedArray`라는 struct를 추가했습니다.
  * `pin_project`의 경우, struct A가 struct B를 own하고 있다면 `Pin<&mut A>` -> `Pin<&mut B>`로 **safe**하게 넘어가는 방법을 제공합니다.
  * 그러나, `Pin<&mut [A; N]>` -> `Pin<&mut A>`로 넘어가는 방법은 제공하지 않는 것으로 보입니다. 그러므로, 불필요하게 unsafe fn인 `Pin::get_unchecked_mut()`나 `Pin::new_unchecked()`를 사용해서 넘어가야 합니다.
  * `PinnedArray`는 위와 같은 불필요한 unsafe 과정을 type안에 가두고 **safe한 API만 제공**합니다. 또, `Index`, `IntoIterator` trait을 impl하며, 특히 `Pin<&mut PinnedArray<T, N>>`을 iterate하려고 하면 자동으로 `Pin<&mut A>`가 나옵니다.