### PR TITLE
Closes #420

### DIFF
--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -15,7 +15,9 @@ use core::{cmp, mem};
 
 use spin::Once;
 
-use crate::{bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, virtio::Disk};
+use crate::{
+    bio::Buf, kernel::kernel_builder, param::BSIZE, sleepablelock::Sleepablelock, virtio::Disk,
+};
 
 mod inode;
 mod log;
@@ -131,7 +133,9 @@ impl FsTransaction<'_> {
 
     /// Zero a block.
     fn bzero(&self, dev: u32, bno: u32) {
-        let mut buf = unsafe { kernel().get_bcache() }.get_buf(dev, bno).lock();
+        let mut buf = unsafe { kernel_builder().get_bcache() }
+            .get_buf(dev, bno)
+            .lock();
         buf.deref_inner_mut().data.fill(0);
         buf.deref_inner_mut().valid = true;
         self.write(buf);

--- a/kernel-rs/src/fs/path.rs
+++ b/kernel-rs/src/fs/path.rs
@@ -3,7 +3,7 @@ use core::cmp;
 use cstr_core::CStr;
 
 use super::{InodeType, RcInode, DIRSIZ, ROOTINO};
-use crate::{kernel::kernel, param::ROOTDEV, proc::CurrentProc};
+use crate::{kernel::kernel_builder, param::ROOTDEV, proc::CurrentProc};
 
 #[derive(PartialEq)]
 #[repr(transparent)]
@@ -63,7 +63,7 @@ impl Path {
     }
 
     pub fn root() -> RcInode<'static> {
-        kernel().itable.get_inode(ROOTDEV, ROOTINO)
+        kernel_builder().itable.get_inode(ROOTDEV, ROOTINO)
     }
 
     pub fn namei(&self, proc: &CurrentProc<'_>) -> Result<RcInode<'static>, ()> {

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -6,7 +6,7 @@ use core::pin::Pin;
 
 use crate::spinlock::RawSpinlock;
 use crate::{
-    kernel::kernel,
+    kernel::kernel_builder,
     proc::{WaitChannel, Waitable},
 };
 
@@ -73,9 +73,10 @@ impl<T: Unpin> Sleepablelock<T> {
 
 impl<T> SleepablelockGuard<'_, T> {
     pub fn sleep(&mut self) {
-        self.lock
-            .waitchannel
-            .sleep(self, &kernel().current_proc().expect("No current proc"));
+        self.lock.waitchannel.sleep(
+            self,
+            &kernel_builder().current_proc().expect("No current proc"),
+        );
     }
 
     pub fn wakeup(&self) {

--- a/kernel-rs/src/sleeplock.rs
+++ b/kernel-rs/src/sleeplock.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 
-use crate::kernel::kernel;
+use crate::kernel::kernel_builder;
 use crate::sleepablelock::Sleepablelock;
 
 /// Long-term locks for processes
@@ -29,7 +29,10 @@ impl RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
-        *guard = kernel().current_proc().expect("No current proc").pid();
+        *guard = kernel_builder()
+            .current_proc()
+            .expect("No current proc")
+            .pid();
     }
 
     pub fn release(&self) {
@@ -40,7 +43,11 @@ impl RawSleeplock {
 
     pub fn holding(&self) -> bool {
         let guard = self.locked.lock();
-        *guard == kernel().current_proc().expect("No current proc").pid()
+        *guard
+            == kernel_builder()
+                .current_proc()
+                .expect("No current proc")
+                .pid()
     }
 }
 

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -68,15 +68,11 @@ pub fn argstr<'a>(n: usize, buf: &'a mut [u8], proc: &mut CurrentProc<'_>) -> Re
 }
 
 impl Kernel {
-    pub unsafe fn syscall(
-        &'static self,
-        num: i32,
-        proc: &mut CurrentProc<'_>,
-    ) -> Result<usize, ()> {
+    pub fn syscall(&'static self, num: i32, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         match num {
-            1 => unsafe { self.sys_fork(proc) },
-            2 => unsafe { self.sys_exit(proc) },
-            3 => unsafe { self.sys_wait(proc) },
+            1 => self.sys_fork(proc),
+            2 => self.sys_exit(proc),
+            3 => self.sys_wait(proc),
             4 => self.sys_pipe(proc),
             5 => self.sys_read(proc),
             6 => self.sys_kill(proc),

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -13,7 +13,7 @@ use crate::{
     fcntl::FcntlFlags,
     file::{FileType, InodeFileType, RcFile},
     fs::{Dirent, FileName, FsTransaction, InodeGuard, InodeType, Path, RcInode},
-    kernel::{kernel, Kernel},
+    kernel::{kernel_builder, Kernel},
     ok_or,
     page::Page,
     param::{MAXARG, MAXPATH, NDEV, NOFILE},
@@ -82,7 +82,7 @@ where
         }
         return Err(());
     }
-    let ptr2 = kernel().itable.alloc_inode(dp.dev, typ, tx);
+    let ptr2 = kernel_builder().itable.alloc_inode(dp.dev, typ, tx);
     let mut ip = ptr2.lock();
     ip.deref_inner_mut().nlink = 1;
     ip.update(tx);

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -7,27 +7,27 @@ use crate::{
 
 impl Kernel {
     /// Terminate the current process; status reported to wait(). No return.
-    pub unsafe fn sys_exit(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_exit(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let n = argint(0, proc)?;
-        unsafe { self.procs.exit_current(n, proc) };
+        self.procs().exit_current(n, proc);
+    }
+
+    /// Create a process.
+    /// Returns Ok(child’s PID) on success, Err(()) on error.
+    pub fn sys_fork(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+        Ok(self.procs().fork(proc)? as _)
+    }
+
+    /// Wait for a child to exit.
+    /// Returns Ok(child’s PID) on success, Err(()) on error.
+    pub fn sys_wait(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+        let p = argaddr(0, proc)?;
+        Ok(self.procs().wait(p.into(), proc)? as _)
     }
 
     /// Return the current process’s PID.
     pub fn sys_getpid(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         Ok(proc.pid() as _)
-    }
-
-    /// Create a process.
-    /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_fork(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
-        Ok(unsafe { self.procs.fork(proc) }? as _)
-    }
-
-    /// Wait for a child to exit.
-    /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub unsafe fn sys_wait(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
-        let p = argaddr(0, proc)?;
-        Ok(unsafe { self.procs.wait(p.into(), proc) }? as _)
     }
 
     /// Grow process’s memory by n bytes.
@@ -56,7 +56,7 @@ impl Kernel {
     /// Returns Ok(0) on success, Err(()) on error.
     pub fn sys_kill(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
         let pid = argint(0, proc)?;
-        self.procs.kill(pid)?;
+        self.procs().kill(pid)?;
         Ok(0)
     }
 

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -5,7 +5,7 @@ use self::UartCtrlRegs::{FCR, IER, ISR, LCR, LSR, RBR, THR};
 use crate::memlayout::UART0;
 use crate::{
     console::consoleintr,
-    kernel::kernel,
+    kernel::kernel_builder,
     sleepablelock::{Sleepablelock, SleepablelockGuard},
     spinlock::{pop_off, push_off},
     utils::spin_loop,
@@ -147,7 +147,7 @@ impl Uart {
     /// by write().
     pub fn putc(&self, c: i32) {
         let mut guard = self.tx_lock.lock();
-        if kernel().is_panicked() {
+        if kernel_builder().is_panicked() {
             spin_loop();
         }
         loop {
@@ -173,7 +173,7 @@ impl Uart {
         unsafe {
             push_off();
         }
-        if kernel().is_panicked() {
+        if kernel_builder().is_panicked() {
             spin_loop();
         }
 


### PR DESCRIPTION
Closes #420

## 동기

* `Proc`의 `parent`는 `MaybeUninit`. `parent`의 초기화는 `ProcessSystem::init`에서 진행. 따라서 `parent`에 접근하는 모든 메서드는 `init`이 이미 호출된 상태여야만 안전하게 사용될 수 있고, 메서드 호출 시에 추가적인 가정이 필요한 것이므로 unsafe 메서드가 될 수밖에 없음.
* 이 문제를 해결하기 위해서는 `parent`가 초기화되었다는 것을 나타내는 타입이 필요. 해당 타입의 값은 `init`이 호출된 상태에서만 만들 수 있으므로 unsafe 메서드를 통해 만들어짐. 해당 타입의 값은 `parent`에 접근하는 메서드를 제공하며, 이 메서드는 unsafe가 아님.

## 구현

* `InitializedKernel` 추가: 초기화가 끝난 `Kernel`을 타입으로 나타냄. `Kernel`에서 초기화 없이 접근하면 위험한 값들을 안전하게 접근하는 메서드를 제공. `initialized_kernel`을 호출해 얻을 수 있으며, `initialized_kernel`은 unsafe 함수이기 때문에, 커널의 초기화가 끝났다는 것을 보장할 수 있는 곳(`usertrap` 등)에서만 호출해야 함. 현재는 `InitilalizedProcessSystem`을 만들기 위해서만 사용하지만, 초기화가 필요한 다른 필드(예를 들면 `bcache`)에 안전하게 접근하는 데도 사용할 수 있음.
* `InitilalizedProcessSystem` 추가: 초기화가 끝난 `ProcessSystem`. `initial_proc`과 `process_pool`에 있는 모든 `Proc`의 `parent`가 초기화되었음을 나타내며, `parent`에 안전하게 접근할 방법을 제공. `InitializedKernel`로부터 얻을 수 있음. 기존에 `ProcessSystem`의 unsafe 메서드이던 `fork`, `wait`, `exit_current`는 이제 `InitializedProcessSystem`의 메서드이며, 더 이상 unsafe가 아님.
* `InitializedProc` 추가: `parent`가 초기화된 `Proc`으로, `parent`에 안전하게 접근할 방법을 제공. `InitializedProcessSystem`으로부터 얻을 수 있음.