### PR TITLE
Change `MmioRegs::write` into unsafe fn.

### DIFF
--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -15,9 +15,7 @@ use core::{cmp, mem};
 
 use spin::Once;
 
-use crate::{
-    bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, virtio_disk::Disk,
-};
+use crate::{bio::Buf, kernel::kernel, param::BSIZE, sleepablelock::Sleepablelock, virtio::Disk};
 
 mod inode;
 mod log;

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -86,5 +86,4 @@ mod trap;
 mod uart;
 mod utils;
 mod virtio;
-mod virtio_disk;
 mod vm;

--- a/kernel-rs/src/virtio/mod.rs
+++ b/kernel-rs/src/virtio/mod.rs
@@ -76,7 +76,7 @@ impl MmioRegs {
     }
 
     /// Checks the virtio disk's properties.
-    pub fn check() {
+    fn check() {
         assert!(
             MmioRegs::MagicValue.read() == 0x74726976
                 && MmioRegs::Version.read() == 1
@@ -87,52 +87,52 @@ impl MmioRegs {
     }
 
     /// Sets the virtio status.
-    pub fn set_status(status: &VirtIOStatus) {
+    fn set_status(status: &VirtIOStatus) {
         unsafe {
             MmioRegs::Status.write(status.bits());
         }
     }
 
     /// Returns the device's virtio features.
-    pub fn get_features() -> VirtIOFeatures {
+    fn get_features() -> VirtIOFeatures {
         VirtIOFeatures::from_bits_truncate(MmioRegs::DeviceFeatures.read())
     }
 
     /// Sets the device's virtio features.
-    pub fn set_features(features: &VirtIOFeatures) {
+    fn set_features(features: &VirtIOFeatures) {
         unsafe {
             MmioRegs::DriverFeatures.write(features.bits());
         }
     }
 
     /// Sets the page size for PFN.
-    pub fn set_pg_size(size: u32) {
+    fn set_pg_size(size: u32) {
         unsafe {
             MmioRegs::GuestPageSize.write(size);
         }
     }
 
     /// Selects the current queue.
-    pub fn select_queue(num: u32) {
+    fn select_queue(num: u32) {
         unsafe {
             MmioRegs::QueueSel.write(num);
         }
     }
 
     /// Returns the max size of the current selected queue.
-    pub fn get_max_queue() -> u32 {
+    fn get_max_queue() -> u32 {
         MmioRegs::QueueNumMax.read()
     }
 
     /// Sets the current selected queue's size.
-    pub fn set_queue_size(size: u32) {
+    fn set_queue_size(size: u32) {
         unsafe {
             MmioRegs::QueueNum.write(size);
         }
     }
 
     /// Sets the physical page number of the current selected queue.
-    pub fn set_queue_page_num(pg_num: u32) {
+    fn set_queue_page_num(pg_num: u32) {
         unsafe {
             MmioRegs::QueuePfn.write(pg_num);
         }
@@ -144,14 +144,14 @@ impl MmioRegs {
     ///
     /// After notifying the queue, the driver will read/write the address given through the descriptors.
     /// The caller must make sure not to give a wrong address.
-    pub unsafe fn notify_queue(num: u32) {
+    unsafe fn notify_queue(num: u32) {
         unsafe {
             MmioRegs::QueueNotify.write(num);
         }
     }
 
     /// Acknowledges all interrupts.
-    pub fn intr_ack_all() {
+    fn intr_ack_all() {
         let intr_status = MmioRegs::InterruptStatus.read() & 0x3;
         unsafe {
             MmioRegs::InterruptAck.write(intr_status);
@@ -209,10 +209,10 @@ const NUM: usize = 1 << 3;
 #[repr(C)]
 #[derive(Copy, Clone)]
 struct VirtqDesc {
-    pub addr: usize,
-    pub len: u32,
-    pub flags: VirtqDescFlags,
-    pub next: u16,
+    addr: usize,
+    len: u32,
+    flags: VirtqDescFlags,
+    next: u16,
 }
 
 bitflags! {
@@ -234,13 +234,13 @@ bitflags! {
 #[repr(C)]
 struct VirtqAvail {
     /// always zero
-    pub flags: u16,
+    flags: u16,
 
     /// Tells the device how far to look in `ring`.
-    pub idx: u16,
+    idx: u16,
 
     /// `desc` indices the device should process.
-    pub ring: [u16; NUM],
+    ring: [u16; NUM],
 }
 
 /// https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-430008
@@ -250,12 +250,12 @@ struct VirtqAvail {
 #[repr(C, align(4096))]
 struct VirtqUsed {
     /// always zero
-    pub flags: u16,
+    flags: u16,
 
     /// device increments when it adds a ring[] entry
-    pub id: u16,
+    id: u16,
 
-    pub ring: [VirtqUsedElem; NUM],
+    ring: [VirtqUsedElem; NUM],
 }
 
 /// One entry in the "used" ring, with which the device tells the driver about
@@ -267,9 +267,9 @@ struct VirtqUsed {
 #[derive(Copy, Clone)]
 struct VirtqUsedElem {
     /// index of start of completed descriptor chain
-    pub id: u32,
+    id: u32,
 
-    pub len: u32,
+    len: u32,
 }
 
 /// for disk ops
@@ -280,7 +280,7 @@ const VIRTIO_BLK_T_IN: u32 = 0;
 const VIRTIO_BLK_T_OUT: u32 = 1;
 
 impl VirtqDesc {
-    pub const fn zero() -> Self {
+    const fn zero() -> Self {
         Self {
             addr: 0,
             len: 0,
@@ -291,7 +291,7 @@ impl VirtqDesc {
 }
 
 impl VirtqAvail {
-    pub const fn zero() -> Self {
+    const fn zero() -> Self {
         Self {
             flags: 0,
             idx: 0,
@@ -301,7 +301,7 @@ impl VirtqAvail {
 }
 
 impl VirtqUsed {
-    pub const fn zero() -> Self {
+    const fn zero() -> Self {
         Self {
             flags: 0,
             id: 0,
@@ -311,7 +311,7 @@ impl VirtqUsed {
 }
 
 impl VirtqUsedElem {
-    pub const fn zero() -> Self {
+    const fn zero() -> Self {
         Self { id: 0, len: 0 }
     }
 }

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -186,7 +186,7 @@ impl Disk {
 
         // MMIO registers are located below KERNBASE, while kernel text and data
         // are located above KERNBASE, so we can safely read/write MMIO registers.
-        MmioRegs::check();
+        MmioRegs::check_virtio_disk();
         status.insert(VirtIOStatus::ACKNOWLEDGE);
         MmioRegs::set_status(&status);
         status.insert(VirtIOStatus::DRIVER);
@@ -214,12 +214,7 @@ impl Disk {
         MmioRegs::set_pg_size(PGSIZE as _);
 
         // Initialize queue 0.
-        MmioRegs::select_queue(0);
-        let max = MmioRegs::get_max_queue();
-        assert!(max != 0, "virtio disk has no queue 0");
-        assert!(max >= NUM as u32, "virtio disk max queue too short");
-        MmioRegs::set_queue_size(NUM as _);
-        MmioRegs::set_queue_page_num((self.desc.as_ptr() as usize >> PGSHIFT) as _);
+        MmioRegs::select_and_init_queue(0, NUM as _, (self.desc.as_ptr() as usize >> PGSHIFT) as _)
 
         // plic.rs and trap.rs arrange for interrupts from VIRTIO0_IRQ.
     }

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -1,3 +1,8 @@
+/// Driver for qemu's virtio disk device.
+/// Uses qemu's mmio interface to virtio.
+/// qemu presents a "legacy" virtio interface.
+///
+/// qemu ... -drive file=fs.img,if=none,format=raw,id=x0 -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
 use core::array::IntoIter;
 use core::mem;
 use core::ptr;
@@ -5,18 +10,16 @@ use core::sync::atomic::{fence, Ordering};
 
 use arrayvec::ArrayVec;
 
-/// Driver for qemu's virtio disk device.
-/// Uses qemu's mmio interface to virtio.
-/// qemu presents a "legacy" virtio interface.
-///
-/// qemu ... -drive file=fs.img,if=none,format=raw,id=x0 -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+use super::{
+    MmioRegs, VirtIOFeatures, VirtIOStatus, VirtqAvail, VirtqDesc, VirtqDescFlags, VirtqUsed, NUM,
+    VIRTIO_BLK_T_IN, VIRTIO_BLK_T_OUT,
+};
 use crate::{
     bio::Buf,
     kernel::kernel,
     param::BSIZE,
     riscv::{PGSHIFT, PGSIZE},
     sleepablelock::{Sleepablelock, SleepablelockGuard},
-    virtio::*,
 };
 
 // It must be page-aligned.

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -211,10 +211,19 @@ impl Disk {
         // Tell device we're completely ready.
         status.insert(VirtIOStatus::DRIVER_OK);
         MmioRegs::set_status(&status);
-        MmioRegs::set_pg_size(PGSIZE as _);
+        // Safe since page size is `PGSIZE`.
+        unsafe {
+            MmioRegs::set_pg_size(PGSIZE as _);
+        }
 
         // Initialize queue 0.
-        MmioRegs::select_and_init_queue(0, NUM as _, (self.desc.as_ptr() as usize >> PGSHIFT) as _)
+        unsafe {
+            MmioRegs::select_and_init_queue(
+                0,
+                NUM as _,
+                (self.desc.as_ptr() as usize >> PGSHIFT) as _,
+            );
+        }
 
         // plic.rs and trap.rs arrange for interrupts from VIRTIO0_IRQ.
     }

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -236,20 +236,14 @@ impl Disk {
 
         // MMIO registers are located below KERNBASE, while kernel text and data
         // are located above KERNBASE, so we can safely read/write MMIO registers.
-        assert!(
-            MmioRegs::MagicValue.read() == 0x74726976
-                && MmioRegs::Version.read() == 1
-                && MmioRegs::DeviceId.read() == 2
-                && MmioRegs::VendorId.read() == 0x554d4551,
-            "could not find virtio disk"
-        );
+        MmioRegs::check();
         status.insert(VirtIOStatus::ACKNOWLEDGE);
-        MmioRegs::Status.write(status.bits());
+        MmioRegs::set_status(&status);
         status.insert(VirtIOStatus::DRIVER);
-        MmioRegs::Status.write(status.bits());
+        MmioRegs::set_status(&status);
 
         // Negotiate features
-        let features = VirtIOFeatures::from_bits_truncate(MmioRegs::DeviceFeatures.read())
+        let features = MmioRegs::get_features()
             - (VirtIOFeatures::BLK_F_RO
                 | VirtIOFeatures::BLK_F_SCSI
                 | VirtIOFeatures::BLK_F_CONFIG_WCE
@@ -258,24 +252,24 @@ impl Disk {
                 | VirtIOFeatures::RING_F_EVENT_IDX
                 | VirtIOFeatures::RING_F_INDIRECT_DESC);
 
-        MmioRegs::DriverFeatures.write(features.bits());
+        MmioRegs::set_features(&features);
 
         // Tell device that feature negotiation is complete.
         status.insert(VirtIOStatus::FEATURES_OK);
-        MmioRegs::Status.write(status.bits());
+        MmioRegs::set_status(&status);
 
         // Tell device we're completely ready.
         status.insert(VirtIOStatus::DRIVER_OK);
-        MmioRegs::Status.write(status.bits());
-        MmioRegs::GuestPageSize.write(PGSIZE as _);
+        MmioRegs::set_status(&status);
+        MmioRegs::set_pg_size(PGSIZE as _);
 
         // Initialize queue 0.
-        MmioRegs::QueueSel.write(0);
-        let max = MmioRegs::QueueNumMax.read();
+        MmioRegs::select_queue(0);
+        let max = MmioRegs::get_max_queue();
         assert!(max != 0, "virtio disk has no queue 0");
         assert!(max >= NUM as u32, "virtio disk max queue too short");
-        MmioRegs::QueueNum.write(NUM as _);
-        MmioRegs::QueuePfn.write((self.desc.as_ptr() as usize >> PGSHIFT) as _);
+        MmioRegs::set_queue_size(NUM as _);
+        MmioRegs::set_queue_page_num((self.desc.as_ptr() as usize >> PGSHIFT) as _);
 
         // plic.rs and trap.rs arrange for interrupts from VIRTIO0_IRQ.
     }
@@ -311,6 +305,7 @@ impl Disk {
         // Format the three descriptors.
         // qemu's virtio-blk.c reads them.
 
+        // 1. Set the first descriptor.
         let buf0 = &mut this.info.ops[desc[0].idx];
         *buf0 = VirtIOBlockOutHeader::new(write, sector);
 
@@ -321,6 +316,7 @@ impl Disk {
             next: desc[1].idx as _,
         };
 
+        // 2. Set the second descriptor.
         // Device reads/writes b->data
         this.desc[desc[1].idx] = VirtqDesc {
             addr: b.deref_inner().data.as_ptr() as _,
@@ -333,6 +329,7 @@ impl Disk {
             next: desc[2].idx as _,
         };
 
+        // 3. Set the third descriptor.
         // device writes 0 on success
         this.info.inflight[desc[0].idx].status = true;
 
@@ -361,8 +358,11 @@ impl Disk {
 
         fence(Ordering::SeqCst);
 
+        // Safe since the all three descriptors' fields are well set.
         // Value is queue number.
-        MmioRegs::QueueNotify.write(0);
+        unsafe {
+            MmioRegs::notify_queue(0);
+        }
 
         // Wait for virtio_disk_intr() to say request has finished.
         while b.deref_inner().disk {
@@ -383,7 +383,7 @@ impl Disk {
         // the "used" ring, in which case we may process the new
         // completion entries in this interrupt, and have nothing to do
         // in the next interrupt, which is harmless.
-        MmioRegs::InterruptAck.write(MmioRegs::InterruptStatus.read() & 0x3);
+        MmioRegs::intr_ack_all();
 
         fence(Ordering::SeqCst);
 

--- a/kernel-rs/src/virtio_disk.rs
+++ b/kernel-rs/src/virtio_disk.rs
@@ -43,22 +43,6 @@ pub struct Disk {
     info: DiskInfo,
 }
 
-/// The (entire) avail ring, from the spec.
-/// https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-380006
-// It needs repr(C) because it is read by device.
-// https://github.com/kaist-cp/rv6/issues/52
-#[repr(C)]
-struct VirtqAvail {
-    /// always zero
-    flags: u16,
-
-    /// Tells the device how far to look in `ring`.
-    idx: u16,
-
-    /// `desc` indices the device should process.
-    ring: [u16; NUM],
-}
-
 // It must be page-aligned because a virtqueue (desc + avail + used) occupies
 // two or more physically-contiguous pages.
 #[repr(align(4096))]
@@ -107,43 +91,6 @@ impl Disk {
             used: VirtqUsed::zero(),
             info: DiskInfo::zero(),
         }
-    }
-}
-
-impl VirtqDesc {
-    const fn zero() -> Self {
-        Self {
-            addr: 0,
-            len: 0,
-            flags: VirtqDescFlags::FREED,
-            next: 0,
-        }
-    }
-}
-
-impl VirtqAvail {
-    const fn zero() -> Self {
-        Self {
-            flags: 0,
-            idx: 0,
-            ring: [0; NUM],
-        }
-    }
-}
-
-impl VirtqUsed {
-    const fn zero() -> Self {
-        Self {
-            flags: 0,
-            id: 0,
-            ring: [VirtqUsedElem::zero(); NUM],
-        }
-    }
-}
-
-impl VirtqUsedElem {
-    const fn zero() -> Self {
-        Self { id: 0, len: 0 }
     }
 }
 


### PR DESCRIPTION
### Context
`MmioRegs`를 `write`하게되면 side effect으로 인해 UB가 발생할 수 있으므로, unsafe이여야할 것 같습니다.
https://github.com/kaist-cp/rv6/pull/427#issuecomment-783301930
https://github.com/kaist-cp/rv6/pull/427#issuecomment-783808771
https://github.com/kaist-cp/rv6/pull/427#issuecomment-785499746

### Changes
* hafnium에서 했던 것과 비슷하게 바꿔봤습니다. (ex: https://github.com/kaist-cp/hafnium-verification/blob/hfo2/hfo2/src/cpu.rs)
  * `MmioRegs`를 write하는 것은 항상 unsafe입니다.
  * 다만, safe하게 write해도 되는 register는 따로 safe한 function으로 unsafe 부분을 감쌌습니다.
  * `MmioRegs`를 read하는 건 일단은 safe로 놔두었습니다.
* EDIT: 추가로, virtio.rs와 virtio_disk.rs를 virtio module로 합쳐봤습니다.