### PR TITLE
[Closes #393] Fix Arena's synchronization

### DIFF
--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -208,7 +208,9 @@ impl<T: 'static + ArenaObject + Unpin, const CAPACITY: usize> Arena
                 }
             } else if empty.is_null() {
                 empty = entry;
-                break;
+                // Note: Do not use `break` here.
+                // We must first search through all entries, and then alloc at empty
+                // only if the entry we're finding for doesn't exist.
             }
         }
 

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -62,12 +62,23 @@ pub trait Arena: Sized {
     /// `handle` must be allocated from `self`.
     unsafe fn dealloc(&self, handle: Self::Handle<'_>);
 
-    fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R
+    /// Temporarily releases the lock while calling `f`, and re-acquires the lock after `f` returned.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be careful when calling this inside `ArenaObject::finalize`.
+    /// If you use this while finalizing an `ArenaObject`, the `Arena`'s lock will be temporarily released,
+    /// and hence, another thread may use `Arena::find_or_alloc` to obtain an `Rc` referring to the `ArenaObject`
+    /// we are **currently finalizing**. Therefore, in this case, make sure no thread tries to `find_or_alloc`
+    /// for an `ArenaObject` that may be under finalization.
+    unsafe fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R
     where
         F: FnOnce() -> R;
 }
 
 pub trait ArenaObject {
+    /// Finalizes the `ArenaObject`.
+    /// This function is automatically called when the last `Rc` refereing to this `ArenaObject` gets dropped.
     fn finalize<'s, A: Arena>(&'s mut self, guard: &'s mut A::Guard<'_>);
 }
 
@@ -260,7 +271,7 @@ impl<T: 'static + ArenaObject + Unpin, const CAPACITY: usize> Arena
         mem::forget(handle);
     }
 
-    fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R
+    unsafe fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R
     where
         F: FnOnce() -> R,
     {
@@ -432,7 +443,7 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
         mem::forget(handle);
     }
 
-    fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R
+    unsafe fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R
     where
         F: FnOnce() -> R,
     {


### PR DESCRIPTION
Closes #393
### Background
기존의 rv6는 synchronization 관련하여 **잠재적인 버그** 1개와 **early break 관련된 버그** 1개가 있었던 것으로 보입니다.
* 잠재적인 버그
  * thread가 어떤 `ArenaObject`를 finalize하고 있을때 `Arena::reacquire_after`를 사용하면, 잠깐동안 `Arena`의 lock이 해제되므로, 이 사이에 다른 thread가 실수로 이미 finalize되고 있는 `ArenaObject`을 `find_or_alloc`하려고 시도할 수 있습니다.
* early break 관련된 버그
  * 7b493ce 에서 추가한 break로 인해, xv6와 rv6의 semantics가 달라지게 되었습니다.
  * 기존에는 모든 entry를 한번씩 검사해본 후에만 alloc을 시도하였는데, break을 추가한 이후에는 빈자릴 찾자마자 그 곳에 alloc을 시도하게 되었습니다.

### Changes
* 잠재적인 버그
  * 이런 행위를 시도하면 안된다는 점을 나타내기 위해서, `Arena::reacquire_after`를 unsafe fn으로 변경했습니다.
  * 참고로, xv6는 이런 행위를 시도하지 않는 것을 보입니다. (이유는 주석으로 적어놨습니다.)
* early break 관련된 버그
  * break을 없앴습니다. 즉, 다시 xv6의 semantics로 되돌렸습니다.