### PR TITLE
Make ProcGuard have &Proc, not &ProcBuilder

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -1,7 +1,11 @@
 use core::fmt;
 
 use crate::{
-    file::Devsw, kernel::kernel_builder, lock::SleepablelockGuard, param::NDEV, uart::Uart,
+    file::Devsw,
+    kernel::{kernel, kernel_builder},
+    lock::SleepablelockGuard,
+    param::NDEV,
+    uart::Uart,
     vm::UVAddr,
 };
 
@@ -116,8 +120,8 @@ impl Console {
         match cin {
             // Print process list.
             m if m == ctrl('P') => {
-                // TODO: remove kernel_builder()
-                unsafe { kernel_builder().procs.dump() };
+                // TODO: remove kernel()
+                unsafe { kernel().procs().dump() };
             }
 
             // Kill line.


### PR DESCRIPTION
## 목표

* `ProcGuard`가 `&ProcBuilder` 대신 `&Proc`을 가지고 있게 했습니다.
* `init`을 제외한 나머지 메서드(`user_proc_init`, `alloc` 등)를 `ProcsBuilder`에서 `Procs`로 옮겼습니다.

## 상세 설명

`Procs`의 typestate는 세 종류입니다.
1. `parent`와 `initial_proc`이 초기화되지 않음.
2. `parent`는 초기화되었지만 `initial_proc`이 초기화되지 않음.
3. `parent`와 `initial_proc`이 초기화됨.

기존 코드에서는 1, 2가 `ProcsBuilder`에 의해 표현되고 3만 `Procs`에 의해 표현되었습니다. 이로 인해, `alloc`이 `ProcsBuilder`의 메서드가 되어야만 하고 `ProcGuard`가 `&ProcBuilder`를 가져야만 하는 문제가 있었습니다.

그래서 이 PR에서는 1만 `ProcsBuilder`로 표현하고 2, 3을 `Procs`로 표현하도록 고쳤습니다. 이로 인해 생긴 문제는 `Procs`가 `initial_proc`의 초기화를 보장하지 못하기 때문에 `initial_proc`에 접근할 때 null 검사를 해야 한다는 점입니다. 그러나 이로 인한 성능 손해가 무시할 정도로 작으며, 그 비용을 감수하고 위 목표를 달성하도록 코드를 리팩토링하는 것이 더 바람직하다고 판단했습니다.

세 종류의 typestate를 각각 별도의 타입으로 표현하는 방법도 가능하겠지만, 2가 `init`과 `user_proc_init` 사이의 아주 잠깐 동안만 존재하는 상태이기 때문에, 2를 별도의 타입으로 만드는 것은 코드를 불필요하게 장황하게 만들기에 바람직하지 않다고 판단했습니다.