### PR TITLE
exploiting invariants of ProcData

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -45,8 +45,7 @@ impl Console {
             if kernel()
                 .current_proc()
                 .expect("No current proc")
-                .deref_mut_data()
-                .memory
+                .memory_mut()
                 .copy_in_bytes(&mut c, src + i as usize)
                 .is_err()
             {
@@ -88,8 +87,7 @@ impl Console {
                 if kernel()
                     .current_proc()
                     .expect("No current proc")
-                    .deref_mut_data()
-                    .memory
+                    .memory_mut()
                     .copy_out_bytes(dst, &cbuf)
                     .is_err()
                 {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -101,7 +101,7 @@ impl File {
             }
             | FileType::Device { ip, .. } => {
                 let st = ip.stat();
-                proc.deref_mut_data().memory.copy_out(addr, &st)
+                proc.memory_mut().copy_out(addr, &st)
             }
             _ => Err(()),
         }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -421,9 +421,7 @@ impl InodeGuard<'_> {
         proc: &mut CurrentProc<'_>,
     ) -> Result<usize, ()> {
         self.read_internal(off, n, |off, src| {
-            proc.deref_mut_data()
-                .memory
-                .copy_out_bytes(dst + off as usize, src)
+            proc.memory_mut().copy_out_bytes(dst + off as usize, src)
         })
     }
 
@@ -517,11 +515,7 @@ impl InodeGuard<'_> {
         self.write_internal(
             off,
             n,
-            |off, dst| {
-                proc.deref_mut_data()
-                    .memory
-                    .copy_in_bytes(dst, src + off as usize)
-            },
+            |off, dst| proc.memory_mut().copy_in_bytes(dst, src + off as usize),
             tx,
         )
     }

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -148,7 +148,7 @@ impl Path {
         let mut ptr = if self.is_absolute() {
             Self::root()
         } else {
-            proc.cwd.clone().unwrap()
+            proc.cwd().clone()
         };
 
         let mut path = self;

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -212,12 +212,7 @@ impl PipeInner {
                 //DOC: pipewrite-full
                 return Ok(i);
             }
-            if proc
-                .deref_mut_data()
-                .memory
-                .copy_in_bytes(&mut ch, addr + i)
-                .is_err()
-            {
+            if proc.memory_mut().copy_in_bytes(&mut ch, addr + i).is_err() {
                 return Err(PipeError::InvalidCopyin(i));
             }
             self.data[self.nwrite as usize % PIPESIZE] = ch[0];
@@ -251,12 +246,7 @@ impl PipeInner {
             }
             let ch = [self.data[self.nread as usize % PIPESIZE]];
             self.nread = self.nread.wrapping_add(1);
-            if proc
-                .deref_mut_data()
-                .memory
-                .copy_out_bytes(addr + i, &ch)
-                .is_err()
-            {
+            if proc.memory_mut().copy_out_bytes(addr + i, &ch).is_err() {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -14,11 +14,11 @@ use crate::{
 pub fn fetchaddr(addr: UVAddr, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
     let mut ip = 0;
     let sz = mem::size_of::<usize>();
-    if addr.into_usize() >= proc.memory.size() || addr.into_usize() + sz > proc.memory.size() {
+    if addr.into_usize() >= proc.memory().size() || addr.into_usize() + sz > proc.memory().size() {
         return Err(());
     }
     // Safe since usize does not have any internal structure.
-    unsafe { proc.deref_mut_data().memory.copy_in(&mut ip, addr) }?;
+    unsafe { proc.memory_mut().copy_in(&mut ip, addr) }?;
     Ok(ip)
 }
 
@@ -29,7 +29,7 @@ pub fn fetchstr<'a>(
     buf: &'a mut [u8],
     proc: &mut CurrentProc<'_>,
 ) -> Result<&'a CStr, ()> {
-    proc.deref_mut_data().memory.copy_in_str(buf, addr)?;
+    proc.memory_mut().copy_in_str(buf, addr)?;
 
     // Safe because buf contains '\0' as copy_in_str has succeeded.
     Ok(unsafe { CStr::from_ptr(buf.as_ptr()) })
@@ -100,7 +100,7 @@ impl Kernel {
                 println!(
                     "{} {}: unknown sys call {}",
                     proc.pid(),
-                    str::from_utf8(&proc.name).unwrap_or("???"),
+                    str::from_utf8(&proc.deref_data().name).unwrap_or("???"),
                     num
                 );
                 Err(())

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -34,7 +34,7 @@ impl Kernel {
     /// Returns Ok(start of new memory) on success, Err(()) on error.
     pub fn sys_sbrk(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
-        proc.deref_mut_data().memory.resize(n)
+        proc.memory_mut().resize(n)
     }
 
     /// Pause for n clock ticks.

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -310,14 +310,10 @@ impl<A: VAddr> PageTable<A> {
 
 impl<A: VAddr> Drop for PageTable<A> {
     fn drop(&mut self) {
-        // TODO(https://github.com/kaist-cp/rv6/issues/204)
-        // This check is required because of uninit. When uninit is removed,
-        // this check also can be removed.
-        if !self.ptr.is_null() {
-            // It is safe because this page table is being dropped, and its ptr will
-            // not be used anymore.
-            unsafe { (*self.ptr).free_walk() };
-        }
+        // It is safe because
+        // * self.ptr is a valid pointer.
+        // * this page table is being dropped, and its ptr will not be used anymore.
+        unsafe { (*self.ptr).free_walk() };
     }
 }
 
@@ -347,18 +343,6 @@ pub struct UserMemory {
 }
 
 impl UserMemory {
-    /// # Safety
-    ///
-    /// The result this method must not be used, except for calling size and being dropped.
-    // TODO(https://github.com/kaist-cp/rv6/issues/204): This method should be removed by refactoring Proc.
-    pub const unsafe fn uninit() -> Self {
-        Self {
-            // It is safe because this page table will not be used at all.
-            page_table: unsafe { PageTable::uninit() },
-            size: 0,
-        }
-    }
-
     /// Create a user page table with no user memory, but with the trampoline
     /// and a given trap frame. If `src_opt` is `Some(src)`, then load `src`
     /// into address 0 of the pagetable. In this case, src.len() must be less


### PR DESCRIPTION
`Proc`의 invariant로 다음을 추가했습니다.

```rust
/// * If `info.state` != `Procstate::UNUSED`, then
///   - `data.trap_frame` is a valid pointer, and `Page::from_usize(data.trap_frame)` is safe.
///   - `data.memory` has been initialized.
///   - `data.cwd` has been initialized.
```

이 invariant에 의해 `CurrentProc`에서는 `trap_frame`, `memory`, `cwd`에 안전하게 접근할 수 있습니다. 해당 필드에 안전하게 접근하는 메서드를 `CurrentProc`에 추가했습니다. `CurrentProc`이 아닌데 사용하는 경우에는 unsafe가 필요하며 왜 해당 unsafe가 안전한지 주석으로 추가했습니다.