### PR TITLE
Partially resolves #267

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -42,6 +42,7 @@ impl Console {
     unsafe fn write(&mut self, src: UVAddr, n: i32) -> i32 {
         for i in 0..n {
             let mut c = [0u8];
+            // TODO: remove kernel_builder()
             if kernel_builder()
                 .current_proc()
                 .expect("No current proc")
@@ -64,6 +65,7 @@ impl Console {
             // Wait until interrupt handler has put some
             // input into CONS.buffer.
             while this.r == this.w {
+                // TODO: remove kernel_builder()
                 if kernel_builder()
                     .current_proc()
                     .expect("No current proc")
@@ -88,6 +90,7 @@ impl Console {
             } else {
                 // Copy the input byte to the user-space buffer.
                 let cbuf = [cin as u8];
+                // TODO: remove kernel_builder()
                 if kernel_builder()
                     .current_proc()
                     .expect("No current proc")
@@ -113,6 +116,7 @@ impl Console {
         match cin {
             // Print process list.
             m if m == ctrl('P') => {
+                // TODO: remove kernel_builder()
                 unsafe { kernel_builder().procs.dump() };
             }
 
@@ -227,6 +231,7 @@ pub unsafe fn consoleinit(devsw: &mut [Devsw; NDEV]) {
 fn consolewrite(src: UVAddr, n: i32) -> i32 {
     // TODO(https://github.com/kaist-cp/rv6/issues/298) Remove below comment.
     // consolewrite() does not need console.lock() -- can lead to sleep() with lock held.
+    // TODO: remove kernel_builder()
     unsafe { (*kernel_builder().console.get_mut_raw()).write(src, n) }
 }
 
@@ -235,6 +240,7 @@ fn consolewrite(src: UVAddr, n: i32) -> i32 {
 /// User_dist indicates whether dst is a user
 /// or kernel address.
 fn consoleread(dst: UVAddr, n: i32) -> i32 {
+    // TODO: remove kernel_builder()
     let mut console = kernel_builder().console.lock();
     unsafe { Console::read(&mut console, dst, n) }
 }
@@ -244,6 +250,7 @@ fn consoleread(dst: UVAddr, n: i32) -> i32 {
 /// Do erase/kill processing, append to CONS.buf,
 /// wake up consoleread() if a whole line has arrived.
 pub unsafe fn consoleintr(cin: i32) {
+    // TODO: remove kernel_builder()
     let mut console = kernel_builder().console.lock();
     unsafe { Console::intr(&mut console, cin) };
 }

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -108,7 +108,7 @@ impl Kernel {
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let tx = self.file_system.begin_transaction();
-        let ptr = path.namei(proc)?;
+        let ptr = path.namei(proc, &self.itable)?;
         let mut ip = ptr.lock();
 
         // Check ELF header

--- a/kernel-rs/src/fs/log.rs
+++ b/kernel-rs/src/fs/log.rs
@@ -29,12 +29,12 @@ use static_assertions::const_assert;
 use crate::{
     bio::BufData,
     bio::{Buf, BufUnlocked},
-    kernel::kernel_builder,
     lock::Sleepablelock,
     param::{BSIZE, LOGSIZE, MAXOPBLOCKS},
+    virtio::Disk,
 };
 
-pub struct Log {
+pub struct Log<'a> {
     dev: u32,
     start: i32,
     size: i32,
@@ -47,6 +47,8 @@ pub struct Log {
 
     /// Contents of the header block, used to keep track in memory of logged block# before commit.
     bufs: ArrayVec<[BufUnlocked<'static>; LOGSIZE]>,
+
+    disk: &'a Sleepablelock<Disk>,
 }
 
 /// Contents of the header block, used for the on-disk header block.
@@ -55,8 +57,8 @@ struct LogHeader {
     block: [u32; LOGSIZE],
 }
 
-impl Log {
-    pub fn new(dev: u32, start: i32, size: i32) -> Self {
+impl<'a> Log<'a> {
+    pub fn new(dev: u32, start: i32, size: i32, disk: &'a Sleepablelock<Disk>) -> Self {
         let mut log = Self {
             dev,
             start,
@@ -64,6 +66,7 @@ impl Log {
             outstanding: 0,
             committing: false,
             bufs: ArrayVec::new(),
+            disk,
         };
         log.recover_from_log();
         log
@@ -73,8 +76,7 @@ impl Log {
     fn install_trans(&mut self) {
         for (tail, dbuf) in self.bufs.drain(..).enumerate() {
             // Read log block.
-            let lbuf = kernel_builder()
-                .file_system
+            let lbuf = self
                 .disk
                 .read(self.dev, (self.start + tail as i32 + 1) as u32);
 
@@ -87,16 +89,13 @@ impl Log {
                 .copy_from_slice(&lbuf.deref_inner().data[..]);
 
             // Write dst to disk.
-            kernel_builder().file_system.disk.write(&mut dbuf);
+            self.disk.write(&mut dbuf);
         }
     }
 
     /// Read the log header from disk into the in-memory log header.
     fn read_head(&mut self) {
-        let mut buf = kernel_builder()
-            .file_system
-            .disk
-            .read(self.dev, self.start as u32);
+        let mut buf = self.disk.read(self.dev, self.start as u32);
 
         const_assert!(mem::size_of::<LogHeader>() <= BSIZE);
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<LogHeader>() == 0);
@@ -108,13 +107,7 @@ impl Log {
         let lh = unsafe { &mut *(buf.deref_inner_mut().data.as_mut_ptr() as *mut LogHeader) };
 
         for b in &lh.block[0..lh.n as usize] {
-            self.bufs.push(
-                kernel_builder()
-                    .file_system
-                    .disk
-                    .read(self.dev, *b)
-                    .unlock(),
-            )
+            self.bufs.push(self.disk.read(self.dev, *b).unlock())
         }
     }
 
@@ -122,10 +115,7 @@ impl Log {
     /// This is the true point at which the
     /// current transaction commits.
     fn write_head(&mut self) {
-        let mut buf = kernel_builder()
-            .file_system
-            .disk
-            .read(self.dev, self.start as u32);
+        let mut buf = self.disk.read(self.dev, self.start as u32);
 
         const_assert!(mem::size_of::<LogHeader>() <= BSIZE);
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<LogHeader>() == 0);
@@ -140,7 +130,7 @@ impl Log {
         for (db, b) in izip!(&mut lh.block, &self.bufs) {
             *db = b.blockno;
         }
-        kernel_builder().file_system.disk.write(&mut buf)
+        self.disk.write(&mut buf)
     }
 
     fn recover_from_log(&mut self) {
@@ -204,23 +194,19 @@ impl Log {
     fn write_log(&mut self) {
         for (tail, from) in self.bufs.iter().enumerate() {
             // Log block.
-            let mut to = kernel_builder()
-                .file_system
+            let mut to = self
                 .disk
                 .read(self.dev, (self.start + tail as i32 + 1) as u32);
 
             // Cache block.
-            let from = kernel_builder()
-                .file_system
-                .disk
-                .read(self.dev, from.blockno);
+            let from = self.disk.read(self.dev, from.blockno);
 
             to.deref_inner_mut()
                 .data
                 .copy_from_slice(&from.deref_inner().data[..]);
 
             // Write the log.
-            kernel_builder().file_system.disk.write(&mut to);
+            self.disk.write(&mut to);
         }
     }
 

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -36,7 +36,7 @@ const NDIRECT: usize = 12;
 const NINDIRECT: usize = BSIZE.wrapping_div(mem::size_of::<u32>());
 const MAXFILE: usize = NDIRECT.wrapping_add(NINDIRECT);
 
-pub struct FileSystem {
+pub struct FileSystem<'s> {
     /// TODO(https://github.com/kaist-cp/rv6/issues/358)
     /// Initializing superblock should be run only once because forkret() calls fsinit()
     /// There should be one superblock per disk device, but we run with
@@ -46,17 +46,17 @@ pub struct FileSystem {
     /// TODO(https://github.com/kaist-cp/rv6/issues/358)
     /// document it / initializing log should be run
     /// only once because forkret() calls fsinit()
-    log: Once<Sleepablelock<Log>>,
+    log: Once<Sleepablelock<Log<'s>>>,
 
     /// It may sleep until some Descriptors are freed.
     pub disk: Sleepablelock<Disk>,
 }
 
-pub struct FsTransaction<'s> {
-    fs: &'s FileSystem,
+pub struct FsTransaction<'s, 't> {
+    fs: &'s FileSystem<'t>,
 }
 
-impl FileSystem {
+impl<'s> FileSystem<'s> {
     pub const fn zero() -> Self {
         Self {
             superblock: Once::new(),
@@ -65,7 +65,7 @@ impl FileSystem {
         }
     }
 
-    pub fn init(&self, dev: u32) {
+    pub fn init(&'s self, dev: u32) {
         let _ = self
             .superblock
             .call_once(|| Superblock::new(&self.disk.read(dev, 1)));
@@ -76,6 +76,7 @@ impl FileSystem {
                     dev,
                     self.superblock().logstart as i32,
                     self.superblock().nlog as i32,
+                    &self.disk,
                 ),
             )
         });
@@ -93,7 +94,7 @@ impl FileSystem {
 
     /// TODO(https://github.com/kaist-cp/rv6/issues/358)
     /// Calling log() after initialize is safe
-    fn log(&self) -> &Sleepablelock<Log> {
+    fn log(&self) -> &Sleepablelock<Log<'s>> {
         if let Some(log) = self.log.get() {
             log
         } else {
@@ -102,13 +103,13 @@ impl FileSystem {
     }
 
     /// Called for each FS system call.
-    pub fn begin_transaction(&self) -> FsTransaction<'_> {
+    pub fn begin_transaction(&self) -> FsTransaction<'_, 's> {
         Log::begin_op(self.log());
         FsTransaction { fs: self }
     }
 }
 
-impl Drop for FsTransaction<'_> {
+impl Drop for FsTransaction<'_, '_> {
     fn drop(&mut self) {
         // Called at the end of each FS system call.
         // Commits if this was the last outstanding operation.
@@ -116,7 +117,7 @@ impl Drop for FsTransaction<'_> {
     }
 }
 
-impl FsTransaction<'_> {
+impl FsTransaction<'_, '_> {
     /// Caller has modified b->data and is done with the buffer.
     /// Record the block number and pin in the cache by increasing refcnt.
     /// commit()/write_log() will do the disk write.
@@ -131,6 +132,7 @@ impl FsTransaction<'_> {
 
     /// Zero a block.
     fn bzero(&self, dev: u32, bno: u32) {
+        // TODO: remove kernel_builder()
         let mut buf = unsafe { kernel_builder().get_bcache() }
             .get_buf(dev, bno)
             .lock();

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -100,7 +100,7 @@ pub struct KernelBuilder {
 
     pub itable: Itable,
 
-    pub file_system: FileSystem,
+    pub file_system: FileSystem<'static>,
 }
 
 #[repr(transparent)]
@@ -303,7 +303,6 @@ pub unsafe fn kernel_main() -> ! {
         };
 
         // First user process.
-        // Temporarily create one more `Pin<&mut Kernel>`, just to initialize the first user process.
         unsafe {
             kernel_builder_unchecked_pin()
                 .project()

--- a/kernel-rs/src/lock/sleepablelock.rs
+++ b/kernel-rs/src/lock/sleepablelock.rs
@@ -11,7 +11,7 @@ pub struct RawSleepablelock {
     waitchannel: WaitChannel,
 }
 
-/// Similar to `Spinlock`, but guards of this lock can sleep.   
+/// Similar to `Spinlock`, but guards of this lock can sleep.
 pub type Sleepablelock<T> = Lock<RawSleepablelock, T>;
 /// Guards of `Sleepablelock<T>`. These guards can `sleep()`/`wakeup()`.
 pub type SleepablelockGuard<'s, T> = Guard<'s, RawSleepablelock, T>;
@@ -54,6 +54,7 @@ impl<T> SleepablelockGuard<'_, T> {
     pub fn sleep(&mut self) {
         self.lock.lock.waitchannel.sleep(
             self,
+            // TODO: remove kernel_builder()
             &kernel_builder().current_proc().expect("No current proc"),
         );
     }

--- a/kernel-rs/src/lock/sleeplock.rs
+++ b/kernel-rs/src/lock/sleeplock.rs
@@ -33,6 +33,7 @@ impl RawLock for RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
+        // TODO: remove kernel_builder()
         *guard = kernel_builder()
             .current_proc()
             .expect("No current proc")
@@ -47,6 +48,7 @@ impl RawLock for RawSleeplock {
 
     fn holding(&self) -> bool {
         let guard = self.locked.lock();
+        // TODO: remove kernel_builder()
         *guard
             == kernel_builder()
                 .current_proc()

--- a/kernel-rs/src/lock/spinlock.rs
+++ b/kernel-rs/src/lock/spinlock.rs
@@ -72,6 +72,7 @@ impl RawLock for RawSpinlock {
             .locked
             .compare_exchange(
                 ptr::null_mut(),
+                // TODO: remove kernel_builder()
                 kernel_builder().current_cpu(),
                 Ordering::Acquire,
                 // Okay to use `Relaxed` ordering since we don't enter the critical section anyway
@@ -104,6 +105,7 @@ impl RawLock for RawSpinlock {
     /// Check whether this cpu is holding the lock.
     /// Interrupts must be off.
     fn holding(&self) -> bool {
+        // TODO: remove kernel_builder()
         self.locked.load(Ordering::Relaxed) == kernel_builder().current_cpu()
     }
 }
@@ -115,6 +117,7 @@ pub unsafe fn push_off() {
     let old = intr_get();
     unsafe { intr_off() };
 
+    // TODO: remove kernel_builder()
     let mut cpu = kernel_builder().current_cpu();
     if unsafe { (*cpu).noff } == 0 {
         unsafe { (*cpu).interrupt_enabled = old };
@@ -125,6 +128,7 @@ pub unsafe fn push_off() {
 /// pop_off() should be paired with push_off().
 /// See push_off() for more details.
 pub unsafe fn pop_off() {
+    // TODO: remove kernel_builder()
     let mut cpu: *mut Cpu = kernel_builder().current_cpu();
     assert!(!intr_get(), "pop_off - interruptible");
     assert!(unsafe { (*cpu).noff } >= 1, "pop_off");

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -14,7 +14,7 @@ use pin_project::pin_project;
 
 use crate::{
     file::RcFile,
-    fs::{Path, RcInode},
+    fs::RcInode,
     kernel::{kernel, kernel_builder, KernelBuilder},
     lock::{
         pop_off, push_off, Guard, RawLock, Spinlock, SpinlockProtected, SpinlockProtectedGuard,
@@ -257,6 +257,7 @@ impl WaitChannel {
     /// Wake up all processes sleeping on waitchannel.
     /// Must be called without any p->lock.
     pub fn wakeup(&self) {
+        // TODO: remove kernel_builder()
         kernel_builder().procs.wakeup_pool(self)
     }
 }
@@ -466,17 +467,21 @@ impl ProcGuard {
     /// break in the few places where a lock is held but
     /// there's no process.
     unsafe fn sched(&mut self) {
+        // TODO: remove kernel_builder()
         assert_eq!((*kernel_builder().current_cpu()).noff, 1, "sched locks");
         assert_ne!(self.state(), Procstate::RUNNING, "sched running");
         assert!(!intr_get(), "sched interruptible");
 
+        // TODO: remove kernel_builder()
         let interrupt_enabled = unsafe { (*kernel_builder().current_cpu()).interrupt_enabled };
         unsafe {
             swtch(
                 &mut self.deref_mut_data().context,
+                // TODO: remove kernel_builder()
                 &mut (*kernel_builder().current_cpu()).context,
             )
         };
+        // TODO: remove kernel_builder()
         unsafe { (*kernel_builder().current_cpu()).interrupt_enabled = interrupt_enabled };
     }
 
@@ -492,6 +497,7 @@ impl ProcGuard {
         let data = unsafe { self.deref_mut_data() };
         let trap_frame = mem::replace(&mut data.trap_frame, ptr::null_mut());
         // Safe since trap_frame uniquely refers to a valid page.
+        // TODO: remove kernel_builder()
         kernel_builder().free(unsafe { Page::from_usize(trap_frame as _) });
         // Safe since memory will be initialized again when this process becomes initialized.
         unsafe { data.memory.assume_init_drop() };
@@ -771,6 +777,7 @@ impl ProcsBuilder {
             }
         }
 
+        // TODO: remove kernel_builder()
         kernel_builder().free(trap_frame);
         Err(())
     }
@@ -778,6 +785,7 @@ impl ProcsBuilder {
     /// Wake up all processes in the pool sleeping on waitchannel.
     /// Must be called without any p->lock.
     pub fn wakeup_pool(&self, target: &WaitChannel) {
+        // TODO: remove kernel_builder()
         let current_proc = kernel_builder()
             .current_proc()
             .map_or(ptr::null(), |p| p.raw());
@@ -795,9 +803,11 @@ impl ProcsBuilder {
     pub fn user_proc_init(self: Pin<&mut Self>) {
         // Allocate trap frame.
         let trap_frame = scopeguard::guard(
+            // TODO: remove kernel_builder()
             kernel_builder()
                 .alloc()
                 .expect("user_proc_init: kernel().alloc"),
+            // TODO: remove kernel_builder()
             |page| kernel_builder().free(page),
         );
 
@@ -827,7 +837,8 @@ impl ProcsBuilder {
 
         let name = b"initcode\x00";
         (&mut data.name[..name.len()]).copy_from_slice(name);
-        let _ = data.cwd.write(Path::root());
+        // TODO: remove kernel_builder()
+        let _ = data.cwd.write(kernel_builder().itable.root());
         // It's safe because cwd now has been initialized.
         guard.deref_mut_info().state = Procstate::RUNNABLE;
     }
@@ -892,7 +903,9 @@ impl Procs {
     /// Returns Ok(new process id) on success, Err(()) on error.
     pub fn fork(&self, proc: &mut CurrentProc<'_>) -> Result<Pid, ()> {
         // Allocate trap frame.
+        // TODO: remove kernel_builder()
         let trap_frame = scopeguard::guard(kernel_builder().alloc().ok_or(())?, |page| {
+            // TODO: remove kernel_builder()
             kernel_builder().free(page)
         });
 
@@ -1020,6 +1033,7 @@ impl Procs {
         // If self.cwd is not None, the inode inside self.cwd will be dropped
         // by assigning None to self.cwd. Deallocation of an inode may cause
         // disk write operations, so we must begin a transaction here.
+        // TODO: remove kernel_builder()
         let tx = kernel_builder().file_system.begin_transaction();
         // Safe since CurrentProc's cwd has been initialized.
         // It's ok to drop cwd as proc will not be used any longer.
@@ -1106,6 +1120,7 @@ pub unsafe fn scheduler() -> ! {
 /// A fork child's very first scheduling by scheduler()
 /// will swtch to forkret.
 unsafe fn forkret() {
+    // TODO: remove kernel_builder()
     let kernel = kernel_builder();
 
     let proc = kernel.current_proc().expect("No current proc");

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -13,11 +13,10 @@ use crate::{
     fcntl::FcntlFlags,
     file::{FileType, InodeFileType, RcFile},
     fs::{Dirent, FileName, FsTransaction, InodeGuard, InodeType, Path, RcInode},
-    kernel::{kernel_builder, Kernel},
+    kernel::Kernel,
     ok_or,
     page::Page,
-    param::{MAXARG, MAXPATH, NDEV, NOFILE},
-    pipe::AllocatedPipe,
+    param::{MAXARG, MAXPATH, NOFILE},
     proc::CurrentProc,
     some_or,
     syscall::{argaddr, argint, argstr, fetchaddr, fetchstr},
@@ -53,65 +52,77 @@ fn argfd<'a>(n: usize, proc: &'a CurrentProc<'a>) -> Result<(i32, &'a RcFile<'st
     Ok((fd, f))
 }
 
-/// Create an inode with given type.
-/// Returns Ok(created inode, result of given function f) on success, Err(()) on error.
-fn create<F, T>(
-    path: &Path,
-    typ: InodeType,
-    tx: &FsTransaction<'_>,
-    proc: &CurrentProc<'_>,
-    f: F,
-) -> Result<(RcInode<'static>, T), ()>
-where
-    F: FnOnce(&mut InodeGuard<'_>) -> T,
-{
-    let (ptr, name) = path.nameiparent(proc)?;
-    let mut dp = ptr.lock();
-    if let Ok((ptr2, _)) = dp.dirlookup(&name) {
-        drop(dp);
-        let mut ip = ptr2.lock();
-        if typ == InodeType::File {
-            match ip.deref_inner().typ {
-                InodeType::File | InodeType::Device { .. } => {
-                    let ret = f(&mut ip);
-                    drop(ip);
-                    return Ok((ptr2, ret));
-                }
-                _ => return Err(()),
-            }
-        }
-        return Err(());
-    }
-    let ptr2 = kernel_builder().itable.alloc_inode(dp.dev, typ, tx);
-    let mut ip = ptr2.lock();
-    ip.deref_inner_mut().nlink = 1;
-    ip.update(tx);
-
-    // Create . and .. entries.
-    if typ == InodeType::Dir {
-        // for ".."
-        dp.deref_inner_mut().nlink += 1;
-        dp.update(tx);
-
-        // No ip->nlink++ for ".": avoid cyclic ref count.
-        // It is safe because b"." does not contain any NUL characters.
-        ip.dirlink(unsafe { FileName::from_bytes(b".") }, ip.inum, tx)
-            // It is safe because b".." does not contain any NUL characters.
-            .and_then(|_| ip.dirlink(unsafe { FileName::from_bytes(b"..") }, dp.inum, tx))
-            .expect("create dots");
-    }
-    dp.dirlink(&name, ip.inum, tx).expect("create: dirlink");
-    let ret = f(&mut ip);
-    drop(ip);
-    Ok((ptr2, ret))
-}
-
 impl Kernel {
+    /// Create an inode with given type.
+    /// Returns Ok(created inode, result of given function f) on success, Err(()) on error.
+    fn create<F, T>(
+        &self,
+        path: &Path,
+        typ: InodeType,
+        tx: &FsTransaction<'_, '_>,
+        proc: &CurrentProc<'_>,
+        f: F,
+    ) -> Result<(RcInode<'_>, T), ()>
+    where
+        F: FnOnce(&mut InodeGuard<'_>) -> T,
+    {
+        let (ptr, name) = path.nameiparent(proc, &self.itable)?;
+        let mut dp = ptr.lock();
+        if let Ok((ptr2, _)) = dp.dirlookup(&name, &self.itable) {
+            drop(dp);
+            if typ != InodeType::File {
+                return Err(());
+            }
+            let mut ip = ptr2.lock();
+            if let InodeType::None | InodeType::Dir = ip.deref_inner().typ {
+                return Err(());
+            }
+            let ret = f(&mut ip);
+            drop(ip);
+            return Ok((ptr2, ret));
+        }
+        let ptr2 = self.itable.alloc_inode(dp.dev, typ, tx);
+        let mut ip = ptr2.lock();
+        ip.deref_inner_mut().nlink = 1;
+        ip.update(tx);
+
+        // Create . and .. entries.
+        if typ == InodeType::Dir {
+            // for ".."
+            dp.deref_inner_mut().nlink += 1;
+            dp.update(tx);
+
+            // No ip->nlink++ for ".": avoid cyclic ref count.
+            // It is safe because b"." does not contain any NUL characters.
+            ip.dirlink(
+                unsafe { FileName::from_bytes(b".") },
+                ip.inum,
+                tx,
+                &self.itable,
+            )
+            // It is safe because b".." does not contain any NUL characters.
+            .and_then(|_| {
+                ip.dirlink(
+                    unsafe { FileName::from_bytes(b"..") },
+                    dp.inum,
+                    tx,
+                    &self.itable,
+                )
+            })
+            .expect("create dots");
+        }
+        dp.dirlink(&name, ip.inum, tx, &self.itable)
+            .expect("create: dirlink");
+        let ret = f(&mut ip);
+        drop(ip);
+        Ok((ptr2, ret))
+    }
+
     /// Create another name(newname) for the file oldname.
     /// Returns Ok(()) on success, Err(()) on error.
     fn link(&self, oldname: &CStr, newname: &CStr, proc: &CurrentProc<'_>) -> Result<(), ()> {
         let tx = self.file_system.begin_transaction();
-        let ptr = Path::new(oldname).namei(proc)?;
+        let ptr = Path::new(oldname).namei(proc, &self.itable)?;
         let mut ip = ptr.lock();
         if ip.deref_inner().typ == InodeType::Dir {
             return Err(());
@@ -120,9 +131,9 @@ impl Kernel {
         ip.update(&tx);
         drop(ip);
 
-        if let Ok((ptr2, name)) = Path::new(newname).nameiparent(proc) {
+        if let Ok((ptr2, name)) = Path::new(newname).nameiparent(proc, &self.itable) {
             let mut dp = ptr2.lock();
-            if dp.dev != ptr.dev || dp.dirlink(name, ptr.inum, &tx).is_err() {
+            if dp.dev != ptr.dev || dp.dirlink(name, ptr.inum, &tx, &self.itable).is_err() {
             } else {
                 return Ok(());
             }
@@ -139,12 +150,12 @@ impl Kernel {
     fn unlink(&self, filename: &CStr, proc: &CurrentProc<'_>) -> Result<(), ()> {
         let de: Dirent = Default::default();
         let tx = self.file_system.begin_transaction();
-        let (ptr, name) = Path::new(filename).nameiparent(proc)?;
+        let (ptr, name) = Path::new(filename).nameiparent(proc, &self.itable)?;
         let mut dp = ptr.lock();
 
         // Cannot unlink "." or "..".
         if !(name.as_bytes() == b"." || name.as_bytes() == b"..") {
-            if let Ok((ptr2, off)) = dp.dirlookup(&name) {
+            if let Ok((ptr2, off)) = dp.dirlookup(&name, &self.itable) {
                 let mut ip = ptr2.lock();
                 assert!(ip.deref_inner().nlink >= 1, "unlink: nlink < 1");
 
@@ -177,9 +188,9 @@ impl Kernel {
         let tx = self.file_system.begin_transaction();
 
         let (ip, typ) = if omode.contains(FcntlFlags::O_CREATE) {
-            create(name, InodeType::File, &tx, proc, |ip| ip.deref_inner().typ)?
+            self.create(name, InodeType::File, &tx, proc, |ip| ip.deref_inner().typ)?
         } else {
-            let ptr = name.namei(proc)?;
+            let ptr = name.namei(proc, &self.itable)?;
             let ip = ptr.lock();
             let typ = ip.deref_inner().typ;
 
@@ -192,9 +203,7 @@ impl Kernel {
 
         let filetype = match typ {
             InodeType::Device { major, .. } => {
-                if major as usize >= NDEV {
-                    return Err(());
-                };
+                let major = self.devsw.get(major as usize).ok_or(())?;
                 FileType::Device { ip, major }
             }
             _ => {
@@ -231,7 +240,7 @@ impl Kernel {
     /// Returns Ok(()) on success, Err(()) on error.
     fn mkdir(&self, dirname: &CStr, proc: &CurrentProc<'_>) -> Result<(), ()> {
         let tx = self.file_system.begin_transaction();
-        create(Path::new(dirname), InodeType::Dir, &tx, proc, |_| ())?;
+        self.create(Path::new(dirname), InodeType::Dir, &tx, proc, |_| ())?;
         Ok(())
     }
 
@@ -245,7 +254,7 @@ impl Kernel {
         proc: &CurrentProc<'_>,
     ) -> Result<(), ()> {
         let tx = self.file_system.begin_transaction();
-        create(
+        self.create(
             Path::new(filename),
             InodeType::Device { major, minor },
             &tx,
@@ -257,14 +266,15 @@ impl Kernel {
 
     /// Change the current directory.
     /// Returns Ok(()) on success, Err(()) on error.
-    fn chdir(&self, dirname: &CStr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
+    // TODO(https://github.com/kaist-cp/rv6/issues/444): &'static self -> &self
+    fn chdir(&'static self, dirname: &CStr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/290)
         // The method namei can drop inodes. If namei succeeds, its return
         // value, ptr, will be dropped when this method returns. Deallocation
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let _tx = self.file_system.begin_transaction();
-        let ptr = Path::new(dirname).namei(proc)?;
+        let ptr = Path::new(dirname).namei(proc, &self.itable)?;
         let ip = ptr.lock();
         if ip.deref_inner().typ != InodeType::Dir {
             return Err(());
@@ -276,8 +286,8 @@ impl Kernel {
 
     /// Create a pipe, put read/write file descriptors in fd0 and fd1.
     /// Returns Ok(()) on success, Err(()) on error.
-    fn pipe(&self, fdarray: UVAddr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
-        let (pipereader, pipewriter) = AllocatedPipe::alloc()?;
+    fn pipe(&'static self, fdarray: UVAddr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
+        let (pipereader, pipewriter) = self.allocate_pipe()?;
 
         let fd0 = pipereader.fdalloc(proc).map_err(|_| ())?;
         let fd1 = pipewriter
@@ -326,7 +336,7 @@ impl Kernel {
         let n = argint(2, proc)?;
         let p = argaddr(1, proc)?;
         // Safe since write will not access proc's open_files.
-        unsafe { (*(f as *const RcFile<'static>)).write(p.into(), n, proc) }
+        unsafe { (*(f as *const RcFile<'static>)).write(p.into(), n, proc, &self.file_system) }
     }
 
     /// Release open file fd.
@@ -401,7 +411,7 @@ impl Kernel {
 
     /// Change the current directory.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_chdir(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_chdir(&'static self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = argstr(0, &mut path, proc)?;
         self.chdir(path, proc)?;
@@ -451,7 +461,7 @@ impl Kernel {
 
     /// Create a pipe.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_pipe(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_pipe(&'static self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         // user pointer to array of two integers
         let fdarray = argaddr(0, proc)?.into();
         self.pipe(fdarray, proc)?;

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -146,6 +146,7 @@ impl Uart {
     /// by write().
     pub fn putc(&self, c: i32) {
         let mut guard = self.tx_lock.lock();
+        // TODO: remove kernel_builder()
         if kernel_builder().is_panicked() {
             spin_loop();
         }
@@ -172,6 +173,7 @@ impl Uart {
         unsafe {
             push_off();
         }
+        // TODO: remove kernel_builder()
         if kernel_builder().is_panicked() {
             spin_loop();
         }

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -165,6 +165,7 @@ impl Sleepablelock<Disk> {
     /// Return a locked Buf with the `latest` contents of the indicated block.
     /// If buf.valid is true, we don't need to access Disk.
     pub fn read(&self, dev: u32, blockno: u32) -> Buf<'static> {
+        // TODO: remove kernel_builder()
         let mut buf = unsafe { kernel_builder().get_bcache() }
             .get_buf(dev, blockno)
             .lock();
@@ -322,6 +323,7 @@ impl Disk {
         while b.deref_inner().disk {
             (*b).vdisk_request_waitchannel.sleep(
                 this,
+                // TODO: remove kernel_builder()
                 &kernel_builder().current_proc().expect("No current proc"),
             );
         }


### PR DESCRIPTION
#267 을 부분적으로 해결하는 PR입니다. 다음 파일에 있는 `kernel_builder` 호출을 없앴습니다.

* fs/path.rs
  * `Path::root`를 `Itable::root`로 옮김. 이에 따라 `ProcsBuilder::user_proc_init`이 init 프로세스의 초기 cwd를 인자로 받음.
  * `Path::namei`와 `Path::nameiparent`가 `&Itable`을 인자로 받음.
* fs/log.rs
  * `Log`의 대부분 메서드가 `&Disk`를 인자로 받음.
* fs/inode.rs (partial)
  * `InodeGuard::dirlink`와 `InodeGuard::dirlookup`이 `&Itable`을 인자로 받음.
* file.rs (partial)
  * `FileType::Device`가 `major`로 `u16` 대신 `&Devsw`를 가짐.
  * `File::write`이 `&FileSystem`을 인자로 받음.
* sysfile.rs
  * `create`을 전역 함수에서 `Kernel`의 메서드로 바꿈.
* pipe.rs
  * `AllocatedPipe::alloc`을 `Kernel::allocate_pipe`로 옮김.
  * `AllocatedPipe::close`가 `Page`를 직접 free하는 대신 그냥 반환.

`'b: 'a`일 때 `Rc<'b, T, S>`를 `Rc<'a, T, S>`의 서브타입으로 취급하기 위해 `arena.rs`에 `narrow_lifetime`을 정의했습니다. 알아서 서브타입으로 간주가 되면 좋겠는데, 이유는 잘 모르겠지만 그렇게는 되지 않습니다. 실질적으로 `narrow_lifetime`이 하는 일이 없으므로 최적화가 잘 된다면 overhead를 추가하지는 않을 것 같습니다.