### PR TITLE
[Sub-issue of #378] Pin `DiskInfo`

### DIFF
--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -66,6 +66,7 @@ pub struct BufInner {
 #[repr(align(4))]
 pub struct BufData {
     pub inner: [u8; BSIZE],
+    // !Unpin
 }
 
 impl Deref for BufData {

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -66,7 +66,6 @@ pub struct BufInner {
 #[repr(align(4))]
 pub struct BufData {
     pub inner: [u8; BSIZE],
-    // !Unpin
 }
 
 impl Deref for BufData {

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -13,6 +13,7 @@
 
 use core::{cmp, mem};
 
+use pin_project::pin_project;
 use spin::Once;
 
 use crate::{bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, virtio::Disk};
@@ -36,6 +37,7 @@ const NDIRECT: usize = 12;
 const NINDIRECT: usize = BSIZE.wrapping_div(mem::size_of::<u32>());
 const MAXFILE: usize = NDIRECT.wrapping_add(NINDIRECT);
 
+#[pin_project]
 pub struct FileSystem {
     /// TODO(https://github.com/kaist-cp/rv6/issues/358)
     /// Initializing superblock should be run only once because forkret() calls fsinit()
@@ -49,6 +51,7 @@ pub struct FileSystem {
     log: Once<Sleepablelock<Log>>,
 
     /// It may sleep until some Descriptors are freed.
+    #[pin]
     pub disk: Sleepablelock<Disk>,
 }
 

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -16,7 +16,9 @@ use core::{cmp, mem};
 use pin_project::pin_project;
 use spin::Once;
 
-use crate::{bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, virtio::Disk};
+use crate::{
+    bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, virtio::VirtIODisk,
+};
 
 mod inode;
 mod log;
@@ -52,7 +54,7 @@ pub struct FileSystem {
 
     /// It may sleep until some Descriptors are freed.
     #[pin]
-    pub disk: Sleepablelock<Disk>,
+    pub disk: Sleepablelock<VirtIODisk>,
 }
 
 pub struct FsTransaction<'s> {
@@ -64,7 +66,7 @@ impl FileSystem {
         Self {
             superblock: Once::new(),
             log: Once::new(),
-            disk: Sleepablelock::new("virtio_disk", Disk::zero()),
+            disk: Sleepablelock::new("virtio_disk", VirtIODisk::zero()),
         }
     }
 

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -17,7 +17,7 @@ use pin_project::pin_project;
 use spin::Once;
 
 use crate::{
-    bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, virtio::VirtIODisk,
+    bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, virtio::VirtIoDisk,
 };
 
 mod inode;
@@ -54,7 +54,7 @@ pub struct FileSystem {
 
     /// It may sleep until some Descriptors are freed.
     #[pin]
-    pub disk: Sleepablelock<VirtIODisk>,
+    pub disk: Sleepablelock<VirtIoDisk>,
 }
 
 pub struct FsTransaction<'s> {
@@ -66,7 +66,7 @@ impl FileSystem {
         Self {
             superblock: Once::new(),
             log: Once::new(),
-            disk: Sleepablelock::new("virtio_disk", VirtIODisk::zero()),
+            disk: Sleepablelock::new("virtio_disk", VirtIoDisk::zero()),
         }
     }
 

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -93,6 +93,7 @@ pub struct Kernel {
 
     pub itable: Itable,
 
+    #[pin]
     pub file_system: FileSystem,
 }
 
@@ -257,8 +258,9 @@ pub unsafe fn kernel_main() -> ! {
             kernel_unchecked_pin()
                 .project()
                 .file_system
+                .project()
                 .disk
-                .get_mut()
+                .get_pin_mut()
                 .init()
         };
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -2,6 +2,7 @@
 
 use core::{
     cell::UnsafeCell,
+    marker::PhantomPinned,
     mem::{self, MaybeUninit},
     ops::Deref,
     pin::Pin,
@@ -335,6 +336,7 @@ pub struct ProcData {
 ///   - `data.memory` has been initialized.
 /// * If `info.state` ∉ { `UNUSED`, `USED` }, then
 ///   - `data.cwd` has been initialized.
+#[pin_project]
 pub struct Proc {
     /// Parent process.
     ///
@@ -353,6 +355,10 @@ pub struct Proc {
 
     /// If true, the process have been killed.
     killed: AtomicBool,
+
+    // Should be `!Unpin`, because of the `Proc::parent` pointer.
+    #[pin]
+    _marker: PhantomPinned,
 }
 
 /// CurrentProc wraps mutable pointer of current CPU's proc.
@@ -640,6 +646,7 @@ impl Proc {
             data: UnsafeCell::new(ProcData::new()),
             child_waitchannel: WaitChannel::new(),
             killed: AtomicBool::new(false),
+            _marker: PhantomPinned,
         }
     }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -356,7 +356,8 @@ pub struct Proc {
     /// If true, the process have been killed.
     killed: AtomicBool,
 
-    // Should be `!Unpin`, because of the `Proc::parent` pointer.
+    // `Proc` should be `!Unpin`, because there are many pointers that point to `Proc`,
+    // such as `Proc::parent`, `Cpu::proc`, or `ProcessSystem::initial_proc`.
     #[pin]
     _marker: PhantomPinned,
 }

--- a/kernel-rs/src/sleepablelock.rs
+++ b/kernel-rs/src/sleepablelock.rs
@@ -47,7 +47,7 @@ impl<T> Sleepablelock<T> {
     }
 
     /// Returns a pinned mutable reference to the inner data.
-    pub fn get_pin_mut(&mut self) -> Pin<&mut T> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
         // Safe since for `T: !Unpin`, we only provide pinned references and don't move `T`.
         unsafe { Pin::new_unchecked(&mut *self.data.get()) }
     }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -222,7 +222,7 @@ pub unsafe fn devintr() -> i32 {
         if irq as usize == UART0_IRQ {
             kernel().uart.intr();
         } else if irq as usize == VIRTIO0_IRQ {
-            kernel().file_system.disk.lock().intr();
+            kernel().file_system.disk.lock().get_pin_mut().intr();
         } else if irq != 0 {
             println!("unexpected interrupt irq={}\n", irq);
         }

--- a/kernel-rs/src/virtio/mod.rs
+++ b/kernel-rs/src/virtio/mod.rs
@@ -17,7 +17,7 @@ use crate::memlayout::VIRTIO0;
 
 mod virtio_disk;
 
-pub use virtio_disk::Disk;
+pub use virtio_disk::VirtIODisk;
 
 /// Memory mapped IO registers.
 /// The kernel and virtio driver communicates to each other using these registers.

--- a/kernel-rs/src/virtio/mod.rs
+++ b/kernel-rs/src/virtio/mod.rs
@@ -17,7 +17,7 @@ use crate::memlayout::VIRTIO0;
 
 mod virtio_disk;
 
-pub use virtio_disk::VirtIODisk;
+pub use virtio_disk::VirtIoDisk;
 
 /// Memory mapped IO registers.
 /// The kernel and virtio driver communicates to each other using these registers.
@@ -101,7 +101,7 @@ impl MmioRegs {
     }
 
     /// Sets the virtio status.
-    fn set_status(status: &VirtIOStatus) {
+    fn set_status(status: &VirtIoStatus) {
         // Simply setting status bits does not cause side effects.
         unsafe {
             MmioRegs::Status.write(status.bits());
@@ -109,12 +109,12 @@ impl MmioRegs {
     }
 
     /// Returns the device's virtio features.
-    fn get_features() -> VirtIOFeatures {
-        VirtIOFeatures::from_bits_truncate(MmioRegs::DeviceFeatures.read())
+    fn get_features() -> VirtIoFeatures {
+        VirtIoFeatures::from_bits_truncate(MmioRegs::DeviceFeatures.read())
     }
 
     /// Sets the device's virtio features.
-    fn set_features(features: &VirtIOFeatures) {
+    fn set_features(features: &VirtIoFeatures) {
         // Simply setting features bits does not cause side effects.
         unsafe {
             MmioRegs::DriverFeatures.write(features.bits());
@@ -179,7 +179,7 @@ impl MmioRegs {
 
 bitflags! {
     /// Status register bits, from qemu virtio_config.h
-    struct VirtIOStatus: u32 {
+    struct VirtIoStatus: u32 {
         const ACKNOWLEDGE = 0b0001;
         const DRIVER = 0b0010;
         const DRIVER_OK = 0b0100;
@@ -189,7 +189,7 @@ bitflags! {
 
 bitflags! {
     // Device feature bits
-    struct VirtIOFeatures: u32 {
+    struct VirtIoFeatures: u32 {
         /// Disk is read-only
         const BLK_F_RO = 1 << 5;
 

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -130,7 +130,7 @@ impl DiskInfo {
         // Safe since we drop the element at `index` before assigning.
         let this = unsafe { self.get_unchecked_mut() };
         this.ops[index] = op;
-        &mut this.ops[index]
+        &this.ops[index]
     }
 
     /// Assigns a new `InflightInfo` at index `index` after dropping the original one.
@@ -139,7 +139,7 @@ impl DiskInfo {
         // Safe since we drop the element at `index` before assigning.
         let this = unsafe { self.get_unchecked_mut() };
         this.inflight[index] = inflight;
-        &mut this.inflight[index]
+        &this.inflight[index]
     }
 
     /// Drops the `InflightInfo` at index `index`, and fills it with `InflightInfo::zero()`.


### PR DESCRIPTION
Partially resolves # 378
Closes #357

### Background
-----
`Disk`는 IO operation에 대한 정보가 담긴 부분의 address를 driver에게 전달한 후 waitchannel에 대해 sleep합니다. 이후, driver가 주어진 address에 있는 정보를 읽어서 operation을 수행합니다.
 * 이때, driver가 operation을 수행하기 전에 address에 있던 정보가 move되면 안되므로, 이 부분을 pin해야합니다.

### Changes
-----
* virtio_disk.rs에서 `VirtIOBlockOutHeader`, `InflightInfo`를 pin했습니다.
  * 추가적으로, 이를 own하는 `DiskInfo`, `Disk`, `FileSystem`까지 pin했습니다.
* 추가적으로, `Proc`도 `!Unpin`이라고 표시했습니다.