### PR TITLE
Closes #419

### DIFF
--- a/count_unsafe.py
+++ b/count_unsafe.py
@@ -10,7 +10,7 @@ if len(sys.argv) > 1:
 
 if subprocess.call('which count-unsafe > /dev/null 2>&1', shell=True) != 0:
     print('''Please install count-unsafe by\n
-`rustup update nightly && cargo +nightly install --git https://github.com/efenniht/count-unsafe`''')
+`rustup update nightly && cargo +nightly install --git https://github.com/Medowhill/count-unsafe`''')
     exit(-1)
 
 if subprocess.call('which cloc > /dev/null 2>&1', shell=True) != 0:


### PR DESCRIPTION
이미 count-unsafe를 설치하신 분들은 `cargo uninstall count-unsafe`를 통해 기존의 count-unsafe를 삭제해 주셔야 합니다.