### PR TITLE
Unsafe reasoning of file-related syscalls

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -166,7 +166,7 @@ impl Kernel {
                 return Err(());
             }
 
-            mem.copy_out(sp.into(), bytes)?;
+            mem.copy_out_bytes(sp.into(), bytes)?;
             *stack = sp;
         }
         let argc: usize = args.len();
@@ -181,7 +181,7 @@ impl Kernel {
         }
         // It is safe because any byte can be considered as a valid u8.
         let (_, ustack, _) = unsafe { ustack.align_to::<u8>() };
-        mem.copy_out(sp.into(), &ustack[..argv_size])?;
+        mem.copy_out_bytes(sp.into(), &ustack[..argv_size])?;
 
         let proc_data = proc.deref_mut_data();
 

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -196,7 +196,7 @@ impl PipeInner {
     /// Tries to write up to `n` bytes.
     /// If the process was killed, returns `Err(InvalidStatus)`.
     /// If an copy-in error happened after successfully writing i >= 0 bytes, returns `Err(InvalidCopyIn(i))`.
-    /// Otherwise, returns `Ok(i)` after successfully writing i >= 0 bytes.    
+    /// Otherwise, returns `Ok(i)` after successfully writing i >= 0 bytes.
     fn try_write(
         &mut self,
         addr: UVAddr,
@@ -215,7 +215,7 @@ impl PipeInner {
             if proc
                 .deref_mut_data()
                 .memory
-                .copy_in(&mut ch, addr + i)
+                .copy_in_bytes(&mut ch, addr + i)
                 .is_err()
             {
                 return Err(PipeError::InvalidCopyin(i));
@@ -254,7 +254,7 @@ impl PipeInner {
             if proc
                 .deref_mut_data()
                 .memory
-                .copy_out(addr + i, &ch)
+                .copy_out_bytes(addr + i, &ch)
                 .is_err()
             {
                 return Ok(i);

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -5,7 +5,7 @@ use core::{
     mem::{self, MaybeUninit},
     ops::Deref,
     pin::Pin,
-    ptr, slice, str,
+    ptr, str,
     sync::atomic::{AtomicBool, AtomicI32, Ordering},
 };
 
@@ -891,12 +891,7 @@ impl ProcessSystem {
                             && proc
                                 .deref_mut_data()
                                 .memory
-                                .copy_out(addr, unsafe {
-                                    slice::from_raw_parts_mut(
-                                        &mut np.deref_mut_info().xstate as *mut i32 as *mut u8,
-                                        mem::size_of::<i32>(),
-                                    )
-                                })
+                                .copy_out(addr, &np.deref_info().xstate)
                                 .is_err()
                         {
                             return Err(());

--- a/kernel-rs/src/riscv.rs
+++ b/kernel-rs/src/riscv.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 
-use crate::vm::{Addr, PAddr, VAddr};
+use crate::vm::{Addr, PAddr};
 
 /// Which hart (core) is this?
 #[inline]
@@ -458,11 +458,6 @@ pub const PXMASK: usize = 0x1ff;
 #[inline]
 pub fn pxshift(level: usize) -> usize {
     PGSHIFT + 9 * level
-}
-
-#[inline]
-pub fn px<A: VAddr>(level: usize, va: A) -> usize {
-    (va.into_usize() >> pxshift(level)) & PXMASK
 }
 
 /// One beyond the highest possible virtual address.

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -13,7 +13,7 @@ impl Kernel {
     }
 
     /// Return the current process’s PID.
-    pub unsafe fn sys_getpid(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_getpid(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         Ok(proc.pid() as _)
     }
 


### PR DESCRIPTION
* 파일 시스템에 관련된 syscall을 처리하는 코드의 불필요한 unsafe를 제거하고 남은 unsafe에는 안전성을 설명하는 주석을 달았습니다.
* `InodeFileType`과 `InodeFileTypeGuard`를 추가했습니다. `InodeFileType`은 `FileType`이 `Inode`인 경우에 사용되며, `ip`가 lock되어 있을 때만 `off`에 접근할 수 있도록 합니다.