### PR TITLE
Fix minor issues

### DIFF
--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -269,13 +269,7 @@ pub unsafe fn kernel_main() -> ! {
         println!("hart {} starting", cpuid());
 
         // Turn on paging.
-        unsafe {
-            kernel_unchecked_pin()
-                .project()
-                .memory
-                .assume_init_mut()
-                .init_hart()
-        };
+        unsafe { kernel().memory.assume_init_ref().init_hart() };
 
         // Install kernel trap vector.
         unsafe { trapinithart() };

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -45,12 +45,12 @@ impl ListEntry {
         this.prev = this;
     }
 
-    pub fn prev(&self) -> &Self {
-        unsafe { &*self.prev }
+    pub fn prev(self: Pin<&mut Self>) -> Pin<&mut Self> {
+        unsafe { Pin::new_unchecked(&mut **self.project().prev) }
     }
 
-    pub fn next(&self) -> &Self {
-        unsafe { &*self.next }
+    pub fn next(self: Pin<&mut Self>) -> Pin<&mut Self> {
+        unsafe { Pin::new_unchecked(&mut **self.project().next) }
     }
 
     /// `e` <-> `this`


### PR DESCRIPTION
개별적인 PR로 만들기는 애매한 자잘한 TODO들을 모아봤습니다.
* `MruEntry`가 `&ListEntry`로부터 `&mut MruEntry`를 얻던 부분을 변경했습니다. 이제 `Pin<&mut ListEntry>`로부터 `Pin<&mut MruEntry>`를 얻습니다. https://github.com/kaist-cp/rv6/commit/a3dbea939571d272765655247dda22a30ce84d44
* `Kernel`의 initialization이 끝난 후에도 `Pin<&mut Kernel>`로 `Kernel`을 접근하는 곳이 있어서 `&Kernel`로 접근하도록 변경했습니다. https://github.com/kaist-cp/rv6/commit/2ed78dbbcfb01dc75bdf957d01546c9928128122
* Closes #416 : `ProcInfo::child_wait_channel`을 `Proc`으로 옮겨봤습니다. https://github.com/kaist-cp/rv6/commit/82417413e66aa667f247951d9e761e26ee093663
  * 혹시, 이 부분에 대해서 다른 생각이 있으시다면 말씀해주시면 감사드리겠습니다. @Medowhill 