### PR TITLE
[Sub-issue of #378] Pin `ArrayArena`, `RawPageTable`, and `Pipe`.

### DIFF
--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -71,6 +71,7 @@ pub trait ArenaObject {
     fn finalize<'s, A: Arena>(&'s mut self, guard: &'s mut A::Guard<'_>);
 }
 
+// `ArrayEntry` should be pinned, since `ArrayPtr` points to it.
 #[pin_project]
 pub struct ArrayEntry<T> {
     refcnt: usize,
@@ -90,6 +91,7 @@ pub struct ArrayArena<T, const CAPACITY: usize> {
 ///
 /// `ptr` is a valid pointer to `ArrayEntry<T>` and has lifetime `'s`.
 /// Always acquire the `Spinlock<ArrayArena<T, CAPACITY>>` before modifying `ArrayEntry<T>`.
+/// Also, never move `ArrayEntry<T>`.
 pub struct ArrayPtr<'s, T> {
     ptr: NonNull<ArrayEntry<T>>,
     _marker: PhantomData<&'s T>,
@@ -112,6 +114,8 @@ impl<'s, T> ArrayPtr<'s, T> {
     }
 }
 
+// `MruEntry` should be pinned, because `MruPtr` points to it
+// and because `ListEntry` is pinned.
 #[pin_project]
 #[repr(C)]
 pub struct MruEntry<T> {

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -204,7 +204,7 @@ impl<T: 'static + ArenaObject + Unpin, const CAPACITY: usize> Arena
                 if c(&entry.as_mut().project().data) {
                     *entry.as_mut().project().refcnt += 1;
                     // It is safe because entry is a part of self, whose lifetime is 's.
-                    // Also, we do not use the entry until it gets deallocated.
+                    // Also, the arena does not use the entry until it gets deallocated.
                     return Some(unsafe {
                         ArrayPtr::new(NonNull::from(entry.get_unchecked_mut()))
                     });
@@ -238,7 +238,7 @@ impl<T: 'static + ArenaObject + Unpin, const CAPACITY: usize> Arena
                 *entry.as_mut().project().refcnt = 1;
                 f(entry.as_mut().project().data);
                 // It is safe because entry is a part of self, whose lifetime is 's.
-                // Also, we do not use the entry until it gets deallocated.
+                // Also, the arena does not use the entry until it gets deallocated.
                 return Some(unsafe { ArrayPtr::new(NonNull::from(entry.get_unchecked_mut())) });
             }
         }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -221,11 +221,16 @@ impl ArenaObject for File {
 }
 
 impl FileTable {
-    pub const fn zero() -> Self {
-        Spinlock::new(
-            "FTABLE",
-            ArrayArena::new(array![_ => ArrayEntry::new(File::zero()); NFILE]),
-        )
+    /// # Safety
+    ///
+    /// The caller should make sure that `FileTable` never gets moved.
+    pub const unsafe fn zero() -> Self {
+        unsafe {
+            Spinlock::new_unchecked(
+                "FTABLE",
+                ArrayArena::new(array![_ => ArrayEntry::new(File::zero()); NFILE]),
+            )
+        }
     }
 
     /// Allocate a file structure.

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -777,11 +777,16 @@ impl Inode {
 }
 
 impl Itable {
-    pub const fn zero() -> Self {
-        Spinlock::new(
-            "ITABLE",
-            ArrayArena::new(array![_ => ArrayEntry::new(Inode::zero()); NINODE]),
-        )
+    /// # Safety
+    ///
+    /// The caller should make sure that `Itable` never gets moved.
+    pub const unsafe fn zero() -> Self {
+        unsafe {
+            Spinlock::new_unchecked(
+                "ITABLE",
+                ArrayArena::new(array![_ => ArrayEntry::new(Inode::zero()); NINODE]),
+            )
+        }
     }
 
     /// Find the inode with number inum on device dev

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -114,8 +114,9 @@ impl Kernel {
                 read: None,
                 write: None,
             }; NDEV],
-            ftable: FileTable::zero(),
-            itable: Itable::zero(),
+            // Safe since the only way to access `ftable` and `itable` is through `kernel()`, which is an immutable reference.
+            ftable: unsafe { FileTable::zero() },
+            itable: unsafe { Itable::zero() },
             file_system: FileSystem::zero(),
         }
     }

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -1,4 +1,4 @@
-use core::{mem, ops::Deref, ptr::NonNull};
+use core::{marker::PhantomPinned, mem, ops::Deref, ptr::NonNull};
 
 use static_assertions::const_assert;
 
@@ -38,6 +38,9 @@ pub struct Pipe {
 
     /// WaitChannel for saying all bytes in Pipe.data are already read.
     write_waitchannel: WaitChannel,
+
+    /// Must be `!Unpin`, since `AllocatedPipe::ptr` points to `Pipe`.
+    _marker: PhantomPinned,
 }
 
 impl Pipe {
@@ -160,6 +163,7 @@ impl AllocatedPipe {
                 ),
                 read_waitchannel: WaitChannel::new(),
                 write_waitchannel: WaitChannel::new(),
+                _marker: PhantomPinned,
             };
         }
         let f0 = kernel()

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -166,7 +166,7 @@ const PTE_PER_PT: usize = PGSIZE / mem::size_of::<PageTableEntry>();
 ///
 /// It should be converted to a Page by Page::from_usize(self.inner.as_ptr() as _)
 /// without breaking the invariants of Page.
-/// Also, it is always pinned.
+/// Also, it is always pinned, since `PageTable` points to it.
 #[pin_project]
 struct RawPageTable {
     inner: [PageTableEntry; PTE_PER_PT],


### PR DESCRIPTION
Partially resolves # 378.
* Pinned `ArrayArena`.
* Pinned `RawPageTable`.
* Pinned `Pipe`.