### PR TITLE
Remove unsafe of functions reading registers

### DIFF
--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -429,7 +429,7 @@ impl ProcGuard {
     unsafe fn sched(&mut self) {
         assert_eq!((*kernel().mycpu()).noff, 1, "sched locks");
         assert_ne!(self.state(), Procstate::RUNNING, "sched running");
-        assert!(!unsafe { intr_get() }, "sched interruptible");
+        assert!(!intr_get(), "sched interruptible");
 
         let interrupt_enabled = unsafe { (*kernel().mycpu()).interrupt_enabled };
         unsafe {
@@ -958,7 +958,7 @@ impl ProcessSystem {
 /// It is safe to call this function with interrupts enabled, but the returned id may not be the
 /// current CPU since the scheduler can move the process to another CPU on time interrupt.
 pub fn cpuid() -> usize {
-    unsafe { r_tp() }
+    r_tp()
 }
 
 /// A user program that calls exec("/init").

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -339,7 +339,7 @@ impl Drop for SpinlockProtectedGuard<'_> {
 /// it takes two pop_off()s to undo two push_off()s.  Also, if interrupts
 /// are initially off, then push_off, pop_off leaves them off.
 pub unsafe fn push_off() {
-    let old = unsafe { intr_get() };
+    let old = intr_get();
     unsafe { intr_off() };
     if unsafe { (*(kernel().mycpu())).noff } == 0 {
         unsafe { (*(kernel().mycpu())).interrupt_enabled = old }
@@ -349,7 +349,7 @@ pub unsafe fn push_off() {
 
 pub unsafe fn pop_off() {
     let mut c: *mut Cpu = kernel().mycpu();
-    assert!(!unsafe { intr_get() }, "pop_off - interruptible");
+    assert!(!intr_get(), "pop_off - interruptible");
     assert!(unsafe { (*c).noff } >= 1, "pop_off");
 
     unsafe { (*c).noff -= 1 };

--- a/kernel-rs/src/start.rs
+++ b/kernel-rs/src/start.rs
@@ -33,7 +33,7 @@ static mut TIMER_SCRATCH: [[usize; NCPU]; 5] = [[0; NCPU]; 5];
 #[no_mangle]
 pub unsafe fn start() {
     // set M Previous Privilege mode to Supervisor, for mret.
-    let mut x = unsafe { Mstatus::read() };
+    let mut x = Mstatus::read();
     x.remove(Mstatus::MPP_MASK);
     x.insert(Mstatus::MPP_S);
     unsafe { x.write() };
@@ -47,7 +47,7 @@ pub unsafe fn start() {
     // delegate all interrupts and exceptions to supervisor mode.
     unsafe { w_medeleg(0xffff) };
     unsafe { w_mideleg(0xffff) };
-    let mut x = unsafe { SIE::read() };
+    let mut x = SIE::read();
     x.insert(SIE::SEIE);
     x.insert(SIE::STIE);
     x.insert(SIE::SSIE);
@@ -70,7 +70,7 @@ pub unsafe fn start() {
 /// which turns them into software interrupts for devintr() in trap.c.
 unsafe fn timerinit() {
     // each CPU has a separate source of timer interrupts.
-    let id = unsafe { r_mhartid() };
+    let id = r_mhartid();
 
     // ask the CLINT for a timer interrupt.
     let interval: usize = 1_000_000; // cycles; about 1/10th second in qemu.
@@ -89,12 +89,12 @@ unsafe fn timerinit() {
     unsafe { w_mtvec(timervec as _) };
 
     // enable machine-mode interrupts.
-    let mut x = unsafe { Mstatus::read() };
+    let mut x = Mstatus::read();
     x.insert(Mstatus::MIE);
     unsafe { x.write() };
 
     // enable machine-mode timer interrupts.
-    let mut y = unsafe { MIE::read() };
+    let mut y = MIE::read();
     y.insert(MIE::MTIE);
     unsafe { y.write() };
 }

--- a/kernel-rs/src/virtio.rs
+++ b/kernel-rs/src/virtio.rs
@@ -99,6 +99,15 @@ bitflags! {
         const F_ANY_LAYOUT = 1 << 27;
         const RING_F_INDIRECT_DESC = 1 << 28;
         const RING_F_EVENT_IDX = 1 << 29;
+
+        const ETC =
+            !Self::BLK_F_RO.bits &
+            !Self::BLK_F_SCSI.bits &
+            !Self::BLK_F_CONFIG_WCE.bits &
+            !Self::BLK_F_MQ.bits &
+            !Self::F_ANY_LAYOUT.bits &
+            !Self::RING_F_INDIRECT_DESC.bits &
+            !Self::RING_F_EVENT_IDX.bits;
     }
 }
 

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -249,19 +249,14 @@ impl Disk {
         MmioRegs::Status.write(status.bits());
 
         // Negotiate features
-        // It is safe because we just erase some bits and write the others back.
-        // Since some feature bits are not defined in VirtIOFeatures, we use
-        // `- (...)` instead of `& !(...)` to keep those bits. Note that `-` is
-        // set difference (https://docs.rs/bitflags/1.2.1/bitflags/#operators).
-        let features =
-            unsafe { VirtIOFeatures::from_bits_unchecked(MmioRegs::DeviceFeatures.read()) }
-                - (VirtIOFeatures::BLK_F_RO
-                    | VirtIOFeatures::BLK_F_SCSI
-                    | VirtIOFeatures::BLK_F_CONFIG_WCE
-                    | VirtIOFeatures::BLK_F_MQ
-                    | VirtIOFeatures::F_ANY_LAYOUT
-                    | VirtIOFeatures::RING_F_EVENT_IDX
-                    | VirtIOFeatures::RING_F_INDIRECT_DESC);
+        let features = VirtIOFeatures::from_bits_truncate(MmioRegs::DeviceFeatures.read())
+            - (VirtIOFeatures::BLK_F_RO
+                | VirtIOFeatures::BLK_F_SCSI
+                | VirtIOFeatures::BLK_F_CONFIG_WCE
+                | VirtIOFeatures::BLK_F_MQ
+                | VirtIOFeatures::F_ANY_LAYOUT
+                | VirtIOFeatures::RING_F_EVENT_IDX
+                | VirtIOFeatures::RING_F_INDIRECT_DESC);
 
         MmioRegs::DriverFeatures.write(features.bits());
 


### PR DESCRIPTION
Inline assembly를 사용해 레지스터의 값을 읽기만 하는 함수는 메모리 안전성을 깨거나 data race를 일으키지 않으므로 unsafe를 제거했습니다.