### PR TITLE
[Closes #450] Fix unsoundness in list.rs.

### DIFF
--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -122,7 +122,7 @@ pub struct MruArena<T, const CAPACITY: usize> {
     #[pin]
     entries: [MruEntry<T>; CAPACITY],
     #[pin]
-    list: List<MruEntry<T>, 0>,
+    list: List<MruEntry<T>>,
 }
 
 /// # Safety
@@ -285,7 +285,8 @@ impl<T> MruEntry<T> {
     }
 }
 
-impl<T> ListNode<0> for MruEntry<T> {
+// Safe since `MruEntry` owns a `ListEntry`.
+unsafe impl<T> ListNode for MruEntry<T> {
     fn get_list_entry(&self) -> &ListEntry {
         &self.list_entry
     }

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -110,8 +110,6 @@ impl<'s, T> ArrayPtr<'s, T> {
 #[pin_project]
 #[repr(C)]
 pub struct MruEntry<T> {
-    #[pin]
-    list_entry: ListEntry,
     refcnt: usize,
     data: T,
 }
@@ -120,7 +118,7 @@ pub struct MruEntry<T> {
 #[pin_project]
 pub struct MruArena<T, const CAPACITY: usize> {
     #[pin]
-    entries: [MruEntry<T>; CAPACITY],
+    entries: [ListNode<MruEntry<T>>; CAPACITY],
     #[pin]
     list: List<MruEntry<T>>,
 }
@@ -131,7 +129,7 @@ pub struct MruArena<T, const CAPACITY: usize> {
 /// Always acquire the `Spinlock<MruArena<T, CAPACITY>>` before modifying `MruEntry<T>`.
 /// Also, never move `MruEntry<T>`.
 pub struct MruPtr<'s, T> {
-    ptr: NonNull<MruEntry<T>>,
+    ptr: NonNull<ListNode<MruEntry<T>>>,
     _marker: PhantomData<&'s T>,
 }
 
@@ -277,28 +275,13 @@ impl<T> MruEntry<T> {
     // const LIST_ENTRY_OFFSET: usize = offset_of!(MruEntry<T>, list_entry);
 
     pub const fn new(data: T) -> Self {
-        Self {
-            refcnt: 0,
-            data,
-            list_entry: unsafe { ListEntry::new() },
-        }
-    }
-}
-
-// Safe since `MruEntry` owns a `ListEntry`.
-unsafe impl<T> ListNode for MruEntry<T> {
-    fn get_list_entry(&self) -> &ListEntry {
-        &self.list_entry
-    }
-
-    fn from_list_entry(list_entry: *const ListEntry) -> *const Self {
-        (list_entry as *const _ as usize - Self::LIST_ENTRY_OFFSET) as *const Self
+        Self { refcnt: 0, data }
     }
 }
 
 impl<T, const CAPACITY: usize> MruArena<T, CAPACITY> {
     // TODO(https://github.com/kaist-cp/rv6/issues/371): unsafe...
-    pub const fn new(entries: [MruEntry<T>; CAPACITY]) -> Self {
+    pub const fn new(entries: [ListNode<MruEntry<T>>; CAPACITY]) -> Self {
         Self {
             entries,
             list: unsafe { List::new() },
@@ -309,7 +292,7 @@ impl<T, const CAPACITY: usize> MruArena<T, CAPACITY> {
         let mut this = self.project();
         this.list.as_mut().init();
         for mut entry in IterPinMut::from(this.entries) {
-            entry.as_mut().project().list_entry.init();
+            entry.as_mut().init();
             this.list.push_front(&entry);
         }
     }
@@ -343,13 +326,13 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
         n: N,
     ) -> Option<Self::Handle<'s>> {
         let this = self.lock();
-        let mut empty: *mut MruEntry<T> = ptr::null_mut();
+        let mut empty: *mut ListNode<MruEntry<T>> = ptr::null_mut();
         // Safe since the whole `MruArena` is protected by a lock.
         for entry in unsafe { this.list.iter_unchecked() } {
             if c(&entry.data) {
                 // Safe since we just increase the refcnt.
                 // TODO: Remove this after PR #435.
-                let entry = unsafe { &mut *(entry as *const _ as *mut MruEntry<T>) };
+                let entry = unsafe { &mut *(entry as *const _ as *mut ListNode<MruEntry<T>>) };
                 entry.refcnt += 1;
                 return Some(Self::Handle::<'s> {
                     ptr: NonNull::from(entry),
@@ -381,7 +364,7 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
             if entry.refcnt == 0 {
                 // Safe since we hold the `MruArena` lock, and nobody uses the `MruEntry`.
                 // TODO: Remove this after PR #435.
-                let entry = unsafe { &mut *(entry as *const _ as *mut MruEntry<T>) };
+                let entry = unsafe { &mut *(entry as *const _ as *mut ListNode<MruEntry<T>>) };
                 entry.refcnt = 1;
                 f(&mut entry.data);
                 return Some(Self::Handle::<'s> {
@@ -416,14 +399,14 @@ impl<T: 'static + ArenaObject, const CAPACITY: usize> Arena for Spinlock<MruAren
         let mut this = self.lock();
 
         // Safe since we mutate the `MruEntry`'s data only when this is the last handle.
-        let mut entry = unsafe { handle.ptr.as_mut() };
+        let entry = unsafe { handle.ptr.as_mut() };
         if entry.refcnt == 1 {
             entry.data.finalize::<Self>(&mut this);
         }
         entry.refcnt -= 1;
 
         if entry.refcnt == 0 {
-            entry.list_entry.remove();
+            entry.remove();
             this.list.push_back(entry);
         }
 

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -122,7 +122,7 @@ pub struct MruArena<T, const CAPACITY: usize> {
     #[pin]
     entries: [MruEntry<T>; CAPACITY],
     #[pin]
-    list: List<MruEntry<T>>,
+    list: List<MruEntry<T>, 0>,
 }
 
 /// # Safety
@@ -285,8 +285,7 @@ impl<T> MruEntry<T> {
     }
 }
 
-// Safe since `MruEntry` owns a `ListEntry`.
-unsafe impl<T> ListNode for MruEntry<T> {
+impl<T> ListNode<0> for MruEntry<T> {
     fn get_list_entry(&self) -> &ListEntry {
         &self.list_entry
     }

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -18,6 +18,7 @@ use array_macro::array;
 
 use crate::{
     arena::{Arena, ArenaObject, MruArena, MruEntry, Rc},
+    list::ListNode,
     lock::{Sleeplock, Spinlock},
     param::{BSIZE, NBUF},
     proc::WaitChannel,
@@ -151,7 +152,7 @@ impl Bcache {
         unsafe {
             Spinlock::new(
                 "BCACHE",
-                MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF]),
+                MruArena::new(array![_ => ListNode::new(MruEntry::new(BufEntry::zero())); NBUF]),
             )
         }
     }

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -18,7 +18,6 @@ use array_macro::array;
 
 use crate::{
     arena::{Arena, ArenaObject, MruArena, MruEntry, Rc},
-    list::ListNode,
     lock::{Sleeplock, Spinlock},
     param::{BSIZE, NBUF},
     proc::WaitChannel,
@@ -152,7 +151,7 @@ impl Bcache {
         unsafe {
             Spinlock::new(
                 "BCACHE",
-                MruArena::new(array![_ => ListNode::new(MruEntry::new(BufEntry::zero())); NBUF]),
+                MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF]),
             )
         }
     }

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -1,108 +1,301 @@
-//! Doubly circular intrusive linked list with head node.
-//! `ListEntry` types must be first initialized with init()
-//! before calling its member functions.
+//! Doubly intrusive linked list with head node.
+//! A `List` or `ListEntry` must be first initialized before using its methods.
+//!
+//! # Lifetime-less intrusive linked lists
+//!
+//! Intrusive linked lists are interesting and useful because the list does not own the nodes.
+//! However, it can also be unsafe if the nodes could move or drop while it's inside the list.
+//! Hence, many intrusive linked lists written in Rust use lifetimes and prohibit nodes
+//! from being moved or dropped during the list's whole lifetime.
+//! However, this means nodes cannot be mutated, moved or dropped even after it was removed from the list.
+//!
+//! On contrast, this list does not use lifetimes and allows nodes from being mutated or dropped
+//! even when its inside the list. When a node gets dropped, we simply remove it from the list.
+//! Instead, a `List` or `ListEntry`'s methods never returns a reference to a node or `ListEntry`, and always
+//! returns a raw pointer instead. This is because a node could get mutated or dropped at any time, and hence,
+//! the caller should make sure the node is not under mutation or already dropped when dereferencing the raw pointer.
+// TODO: Also allow move.
 
+use core::cell::Cell;
 use core::marker::PhantomPinned;
 use core::pin::Pin;
 use core::ptr;
 
 use pin_project::{pin_project, pinned_drop};
 
+/// A doubly linked list.
+/// Can only contain types that implement the `ListNode` trait.
+/// Use only after initialization.
+///
+/// # Safety
+///
+/// A `List` contains one or more `ListEntry`s.
+/// * Exactly one of them is the `head`.
+/// * All other of them are a `ListEntry` owned by a `T: ListNode`.
 #[pin_project(PinnedDrop)]
-pub struct ListEntry {
-    next: *mut ListEntry,
-    prev: *mut ListEntry,
+pub struct List<T: ListNode> {
+    #[pin]
+    head: ListEntry<T>,
+}
+
+/// An iterator over the elements of `List`.
+pub struct Iter<'s, T: ListNode> {
+    last: &'s ListEntry<T>,
+    curr: &'s ListEntry<T>,
+}
+
+/// Intrusive linked list nodes that can be inserted into a `List`.
+///
+/// # Safety
+///
+/// Only implement this for structs that own a `ListEntry`.
+/// The required functions should provide conversion between the struct and its `ListEntry`.
+pub unsafe trait ListNode: Sized {
+    /// Returns a reference of this struct's `ListEntry`.
+    fn get_list_entry(&self) -> &ListEntry<Self>;
+
+    /// Returns a raw pointer which points to the struct that owns the given `list_entry`.
+    /// You may want to use `offset_of!` to implement this.
+    fn from_list_entry(list_entry: *const ListEntry<Self>) -> *const Self;
+}
+
+/// A list entry for doubly, intrusive linked lists.
+///
+/// # Safety
+///
+/// * All `ListEntry` types must be used only after initializing it with `ListEntry::init`.
+/// After this, `ListEntry::{prev, next}` always refer to a valid, initialized `ListEntry`.
+#[pin_project(PinnedDrop)]
+pub struct ListEntry<T: ListNode> {
+    prev: Cell<*const Self>,
+    next: Cell<*const Self>,
     #[pin]
     _marker: PhantomPinned, //`ListEntry` is `!Unpin`.
 }
 
-/// A list entry for doubly, circular, intrusive linked lists.
-///
-/// # Safety
-///
-/// All `ListEntry` types must be used only after initializing it with `ListEntry::init()`,
-/// or after appending/prepending it to another initialized `ListEntry`.
-/// After this, `ListEntry::{prev, next}` always refer to a valid, initialized `ListEntry`.
-impl ListEntry {
-    /// Returns an uninitialized `ListEntry`,
+impl<T: ListNode> List<T> {
+    /// Returns an uninitialized `List`,
     ///
     /// # Safety
     ///
-    /// All `ListEntry` types must be used only after initializing it with `ListEntry::init()`,
-    /// or after appending/prepending it to another initialized `ListEntry`.
+    /// All `List` types must be used only after initializing it with `List::init`.
     pub const unsafe fn new() -> Self {
         Self {
-            prev: ptr::null_mut(),
-            next: ptr::null_mut(),
-            _marker: PhantomPinned,
+            head: unsafe { ListEntry::new() },
         }
     }
 
+    /// Initializes this `ListEntry` if it was not initialized.
+    /// Otherwise, does nothing.
     pub fn init(self: Pin<&mut Self>) {
-        // Safe since we don't move the inner data and don't leak the mutable reference.
-        let this = unsafe { self.get_unchecked_mut() };
-        this.next = this;
-        this.prev = this;
+        self.project().head.init();
     }
 
-    pub fn prev(self: Pin<&mut Self>) -> Pin<&mut Self> {
-        unsafe { Pin::new_unchecked(&mut **self.project().prev) }
-    }
-
-    pub fn next(self: Pin<&mut Self>) -> Pin<&mut Self> {
-        unsafe { Pin::new_unchecked(&mut **self.project().next) }
-    }
-
-    /// `e` <-> `this`
-    pub fn append(self: Pin<&mut Self>, e: Pin<&mut Self>) {
-        // Safe since we don't move the inner data and don't leak the mutable reference.
-        let this = unsafe { self.get_unchecked_mut() };
-        let elem = unsafe { e.get_unchecked_mut() };
-
-        elem.next = this;
-        elem.prev = this.prev;
-        unsafe {
-            (*elem.next).prev = elem;
-            (*elem.prev).next = elem;
-        }
-    }
-
-    /// `this` <-> `e`
-    pub fn prepend(self: Pin<&mut Self>, e: Pin<&mut Self>) {
-        // Safe since we don't move the inner data and don't leak the mutable reference.
-        let this = unsafe { self.get_unchecked_mut() };
-        let elem = unsafe { e.get_unchecked_mut() };
-
-        elem.next = this.next;
-        elem.prev = this;
-        unsafe {
-            (*elem.next).prev = elem;
-            (*elem.prev).next = elem;
-        }
-    }
-
+    /// Returns true if this `List` is empty.
+    /// Otherwise, returns flase.
     pub fn is_empty(&self) -> bool {
-        ptr::eq(self.next, self)
+        self.head.is_unlinked()
     }
 
-    pub fn remove(self: Pin<&mut Self>) {
-        unsafe {
-            (*self.prev).next = self.next;
-            (*self.next).prev = self.prev;
+    /// Provides a raw pointer to the back node, or `None` if the list is empty.
+    pub fn back(&self) -> Option<*const T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(T::from_list_entry(self.head.prev()))
         }
-        self.init();
     }
 
-    pub fn list_pop_front(self: Pin<&mut Self>) -> Pin<&mut Self> {
-        // Safe since we don't move the inner data and don't leak the mutable reference.
-        let mut result = unsafe { Pin::new_unchecked(&mut *self.next) };
-        result.as_mut().remove();
-        result
+    /// Provides a raw pointer to the front node, or `None` if the list is empty.
+    pub fn front(&self) -> Option<*const T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(T::from_list_entry(self.head.next()))
+        }
+    }
+
+    /// Push `elt` at the back of the list after unlinking it.
+    // TODO: Use PinFreeze<T>?
+    pub fn push_back(&self, elt: &T) {
+        self.head.push_back(elt);
+    }
+
+    /// Push `elt` at the front of the list after unlinking it.
+    pub fn push_front(&self, elt: &T) {
+        self.head.push_front(elt);
+    }
+
+    /// Removes the last node from the list and returns a raw pointer to it,
+    /// or `None` if the list is empty.
+    pub fn pop_back(&self) -> Option<*const T> {
+        let ptr = self.head.prev();
+        if ptr::eq(ptr, &self.head) {
+            None
+        } else {
+            unsafe { (&*ptr).remove() };
+            Some(T::from_list_entry(ptr))
+        }
+    }
+
+    /// Removes the last node from the list and returns a raw pointer to it,
+    /// or `None` if the list is empty.
+    pub fn pop_front(&self) -> Option<*const T> {
+        let ptr = self.head.next();
+        if ptr::eq(ptr, &self.head) {
+            None
+        } else {
+            unsafe { (&*ptr).remove() };
+            Some(T::from_list_entry(ptr))
+        }
+    }
+
+    /// Removes all nodes from the list.
+    pub fn clear(&self) {
+        while self.pop_front().is_some() {}
+    }
+
+    /// Provides an unsafe forward iterator.
+    ///
+    /// # Safety
+    ///
+    /// The caller must make sure that the iterator's **current** items does not get removed, mutated, or dropped.
+    /// * If the item gets removed, the iterator will loop forever.
+    /// * If the item gets mutated/dropped, using the iterator may lead to undefined behavior.
+    pub unsafe fn unsafe_iter(&self) -> Iter<'_, T> {
+        Iter {
+            last: &self.head,
+            curr: unsafe { &*self.head.next() },
+        }
     }
 }
 
 #[pinned_drop]
-impl PinnedDrop for ListEntry {
+impl<T: ListNode> PinnedDrop for List<T> {
+    fn drop(self: Pin<&mut Self>) {
+        self.clear();
+    }
+}
+
+impl<'s, T: 's + ListNode> Iterator for Iter<'s, T> {
+    type Item = &'s T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if ptr::eq(self.last, self.curr) {
+            None
+        } else {
+            // Safe since `self.curr` is a `ListEntry` contained inside a `T`.
+            let res = Some(unsafe { &*T::from_list_entry(self.curr) });
+            debug_assert_ne!(self.curr as *const _, self.curr.next(), "loops forever");
+            self.curr = unsafe { &*self.curr.next() };
+            res
+        }
+    }
+}
+
+impl<'s, T: 's + ListNode> DoubleEndedIterator for Iter<'s, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if ptr::eq(self.last, self.curr) {
+            None
+        } else {
+            debug_assert_ne!(self.last as *const _, self.last.prev(), "loops forever");
+            self.last = unsafe { &*self.last.prev() };
+            // Safe since `self.last` is a `ListEntry` contained inside a `T`.
+            Some(unsafe { &*T::from_list_entry(self.last) })
+        }
+    }
+}
+
+impl<T: ListNode> ListEntry<T> {
+    /// Returns an uninitialized `ListEntry`,
+    ///
+    /// # Safety
+    ///
+    /// All `ListEntry` types must be used only after initializing it with `ListEntry::init`.
+    pub const unsafe fn new() -> Self {
+        Self {
+            prev: Cell::new(ptr::null_mut()),
+            next: Cell::new(ptr::null_mut()),
+            _marker: PhantomPinned,
+        }
+    }
+
+    /// Initializes this `ListEntry` if it was not initialized.
+    /// Otherwise, does nothing.
+    pub fn init(self: Pin<&mut Self>) {
+        if self.next().is_null() {
+            self.next.set(self.as_ref().get_ref());
+            self.prev.set(self.as_ref().get_ref());
+        }
+    }
+
+    /// Returns a raw pointer pointing to the previous `ListEntry`.
+    ///
+    /// # Note
+    ///
+    /// Do not use `ListNode::from_list_entry` on the returned pointer if `self` is the front node of a list.
+    pub fn prev(&self) -> *const Self {
+        self.prev.get()
+    }
+
+    /// Returns a raw pointer pointing to the next `ListEntry`.
+    ///
+    /// # Note
+    ///
+    /// Do not use `ListNode::from_list_entry` on the returned pointer if `self` is the back node of a list.
+    pub fn next(&self) -> *const Self {
+        self.next.get()
+    }
+
+    /// Returns `true` if this `ListEntry` is not linked to any other `ListEntry`.
+    /// Otherwise, returns `false`.
+    pub fn is_unlinked(&self) -> bool {
+        ptr::eq(self.next(), self)
+    }
+
+    /// Inserts `elt` at the back of this `ListEntry` after unlinking `elt`.
+    pub fn push_back(&self, elt: &T) {
+        let e = elt.get_list_entry();
+        if !e.is_unlinked() {
+            e.remove();
+        }
+
+        e.next.set(self);
+        e.prev.set(self.prev());
+        unsafe {
+            (*e.next()).prev.set(e);
+            (*e.prev()).next.set(e);
+        }
+    }
+
+    /// Inserts `elt` in front of this `ListEntry` after unlinking `elt`.
+    pub fn push_front(&self, elt: &T) {
+        let e = elt.get_list_entry();
+        if !e.is_unlinked() {
+            e.remove();
+        }
+
+        e.next.set(self.next());
+        e.prev.set(self);
+        unsafe {
+            (*e.next()).prev.set(e);
+            (*e.prev()).next.set(e);
+        }
+    }
+
+    /// Unlinks this `ListEntry` from other `ListEntry`s.
+    pub fn remove(&self) {
+        unsafe {
+            (*self.prev()).next.set(self.next());
+            (*self.next()).prev.set(self.prev());
+        }
+        self.prev.set(self);
+        self.next.set(self);
+    }
+}
+
+#[pinned_drop]
+impl<T: ListNode> PinnedDrop for ListEntry<T> {
     fn drop(self: Pin<&mut Self>) {
         self.remove();
     }

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -1,5 +1,5 @@
 //! Doubly intrusive linked list with head node.
-//! A `List` or `ListEntry` must be first initialized before using its methods.
+//! A [`List`] or [`ListNode`] must be first initialized before using its methods.
 //!
 //! # Lifetime-less intrusive linked lists
 //!
@@ -11,71 +11,67 @@
 //!
 //! In contrast, [`List`] does not use lifetimes and allows nodes from being mutated or dropped
 //! even when its inserted in the list. When a node gets dropped, we simply remove it from the list.
-//! Instead, a `List` or `ListEntry`'s methods never returns a reference to a node or `ListEntry`, and always
+//! Instead, a [`List`] or [`ListNode`]'s methods never returns a reference to a node and always
 //! returns a raw pointer instead. This is because a node could get mutated or dropped at any time, and hence,
 //! the caller should make sure the node is not under mutation or already dropped when dereferencing the raw pointer.
 // TODO: Also allow move.
 
 use core::cell::Cell;
 use core::marker::{PhantomData, PhantomPinned};
+use core::mem;
+use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::ptr;
 
 use pin_project::{pin_project, pinned_drop};
 
 /// A doubly linked list.
-/// Can only contain types that implement the `ListNode` trait.
+/// Can only contain `ListNode`s.
 /// Use only after initialization.
 ///
 /// # Safety
 ///
 /// A `List` contains one or more `ListEntry`s.
 /// * Exactly one of them is the `head`.
-/// * All other of them are a `ListEntry` owned by a `T: ListNode`.
+/// * All other of them are a `ListEntry` owned by a `ListNode`.
 #[pin_project(PinnedDrop)]
-pub struct List<T: ListNode> {
+pub struct List<T> {
     #[pin]
     head: ListEntry,
     _marker: PhantomData<T>,
 }
 
-/// An iterator over the elements of `List`.
-pub struct Iter<'s, T: ListNode> {
+/// An iterator over the `ListNode`s of a `List`.
+pub struct Iter<'s, T> {
     last: &'s ListEntry,
     curr: &'s ListEntry,
     _marker: PhantomData<T>,
 }
 
 /// Intrusive linked list nodes that can be inserted into a `List`.
-///
-/// # Safety
-///
-/// Only implement this for structs that own a `ListEntry`.
-/// The required functions should provide conversion between the struct and its `ListEntry`.
-pub unsafe trait ListNode: Sized {
-    /// Returns a reference of this struct's `ListEntry`.
-    fn get_list_entry(&self) -> &ListEntry;
-
-    /// Returns a raw pointer which points to the struct that owns the given `list_entry`.
-    /// You may want to use `offset_of!` to implement this.
-    fn from_list_entry(list_entry: *const ListEntry) -> *const Self;
+#[pin_project]
+#[repr(C)]
+pub struct ListNode<T> {
+    #[pin]
+    list_entry: ListEntry,
+    data: T,
 }
 
-/// A list entry for doubly, intrusive linked lists.
+/// A low level primitive for doubly, intrusive linked lists and nodes.
 ///
 /// # Safety
 ///
 /// * All `ListEntry` types must be used only after initializing it with `ListEntry::init`.
 /// After this, `ListEntry::{prev, next}` always refer to a valid, initialized `ListEntry`.
 #[pin_project(PinnedDrop)]
-pub struct ListEntry {
+struct ListEntry {
     prev: Cell<*const Self>,
     next: Cell<*const Self>,
     #[pin]
     _marker: PhantomPinned, //`ListEntry` is `!Unpin`.
 }
 
-impl<T: ListNode> List<T> {
+impl<T> List<T> {
     /// Returns an uninitialized `List`,
     ///
     /// # Safety
@@ -101,55 +97,55 @@ impl<T: ListNode> List<T> {
     }
 
     /// Provides a raw pointer to the back node, or `None` if the list is empty.
-    pub fn back(&self) -> Option<*const T> {
+    pub fn back(&self) -> Option<*const ListNode<T>> {
         if self.is_empty() {
             None
         } else {
-            Some(T::from_list_entry(self.head.prev()))
+            Some(ListNode::from_list_entry(self.head.prev()))
         }
     }
 
     /// Provides a raw pointer to the front node, or `None` if the list is empty.
-    pub fn front(&self) -> Option<*const T> {
+    pub fn front(&self) -> Option<*const ListNode<T>> {
         if self.is_empty() {
             None
         } else {
-            Some(T::from_list_entry(self.head.next()))
+            Some(ListNode::from_list_entry(self.head.next()))
         }
     }
 
     /// Push `elt` at the back of the list after unlinking it.
     // TODO: Use PinFreeze<T>?
-    pub fn push_back(&self, elt: &T) {
-        self.head.push_back(elt.get_list_entry());
+    pub fn push_back(&self, elt: &ListNode<T>) {
+        self.head.push_back(&elt.list_entry);
     }
 
     /// Push `elt` at the front of the list after unlinking it.
-    pub fn push_front(&self, elt: &T) {
-        self.head.push_front(elt.get_list_entry());
+    pub fn push_front(&self, elt: &ListNode<T>) {
+        self.head.push_front(&elt.list_entry);
     }
 
     /// Removes the last node from the list and returns a raw pointer to it,
     /// or `None` if the list is empty.
-    pub fn pop_back(&self) -> Option<*const T> {
+    pub fn pop_back(&self) -> Option<*const ListNode<T>> {
         let ptr = self.head.prev();
         if ptr::eq(ptr, &self.head) {
             None
         } else {
             unsafe { (&*ptr).remove() };
-            Some(T::from_list_entry(ptr))
+            Some(ListNode::from_list_entry(ptr))
         }
     }
 
     /// Removes the last node from the list and returns a raw pointer to it,
     /// or `None` if the list is empty.
-    pub fn pop_front(&self) -> Option<*const T> {
+    pub fn pop_front(&self) -> Option<*const ListNode<T>> {
         let ptr = self.head.next();
         if ptr::eq(ptr, &self.head) {
             None
         } else {
             unsafe { (&*ptr).remove() };
-            Some(T::from_list_entry(ptr))
+            Some(ListNode::from_list_entry(ptr))
         }
     }
 
@@ -179,21 +175,21 @@ impl<T: ListNode> List<T> {
 }
 
 #[pinned_drop]
-impl<T: ListNode> PinnedDrop for List<T> {
+impl<T> PinnedDrop for List<T> {
     fn drop(self: Pin<&mut Self>) {
         self.clear();
     }
 }
 
-impl<'s, T: 's + ListNode> Iterator for Iter<'s, T> {
-    type Item = &'s T;
+impl<'s, T: 's> Iterator for Iter<'s, T> {
+    type Item = &'s ListNode<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if ptr::eq(self.last, self.curr) {
             None
         } else {
             // Safe since `self.curr` is a `ListEntry` contained inside a `T`.
-            let res = Some(unsafe { &*T::from_list_entry(self.curr) });
+            let res = Some(unsafe { &*ListNode::from_list_entry(self.curr) });
             debug_assert_ne!(self.curr as *const _, self.curr.next(), "loops forever");
             self.curr = unsafe { &*self.curr.next() };
             res
@@ -201,7 +197,7 @@ impl<'s, T: 's + ListNode> Iterator for Iter<'s, T> {
     }
 }
 
-impl<'s, T: 's + ListNode> DoubleEndedIterator for Iter<'s, T> {
+impl<'s, T: 's> DoubleEndedIterator for Iter<'s, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if ptr::eq(self.last, self.curr) {
             None
@@ -209,8 +205,84 @@ impl<'s, T: 's + ListNode> DoubleEndedIterator for Iter<'s, T> {
             debug_assert_ne!(self.last as *const _, self.last.prev(), "loops forever");
             self.last = unsafe { &*self.last.prev() };
             // Safe since `self.last` is a `ListEntry` contained inside a `T`.
-            Some(unsafe { &*T::from_list_entry(self.last) })
+            Some(unsafe { &*ListNode::from_list_entry(self.last) })
         }
+    }
+}
+
+impl<T> ListNode<T> {
+    // TODO(https://github.com/kaist-cp/rv6/issues/369)
+    // A workarond for https://github.com/Gilnaa/memoffset/issues/49.
+    // Assumes `list_entry` is located at the beginning of `ListNode`
+    // and `data` is located at `mem::size_of::<ListEntry>()`.
+    const DATA_OFFSET: usize = mem::size_of::<ListEntry>();
+    const LIST_ENTRY_OFFSET: usize = 0;
+
+    // const DATA_OFFSET: usize = offset_of!(ListNode<T>, data);
+    // const LIST_ENTRY_OFFSET: usize = offset_of!(ListNode<T>, list_entry);
+
+    /// Returns an uninitialized `ListNode`.
+    ///
+    /// # Safety
+    ///
+    /// All `ListNode` types must be used only after initializing it with `ListNode::init`.
+    pub const unsafe fn new(data: T) -> Self {
+        Self {
+            data,
+            list_entry: unsafe { ListEntry::new() },
+        }
+    }
+
+    pub fn init(self: Pin<&mut Self>) {
+        self.project().list_entry.init();
+    }
+
+    /// # Note
+    ///
+    /// Do not dereference the returned pointer if `self` is the head node.
+    pub fn prev(&self) -> *const Self {
+        Self::from_list_entry(self.list_entry.prev())
+    }
+
+    /// # Note
+    ///
+    /// Do not dereference the returned pointer if `self` is the head node.
+    pub fn next(&self) -> *const Self {
+        Self::from_list_entry(self.list_entry.next())
+    }
+
+    pub fn push_back(&self, elt: &Self) {
+        self.list_entry.push_back(&elt.list_entry);
+    }
+
+    pub fn push_front(&self, elt: &Self) {
+        self.list_entry.push_front(&elt.list_entry);
+    }
+
+    pub fn remove(&self) {
+        self.list_entry.remove();
+    }
+
+    pub fn from_data(data: *const T) -> *const Self {
+        (data as usize - Self::DATA_OFFSET) as *const Self
+    }
+
+    fn from_list_entry(list_entry: *const ListEntry) -> *const Self {
+        (list_entry as usize - Self::LIST_ENTRY_OFFSET) as *const Self
+    }
+}
+
+impl<T> Deref for ListNode<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<T> DerefMut for ListNode<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
     }
 }
 

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -4,13 +4,13 @@
 //! # Lifetime-less intrusive linked lists
 //!
 //! Intrusive linked lists are interesting and useful because the list does not own the nodes.
-//! However, it can also be unsafe if the nodes could move or drop while it's inside the list.
+//! However, it can also be unsafe if the nodes could move or drop while it's inserted in the list.
 //! Hence, many intrusive linked lists written in Rust use lifetimes and prohibit nodes
 //! from being moved or dropped during the list's whole lifetime.
 //! However, this means nodes cannot be mutated, moved or dropped even after it was removed from the list.
 //!
-//! On contrast, this list does not use lifetimes and allows nodes from being mutated or dropped
-//! even when its inside the list. When a node gets dropped, we simply remove it from the list.
+//! In contrast, [`List`] does not use lifetimes and allows nodes from being mutated or dropped
+//! even when its inserted in the list. When a node gets dropped, we simply remove it from the list.
 //! Instead, a `List` or `ListEntry`'s methods never returns a reference to a node or `ListEntry`, and always
 //! returns a raw pointer instead. This is because a node could get mutated or dropped at any time, and hence,
 //! the caller should make sure the node is not under mutation or already dropped when dereferencing the raw pointer.
@@ -157,11 +157,15 @@ impl<T: ListNode> List<T> {
 
     /// Provides an unsafe forward iterator.
     ///
+    /// # Note
+    ///
+    /// The caller should be careful when removing nodes currently accessed by iterators.
+    /// If an iterator's current node gets removed, the iterator will get stuck at the current node and never advance.
+    ///
     /// # Safety
     ///
-    /// The caller must make sure that the iterator's **current** items does not get removed, mutated, or dropped.
-    /// * If the item gets removed, the iterator will loop forever.
-    /// * If the item gets mutated/dropped, using the iterator may lead to undefined behavior.
+    /// The caller should be even more careful when mutating or dropping nodes that are currently
+    /// accessed by iterators. This can lead to undefined behavior.
     pub unsafe fn unsafe_iter(&self) -> Iter<'_, T> {
         Iter {
             last: &self.head,

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -165,6 +165,33 @@ impl<T> List<T> {
     ///
     /// The caller should be even more careful when mutating or dropping nodes that are currently
     /// accessed by iterators. This can lead to undefined behavior.
+    ///
+    /// # Examples
+    ///
+    /// *Incorrect* usage of this method.
+    ///
+    /// ```rust,no_run
+    /// // Make and initialize a `List` and a `ListNode`.
+    /// let mut list = unsafe { List::new() };
+    /// let mut node = Some(unsafe { ListNode::new(10) });
+    /// let list_pin = unsafe { Pin::new_unchecked(&mut list) };
+    /// let node_pin = unsafe { Pin::new_unchecked(node.as_mut().expect("")) };
+    /// list_pin.init();
+    /// node_pin.init();
+    ///
+    /// // Push the `ListNode` to the `List`.
+    /// list.push_front(node.as_ref().expect(""));
+    ///
+    /// // Use an unsafe iterator.
+    /// for n in unsafe { list.iter_unchecked() } {
+    ///     assert!(**n == 10); // okay!
+    ///     node = None;
+    ///     assert!(**n == 10); // not okay! reading data of already dropped node!
+    ///                         // undefined behavior! ⚠️
+    /// }
+    ///
+    /// assert!(node.is_none());
+    /// ```
     pub unsafe fn iter_unchecked(&self) -> Iter<'_, T> {
         Iter {
             last: &self.head,

--- a/kernel-rs/src/list.rs
+++ b/kernel-rs/src/list.rs
@@ -165,33 +165,6 @@ impl<T> List<T> {
     ///
     /// The caller should be even more careful when mutating or dropping nodes that are currently
     /// accessed by iterators. This can lead to undefined behavior.
-    ///
-    /// # Examples
-    ///
-    /// *Incorrect* usage of this method.
-    ///
-    /// ```rust,no_run
-    /// // Make and initialize a `List` and a `ListNode`.
-    /// let mut list = unsafe { List::new() };
-    /// let mut node = Some(unsafe { ListNode::new(10) });
-    /// let list_pin = unsafe { Pin::new_unchecked(&mut list) };
-    /// let node_pin = unsafe { Pin::new_unchecked(node.as_mut().expect("")) };
-    /// list_pin.init();
-    /// node_pin.init();
-    ///
-    /// // Push the `ListNode` to the `List`.
-    /// list.push_front(node.as_ref().expect(""));
-    ///
-    /// // Use an unsafe iterator.
-    /// for n in unsafe { list.iter_unchecked() } {
-    ///     assert!(**n == 10); // okay!
-    ///     node = None;
-    ///     assert!(**n == 10); // not okay! reading data of already dropped node!
-    ///                         // undefined behavior! ⚠️
-    /// }
-    ///
-    /// assert!(node.is_none());
-    /// ```
     pub unsafe fn iter_unchecked(&self) -> Iter<'_, T> {
         Iter {
             last: &self.head,


### PR DESCRIPTION
Closes #450

### Background
기존의  intrusive linked list에는 unsound한 부분들이 있습니다.
* 예를 들어, `ListEntry::prev`나 `ListEntry::next`는 `Pin<&mut Self>`를 리턴하는데, 사실 node가 언제 mutate/drop될지 알 수 없으므로 이런 type을 리턴하는게 unsound 합니다.
* `ListEntry`의 API를 잘못 사용하면, linked list 구조를 망가뜨릴 수 있습니다. 이를 막기 위하여, `List`와 같은 type을 추가하는 것이 좋을 것 같습니다.

### Changes
* `List`와 `ListEntry`의 API들이 `&Self`나 `Pin<&mut Self>`와 같은 type이 아닌, `*const Self`을 리턴하도록 변경했습니다.
* 항상 linked list 구조를 가지는 `List`라는 type을 추가했습니다.
* intrusive linked list node임을 나타내는 `ListNode` trait을 추가했습니다.