### PR TITLE
Fix get_mut_unchecked of locks

### DIFF
--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -106,13 +106,15 @@ pub struct Buf<'s> {
 
 impl<'s> Buf<'s> {
     pub fn deref_inner(&self) -> &BufInner {
+        let entry: &BufEntry = &self.inner;
         // It is safe becuase inner.inner is locked.
-        unsafe { self.inner.inner.get_mut_unchecked() }
+        unsafe { &*entry.inner.get_mut_raw() }
     }
 
     pub fn deref_inner_mut(&mut self) -> &mut BufInner {
+        let entry: &BufEntry = &self.inner;
         // It is safe becuase inner.inner is locked and &mut self is exclusive.
-        unsafe { self.inner.inner.get_mut_unchecked() }
+        unsafe { &mut *entry.inner.get_mut_raw() }
     }
 
     pub fn unlock(mut self) -> BufUnlocked<'s> {

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -215,7 +215,7 @@ pub unsafe fn consoleinit(devsw: &mut [Devsw; NDEV]) {
 unsafe fn consolewrite(src: UVAddr, n: i32) -> i32 {
     // TODO(https://github.com/kaist-cp/rv6/issues/298) Remove below comment.
     // consolewrite() does not need console.lock() -- can lead to sleep() with lock held.
-    unsafe { kernel().console.get_mut_unchecked().write(src, n) }
+    unsafe { (*kernel().console.get_mut_raw()).write(src, n) }
 }
 
 /// User read()s from the console go here.

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -229,12 +229,12 @@ impl Deref for InodeGuard<'_> {
 impl InodeGuard<'_> {
     pub fn deref_inner(&self) -> &InodeInner {
         // It is safe becuase self.inner is locked.
-        unsafe { self.inner.get_mut_unchecked() }
+        unsafe { &*self.inner.get_mut_raw() }
     }
 
     pub fn deref_inner_mut(&mut self) -> &mut InodeInner {
         // It is safe becuase self.inner is locked and &mut self is exclusive.
-        unsafe { self.inner.get_mut_unchecked() }
+        unsafe { &mut *self.inner.get_mut_raw() }
     }
 }
 

--- a/kernel-rs/src/fs/log.rs
+++ b/kernel-rs/src/fs/log.rs
@@ -182,7 +182,7 @@ impl Log {
             // to sleep with locks.
             // It is safe because other threads neither read nor write this log
             // when guard.committing is true.
-            unsafe { this.get_mut_unchecked().commit() };
+            unsafe { (*this.get_mut_raw()).commit() };
             let mut guard = this.lock();
             guard.committing = false;
             guard.wakeup();

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -148,7 +148,7 @@ impl Kernel {
     /// Prints the given formatted string with the Printer.
     pub fn printer_write_fmt(&self, args: fmt::Arguments<'_>) -> fmt::Result {
         if self.is_panicked() {
-            unsafe { kernel().printer.get_mut_unchecked().write_fmt(args) }
+            unsafe { (*kernel().printer.get_mut_raw()).write_fmt(args) }
         } else {
             let mut lock = kernel().printer.lock();
             lock.write_fmt(args)

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -58,14 +58,11 @@ impl<T: Unpin> Sleepablelock<T> {
         self.data.into_inner()
     }
 
-    /// Returns a mutable reference to the inner data.
-    /// # Safety
-    ///
-    /// `self` must not be shared by other threads. Use this function only in the middle of
-    /// refactoring.
-    #[allow(clippy::mut_from_ref)]
-    pub unsafe fn get_mut_unchecked(&self) -> &mut T {
-        unsafe { &mut *self.data.get() }
+    /// Returns a mutable pointer to the inner data.
+    /// The returned pointer is valid until this lock is moved or dropped.
+    /// The caller must ensure that accessing the pointer does not incur race.
+    pub fn get_mut_raw(&self) -> *mut T {
+        self.data.get()
     }
 
     /// Returns a mutable reference to the inner data.

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -92,14 +92,11 @@ impl<T: Unpin> Sleeplock<T> {
         self.data.into_inner()
     }
 
-    /// Returns a mutable reference to the inner data.
-    /// # Safety
-    ///
-    /// `self` must not be shared by other threads. Use this function only in the middle of
-    /// refactoring.
-    #[allow(clippy::mut_from_ref)]
-    pub unsafe fn get_mut_unchecked(&self) -> &mut T {
-        unsafe { &mut *self.data.get() }
+    /// Returns a mutable pointer to the inner data.
+    /// The returned pointer is valid until this lock is moved or dropped.
+    /// The caller must ensure that accessing the pointer does not incur race.
+    pub fn get_mut_raw(&self) -> *mut T {
+        self.data.get()
     }
 
     /// Returns a mutable reference to the inner data.

--- a/kernel-rs/src/spinlock.rs
+++ b/kernel-rs/src/spinlock.rs
@@ -198,15 +198,11 @@ impl<T: Unpin> Spinlock<T> {
         self.data.into_inner()
     }
 
-    /// Returns a mutable reference to the inner data.
-    ///
-    /// # Safety
-    ///
-    /// `self` must not be shared by other threads. Use this function only in the middle of
-    /// refactoring.
-    #[allow(clippy::mut_from_ref)]
-    pub unsafe fn get_mut_unchecked(&self) -> &mut T {
-        unsafe { &mut *self.data.get() }
+    /// Returns a mutable pointer to the inner data.
+    /// The returned pointer is valid until this lock is moved or dropped.
+    /// The caller must ensure that accessing the pointer does not incur race.
+    pub fn get_mut_raw(&self) -> *mut T {
+        self.data.get()
     }
 
     /// Returns a mutable reference to the inner data.

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -187,7 +187,7 @@ pub unsafe fn kerneltrap() {
         if let Some(proc) = kernel().current_proc() {
             // Reading state without lock is safe because `proc_yield` and `sched`
             // is called after we check if current process is `RUNNING`.
-            if unsafe { proc.info.get_mut_unchecked().state } == Procstate::RUNNING {
+            if unsafe { (*proc.info.get_mut_raw()).state } == Procstate::RUNNING {
                 unsafe { proc.proc_yield() };
             }
         }


### PR DESCRIPTION
기존 `Spinlock`, `Sleeplock`, `Sleepablelock`의 `get_mut_unchecked`는 `&self`로부터 `&mut`을 만들어 내는 위험한 메서드였습니다.

https://github.com/kaist-cp/rv6/blob/1c9ed841809b4758a6c7bd999015ccd820ba2eaa/kernel-rs/src/spinlock.rs#L201-L210

Rust에서 굉장히 강력한 가정을 제공하는 `&mut` 대신, 아래와 같이  `*mut`을 반환함으로써 UB의 가능성을 줄일 수 있습니다. 이 경우 메서드를 호출한 쪽에서 raw pointer를 사용할 때 unsafe 블록을 열고 안전성을 확인해야 하므로, 더 이상 이 메서드가 unsafe일 필요가 없습니다.

https://github.com/kaist-cp/rv6/blob/ca67ebe897d57f593ac71a2c5c3070fc7a3ec184/kernel-rs/src/spinlock.rs#L201-L206

만약 `&mut`이 필요하고 `&mut`의 유일함을 guard를 사용해 보장할 수 있다면, 아래처럼 해당 guard의 메서드가 raw pointer를 reference로 변환하도록 하면 됩니다.

https://github.com/kaist-cp/rv6/blob/ca67ebe897d57f593ac71a2c5c3070fc7a3ec184/kernel-rs/src/fs/inode.rs#L229-L239