### PR TITLE
Closes #344: add Allocator

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -51,7 +51,8 @@ impl Console {
                 .current_proc()
                 .expect("No current proc")
                 .memory_mut()
-                .copy_in_bytes(&mut c, src + i as usize)
+                // TODO: remove kernel_builder()
+                .copy_in_bytes(&mut c, src + i as usize, &kernel_builder().kmem)
                 .is_err()
             {
                 return i;
@@ -99,7 +100,8 @@ impl Console {
                     .current_proc()
                     .expect("No current proc")
                     .memory_mut()
-                    .copy_out_bytes(dst, &cbuf)
+                    // TODO: remove kernel_builder()
+                    .copy_out_bytes(dst, &cbuf, &kernel_builder().kmem)
                     .is_err()
                 {
                     break;

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -121,7 +121,7 @@ impl Kernel {
         }
 
         let trap_frame: PAddr = (proc.trap_frame() as *const _ as usize).into();
-        let mut mem = UserMemory::new(trap_frame, None).ok_or(())?;
+        let mut mem = UserMemory::new(trap_frame, None, self.allocator()).ok_or(())?;
 
         // Load program into memory.
         for i in 0..elf.phnum as usize {

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -121,8 +121,8 @@ impl Kernel {
         }
 
         let trap_frame: PAddr = (proc.trap_frame() as *const _ as usize).into();
-        let mut mem = UserMemory::new(trap_frame, None, self.allocator()).ok_or(())?;
-
+        let mem = UserMemory::new(trap_frame, None, &self.kmem).ok_or(())?;
+        let mut mem = scopeguard::guard(mem, |mem| mem.free(&self.kmem));
         // Load program into memory.
         for i in 0..elf.phnum as usize {
             let off = elf.phoff + i * mem::size_of::<ProgHdr>();
@@ -135,8 +135,14 @@ impl Kernel {
                 if ph.memsz < ph.filesz || ph.vaddr % PGSIZE != 0 {
                     return Err(());
                 }
-                let _ = mem.alloc(ph.vaddr.checked_add(ph.memsz).ok_or(())?)?;
-                mem.load_file(ph.vaddr.into(), &mut ip, ph.off as _, ph.filesz as _)?;
+                let _ = mem.alloc(ph.vaddr.checked_add(ph.memsz).ok_or(())?, &self.kmem)?;
+                mem.load_file(
+                    ph.vaddr.into(),
+                    &mut ip,
+                    ph.off as _,
+                    ph.filesz as _,
+                    &self.kmem,
+                )?;
             }
         }
         drop(ip);
@@ -145,8 +151,8 @@ impl Kernel {
         // Allocate two pages at the next page boundary.
         // Use the second as the user stack.
         let mut sz = pgroundup(mem.size());
-        sz = mem.alloc(sz + 2 * PGSIZE)?;
-        mem.clear((sz - 2 * PGSIZE).into());
+        sz = mem.alloc(sz + 2 * PGSIZE, &self.kmem)?;
+        mem.clear((sz - 2 * PGSIZE).into(), &self.kmem);
         let mut sp: usize = sz;
         let stackbase: usize = sp - PGSIZE;
 
@@ -166,7 +172,7 @@ impl Kernel {
                 return Err(());
             }
 
-            mem.copy_out_bytes(sp.into(), bytes)?;
+            mem.copy_out_bytes(sp.into(), bytes, &self.kmem)?;
             *stack = sp;
         }
         let argc: usize = args.len();
@@ -181,7 +187,7 @@ impl Kernel {
         }
         // SAFETY: any byte can be considered as a valid u8.
         let (_, ustack, _) = unsafe { ustack.align_to::<u8>() };
-        mem.copy_out_bytes(sp.into(), &ustack[..argv_size])?;
+        mem.copy_out_bytes(sp.into(), &ustack[..argv_size], &self.kmem)?;
 
         // Save program name for debugging.
         let path_str = path.as_bytes();
@@ -198,7 +204,7 @@ impl Kernel {
         }
 
         // Commit to the user image.
-        let _ = mem::replace(proc.memory_mut(), mem);
+        mem::replace(proc.memory_mut(), scopeguard::ScopeGuard::into_inner(mem)).free(&self.kmem);
 
         // arguments to user main(argc, argv)
         // argc is returned via the system call return

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -16,7 +16,6 @@ use crate::{
     fs::{FileSystem, Itable},
     kalloc::Kmem,
     lock::{Sleepablelock, Spinlock},
-    page::Page,
     param::{NCPU, NDEV},
     plic::{plicinit, plicinithart},
     println,
@@ -75,7 +74,7 @@ pub struct KernelBuilder {
 
     pub printer: Spinlock<Printer>,
 
-    kmem: Spinlock<Kmem>,
+    pub kmem: Spinlock<Kmem>,
 
     /// The kernel's memory manager.
     memory: MaybeUninit<KernelMemory>,
@@ -106,8 +105,7 @@ pub struct KernelBuilder {
 #[repr(transparent)]
 /// # Safety
 ///
-/// * `inner.kmem` is initialized.
-/// * `inner.procs` is initialized.
+/// `inner.procs` is initialized.
 pub struct Kernel {
     inner: KernelBuilder,
 }
@@ -116,11 +114,6 @@ impl Kernel {
     pub fn procs(&self) -> &Procs {
         // SAFETY: `self.inner.procs` is initialized according to the invariant.
         unsafe { self.inner.procs.as_procs_unchecked() }
-    }
-
-    pub fn allocator(&self) -> Allocator {
-        // SAFETY: self.inner.kmem is initialized.
-        unsafe { Allocator::new_unchecked() }
     }
 }
 
@@ -164,28 +157,6 @@ impl KernelBuilder {
         self.panicked.load(Ordering::Acquire)
     }
 
-    /// Free the page of physical memory pointed at by v,
-    /// which normally should have been returned by a
-    /// call to kernel().alloc().  (The exception is when
-    /// initializing the allocator; see Kmem::init.)
-    pub fn free(&self, mut page: Page) {
-        // Fill with junk to catch dangling refs.
-        page.write_bytes(1);
-
-        self.kmem.lock().free(page);
-    }
-
-    /// Allocate one 4096-byte page of physical memory.
-    /// Returns a pointer that the kernel can use.
-    /// Returns None if the memory cannot be allocated.
-    pub fn alloc(&self) -> Option<Page> {
-        let mut page = self.kmem.lock().alloc()?;
-
-        // fill with junk
-        page.write_bytes(5);
-        Some(page)
-    }
-
     /// Prints the given formatted string with the Printer.
     pub fn printer_write_fmt(&self, args: fmt::Arguments<'_>) -> fmt::Result {
         if self.is_panicked() {
@@ -212,31 +183,6 @@ impl KernelBuilder {
     /// Access it only after initializing the kernel using `kernel_main()`.
     pub unsafe fn get_bcache(&self) -> &Bcache {
         &self.bcache
-    }
-}
-
-/// # Safety
-///
-/// `KERNEL.kmem` has been initialized already.
-#[derive(Copy, Clone)]
-pub struct Allocator;
-
-impl Allocator {
-    /// # Safety
-    ///
-    /// `KERNEL.kmem` has been initialized already.
-    pub unsafe fn new_unchecked() -> Allocator {
-        Allocator
-    }
-
-    pub fn alloc(&self) -> Option<Page> {
-        // SAFETY: `KERNEL.kmem` has been initialized already.
-        kernel_builder().alloc()
-    }
-
-    pub fn free(&self, page: Page) {
-        // SAFETY: `KERNEL.kmem` has been initialized already.
-        kernel_builder().free(page);
     }
 }
 
@@ -271,41 +217,29 @@ pub unsafe fn kernel_main() -> ! {
     static STARTED: AtomicBool = AtomicBool::new(false);
 
     if cpuid() == 0 {
+        let kernel = unsafe { kernel_builder_unchecked_pin().project() };
+
         // Initialize the kernel.
 
         // Console.
         Uart::init();
-        unsafe { consoleinit(kernel_builder_unchecked_pin().project().devsw) };
+        unsafe { consoleinit(kernel.devsw) };
 
         println!();
         println!("rv6 kernel is booting");
         println!();
 
         // Physical page allocator.
-        unsafe {
-            kernel_builder_unchecked_pin()
-                .project()
-                .kmem
-                .get_mut()
-                .init()
-        };
-        // SAFETY: kmem has been initialized.
-        let allocator = unsafe { Allocator::new_unchecked() };
+        unsafe { kernel.kmem.get_mut().init() };
 
         // Create kernel memory manager.
-        let memory = KernelMemory::new(allocator).expect("PageTable::new failed");
+        let memory = KernelMemory::new(kernel.kmem).expect("PageTable::new failed");
 
         // Turn on paging.
-        unsafe {
-            kernel_builder_unchecked_pin()
-                .project()
-                .memory
-                .write(memory)
-                .init_hart()
-        };
+        unsafe { kernel.memory.write(memory).init_hart() };
 
         // Process system.
-        let procs = unsafe { kernel_builder_unchecked_pin().project().procs.init() };
+        let procs = kernel.procs.init();
 
         // Trap vectors.
         trapinit();
@@ -320,27 +254,14 @@ pub unsafe fn kernel_main() -> ! {
         unsafe { plicinithart() };
 
         // Buffer cache.
-        unsafe {
-            kernel_builder_unchecked_pin()
-                .project()
-                .bcache
-                .get_pin_mut()
-                .init()
-        };
+        kernel.bcache.get_pin_mut().init();
 
         // Emulated hard disk.
-        unsafe {
-            kernel_builder_unchecked_pin()
-                .project()
-                .file_system
-                .log
-                .disk
-                .get_mut()
-                .init()
-        };
+        kernel.file_system.log.disk.get_mut().init();
 
         // First user process.
-        procs.user_proc_init(allocator);
+        procs.user_proc_init(kernel.kmem);
+
         STARTED.store(true, Ordering::Release);
     } else {
         while !STARTED.load(Ordering::Acquire) {
@@ -350,7 +271,7 @@ pub unsafe fn kernel_main() -> ! {
         println!("hart {} starting", cpuid());
 
         // Turn on paging.
-        unsafe { kernel_builder().memory.assume_init_ref().init_hart() };
+        unsafe { kernel().memory.assume_init_ref().init_hart() };
 
         // Install kernel trap vector.
         unsafe { trapinithart() };

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -4,6 +4,7 @@ use static_assertions::const_assert;
 
 use crate::{
     file::{FileType, RcFile},
+    kalloc::Kmem,
     kernel::Kernel,
     lock::Spinlock,
     page::Page,
@@ -45,10 +46,16 @@ impl Pipe {
     /// If successfully read i > 0 bytes, wakeups the `write_waitchannel` and returns `Ok(i: usize)`.
     /// If the pipe was empty, sleeps at `read_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn read(&self, addr: UVAddr, n: usize, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn read(
+        &self,
+        addr: UVAddr,
+        n: usize,
+        proc: &mut CurrentProc<'_>,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<usize, ()> {
         let mut inner = self.inner.lock();
         loop {
-            match inner.try_read(addr, n, proc) {
+            match inner.try_read(addr, n, proc, allocator) {
                 Ok(r) => {
                     //DOC: piperead-wakeup
                     self.write_waitchannel.wakeup();
@@ -69,11 +76,17 @@ impl Pipe {
     /// Note that we may have i < `n` if an copy-in error happened.
     /// If the pipe was full, sleeps at `write_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn write(&self, addr: UVAddr, n: usize, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn write(
+        &self,
+        addr: UVAddr,
+        n: usize,
+        proc: &mut CurrentProc<'_>,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<usize, ()> {
         let mut written = 0;
         let mut inner = self.inner.lock();
         loop {
-            match inner.try_write(addr + written, n - written, proc) {
+            match inner.try_write(addr + written, n - written, proc, allocator) {
                 Ok(r) => {
                     written += r;
                     self.read_waitchannel.wakeup();
@@ -134,7 +147,7 @@ impl Deref for AllocatedPipe {
 
 impl Kernel {
     pub fn allocate_pipe(&self) -> Result<(RcFile, RcFile), ()> {
-        let page = self.alloc().ok_or(())?;
+        let page = self.kmem.alloc().ok_or(())?;
         // SAFETY: by the invariant of `Page`, `page` is always non-null.
         let mut ptr = unsafe { NonNull::new_unchecked(page.into_usize() as *mut Pipe) };
 
@@ -168,7 +181,10 @@ impl Kernel {
                 false,
             )
             // SAFETY: ptr is an address of a page obtained by alloc().
-            .map_err(|_| self.free(unsafe { Page::from_usize(ptr.as_ptr() as _) }))?;
+            .map_err(|_| {
+                self.kmem
+                    .free(unsafe { Page::from_usize(ptr.as_ptr() as _) })
+            })?;
         let f1 = self
             .ftable
             .alloc_file(
@@ -179,7 +195,10 @@ impl Kernel {
                 true,
             )
             // SAFETY: ptr is an address of a page obtained by alloc().
-            .map_err(|_| self.free(unsafe { Page::from_usize(ptr.as_ptr() as _) }))?;
+            .map_err(|_| {
+                self.kmem
+                    .free(unsafe { Page::from_usize(ptr.as_ptr() as _) })
+            })?;
 
         Ok((f0, f1))
     }
@@ -215,6 +234,7 @@ impl PipeInner {
         addr: UVAddr,
         n: usize,
         proc: &mut CurrentProc<'_>,
+        allocator: &Spinlock<Kmem>,
     ) -> Result<usize, PipeError> {
         let mut ch = [0u8];
         if !self.readopen || proc.killed() {
@@ -225,7 +245,11 @@ impl PipeInner {
                 //DOC: pipewrite-full
                 return Ok(i);
             }
-            if proc.memory_mut().copy_in_bytes(&mut ch, addr + i).is_err() {
+            if proc
+                .memory_mut()
+                .copy_in_bytes(&mut ch, addr + i, allocator)
+                .is_err()
+            {
                 return Err(PipeError::InvalidCopyin(i));
             }
             self.data[self.nwrite as usize % PIPESIZE] = ch[0];
@@ -243,6 +267,7 @@ impl PipeInner {
         addr: UVAddr,
         n: usize,
         proc: &mut CurrentProc<'_>,
+        allocator: &Spinlock<Kmem>,
     ) -> Result<usize, PipeError> {
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {
@@ -259,7 +284,11 @@ impl PipeInner {
             }
             let ch = [self.data[self.nread as usize % PIPESIZE]];
             self.nread = self.nread.wrapping_add(1);
-            if proc.memory_mut().copy_out_bytes(addr + i, &ch).is_err() {
+            if proc
+                .memory_mut()
+                .copy_out_bytes(addr + i, &ch, allocator)
+                .is_err()
+            {
                 return Ok(i);
             }
         }

--- a/kernel-rs/src/sysproc.rs
+++ b/kernel-rs/src/sysproc.rs
@@ -15,7 +15,7 @@ impl Kernel {
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub fn sys_fork(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
-        Ok(self.procs().fork(proc)? as _)
+        Ok(self.procs().fork(proc, self.allocator())? as _)
     }
 
     /// Wait for a child to exit.

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -2,7 +2,8 @@ use core::{cmp, marker::PhantomData, mem, ops::Add, slice};
 
 use crate::{
     fs::InodeGuard,
-    kernel::Allocator,
+    kalloc::Kmem,
+    lock::Spinlock,
     memlayout::{kstack, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, TRAPFRAME, UART0, VIRTIO0},
     page::Page,
     param::NPROC,
@@ -165,7 +166,7 @@ impl RawPageTable {
     /// Make a new emtpy raw page table by allocating a new page.
     /// Return `Ok(..)` if the allocation has succeeded.
     /// Return `None` if the allocation has failed.
-    fn new(allocator: Allocator) -> Option<*mut RawPageTable> {
+    fn new(allocator: &Spinlock<Kmem>) -> Option<*mut RawPageTable> {
         let mut page = allocator.alloc()?;
         page.write_bytes(0);
         // This line guarantees the invariant.
@@ -182,7 +183,7 @@ impl RawPageTable {
         &mut self,
         index: usize,
         alloc: bool,
-        allocator: Allocator,
+        allocator: &Spinlock<Kmem>,
     ) -> Option<&mut RawPageTable> {
         let pte = &mut self.inner[index];
         if !pte.is_valid() {
@@ -211,7 +212,7 @@ impl RawPageTable {
     ///
     /// This method frees the page table itself, so this page table must
     /// not be used after an invocation of this method.
-    unsafe fn free_walk(&mut self, allocator: Allocator) {
+    unsafe fn free_walk(&mut self, allocator: &Spinlock<Kmem>) {
         // There are 2^9 = 512 PTEs in a page table.
         for pte in &mut self.inner {
             if let Some(ptable) = pte.as_table_mut() {
@@ -229,10 +230,8 @@ impl RawPageTable {
 /// # Safety
 ///
 /// ptr uniquely refers to a valid 3-level RawPageTable.
-pub struct PageTable<A: VAddr> {
+struct PageTable<A: VAddr> {
     ptr: *mut RawPageTable,
-    /// Page allocator that provides pages for this page table.
-    allocator: Allocator,
     _marker: PhantomData<A>,
 }
 
@@ -240,10 +239,9 @@ impl<A: VAddr> PageTable<A> {
     /// Make a new empty page table by allocating a new page.
     /// Return `Ok(..)` if the allocation has succeeded.
     /// Return `None` if the allocation has failed.
-    fn new(allocator: Allocator) -> Option<Self> {
+    fn new(allocator: &Spinlock<Kmem>) -> Option<Self> {
         Some(Self {
             ptr: RawPageTable::new(allocator)?,
-            allocator,
             _marker: PhantomData,
         })
     }
@@ -264,20 +262,31 @@ impl<A: VAddr> PageTable<A> {
     ///   21..29 -- 9 bits of level-1 index.
     ///   12..20 -- 9 bits of level-0 index.
     ///    0..11 -- 12 bits of byte offset within the page.
-    fn get_mut(&mut self, va: A, alloc: bool) -> Option<&mut PageTableEntry> {
+    fn get_mut(
+        &mut self,
+        va: A,
+        alloc: bool,
+        allocator: &Spinlock<Kmem>,
+    ) -> Option<&mut PageTableEntry> {
         assert!(va.into_usize() < MAXVA, "PageTable::get_mut");
         // SAFETY: self.ptr uniquely refers to a valid RawPageTable
         // according to the invariant.
         let mut page_table = unsafe { &mut *self.ptr };
         for level in (1..3).rev() {
-            page_table = page_table.get_table_mut(va.px(level), alloc, self.allocator)?;
+            page_table = page_table.get_table_mut(va.px(level), alloc, allocator)?;
         }
         Some(page_table.get_entry_mut(va.px(0)))
     }
 
-    fn insert(&mut self, va: A, pa: PAddr, perm: PteFlags) -> Result<(), ()> {
+    fn insert(
+        &mut self,
+        va: A,
+        pa: PAddr,
+        perm: PteFlags,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<(), ()> {
         let a = pgrounddown(va.into_usize());
-        let pte = self.get_mut(A::from(a), true).ok_or(())?;
+        let pte = self.get_mut(A::from(a), true, allocator).ok_or(())?;
         assert!(!pte.is_valid(), "PageTable::insert");
         pte.set_entry(pa, perm);
         Ok(())
@@ -287,30 +296,46 @@ impl<A: VAddr> PageTable<A> {
     /// physical addresses starting at pa. va and size might not
     /// be page-aligned. Returns Ok(()) on success, Err(()) if walk() couldn't
     /// allocate a needed page-table page.
-    fn insert_range(&mut self, va: A, size: usize, pa: PAddr, perm: PteFlags) -> Result<(), ()> {
+    fn insert_range(
+        &mut self,
+        va: A,
+        size: usize,
+        pa: PAddr,
+        perm: PteFlags,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<(), ()> {
         let start = pgrounddown(va.into_usize());
         let end = pgrounddown(va.into_usize() + size - 1usize);
         for i in num_iter::range_step_inclusive(0, end - start, PGSIZE) {
-            self.insert(va + i, pa + i, perm)?;
+            self.insert(va + i, pa + i, perm, allocator)?;
         }
         Ok(())
     }
 
-    fn remove(&mut self, va: A) -> Option<PAddr> {
-        let pte = self.get_mut(va, false)?;
+    fn remove(&mut self, va: A, allocator: &Spinlock<Kmem>) -> Option<PAddr> {
+        let pte = self.get_mut(va, false, allocator)?;
         assert!(pte.is_data(), "PageTable::remove");
         let pa = pte.get_pa();
         pte.invalidate();
         Some(pa)
     }
+
+    // # Safety
+    //
+    // This page table must not be used after invoking this method.
+    unsafe fn free(&mut self, allocator: &Spinlock<Kmem>) {
+        // SAFETY:
+        // * self.ptr is a valid pointer.
+        // * this page table is being dropped, and its ptr will not be used anymore.
+        unsafe { (*self.ptr).free_walk(allocator) };
+    }
 }
 
 impl<A: VAddr> Drop for PageTable<A> {
     fn drop(&mut self) {
-        // SAFETY:
-        // * self.ptr is a valid pointer.
-        // * this page table is being dropped, and its ptr will not be used anymore.
-        unsafe { (*self.ptr).free_walk(self.allocator) };
+        // HACK(@efenniht): we really need linear type here:
+        // https://github.com/rust-lang/rfcs/issues/814
+        panic!("PageTable must never drop.");
     }
 }
 
@@ -337,8 +362,6 @@ pub struct UserMemory {
     page_table: PageTable<UVAddr>,
     /// Size of process memory (bytes).
     size: usize,
-    /// Page allocator that provides pages for user process.
-    allocator: Allocator,
 }
 
 impl UserMemory {
@@ -348,8 +371,16 @@ impl UserMemory {
     /// than a page.
     /// Return Some(..) if every allocation has succeeded.
     /// Return None otherwise.
-    pub fn new(trap_frame: PAddr, src_opt: Option<&[u8]>, allocator: Allocator) -> Option<Self> {
-        let mut page_table = PageTable::new(allocator)?;
+    pub fn new(
+        trap_frame: PAddr,
+        src_opt: Option<&[u8]>,
+        allocator: &Spinlock<Kmem>,
+    ) -> Option<Self> {
+        let page_table = PageTable::new(allocator)?;
+        let mut page_table = scopeguard::guard(page_table, |mut page_table| {
+            unsafe { page_table.free(allocator) };
+            mem::forget(page_table);
+        });
 
         // Map the trampoline code (for system call return)
         // at the highest user virtual address.
@@ -361,18 +392,23 @@ impl UserMemory {
                 // SAFETY: we assume that reading the address of trampoline is safe.
                 (unsafe { trampoline.as_mut_ptr() as usize }).into(),
                 PteFlags::R | PteFlags::X,
+                allocator,
             )
             .ok()?;
 
         // Map the trapframe just below TRAMPOLINE, for trampoline.S.
         page_table
-            .insert(TRAPFRAME.into(), trap_frame, PteFlags::R | PteFlags::W)
+            .insert(
+                TRAPFRAME.into(),
+                trap_frame,
+                PteFlags::R | PteFlags::W,
+                allocator,
+            )
             .ok()?;
 
         let mut memory = Self {
-            page_table,
+            page_table: scopeguard::ScopeGuard::into_inner(page_table),
             size: 0,
-            allocator,
         };
 
         if let Some(src) = src_opt {
@@ -381,7 +417,11 @@ impl UserMemory {
             page.write_bytes(0);
             (&mut page[..src.len()]).copy_from_slice(src);
             memory
-                .push_page(page, PteFlags::R | PteFlags::W | PteFlags::X | PteFlags::U)
+                .push_page(
+                    page,
+                    PteFlags::R | PteFlags::W | PteFlags::X | PteFlags::U,
+                    allocator,
+                )
                 .map_err(|page| allocator.free(page))
                 .ok()?;
         }
@@ -392,27 +432,27 @@ impl UserMemory {
     /// Makes a new memory by copying a given memory. Copies both the page
     /// table and the physical memory. Returns Some(memory) on success, None on
     /// failure. Frees any allocated pages on failure.
-    pub fn clone(&mut self, trap_frame: PAddr) -> Option<Self> {
-        let new = Self::new(trap_frame, None, self.allocator)?;
+    pub fn clone(&mut self, trap_frame: PAddr, allocator: &Spinlock<Kmem>) -> Option<Self> {
+        let new = Self::new(trap_frame, None, allocator)?;
         let mut new = scopeguard::guard(new, |mut new| {
-            let _ = new.dealloc(0);
+            let _ = new.dealloc(0, allocator);
         });
         for i in num_iter::range_step(0, self.size, PGSIZE) {
             let pte = self
                 .page_table
-                .get_mut(i.into(), false)
+                .get_mut(i.into(), false, allocator)
                 .expect("clone_into: pte not found");
             assert!(pte.is_valid(), "clone_into: invalid page");
 
             let pa = pte.get_pa();
             let flags = pte.get_flags();
-            let mut page = new.allocator.alloc()?;
+            let mut page = allocator.alloc()?;
             // SAFETY: pa is an address in page_table,
             // and thus it is the address of a page by the invariant.
             let src = unsafe { slice::from_raw_parts(pa.into_usize() as *const u8, PGSIZE) };
             page.copy_from_slice(src);
-            new.push_page(page, flags)
-                .map_err(|page| new.allocator.free(page))
+            new.push_page(page, flags, allocator)
+                .map_err(|page| allocator.free(page))
                 .ok()?;
         }
         let mut new = scopeguard::ScopeGuard::into_inner(new);
@@ -435,11 +475,12 @@ impl UserMemory {
         ip: &mut InodeGuard<'_>,
         offset: u32,
         sz: u32,
+        allocator: &Spinlock<Kmem>,
     ) -> Result<(), ()> {
         assert!(va.is_page_aligned(), "load_file: va must be page aligned");
         for i in num_iter::range_step(0, sz, PGSIZE as _) {
             let dst = self
-                .get_slice(va + i as usize)
+                .get_slice(va + i as usize, allocator)
                 .expect("load_file: address should exist");
             let n = cmp::min((sz - i) as usize, PGSIZE);
             let bytes_read = ip.read_bytes_kernel(&mut dst[..n], offset + i);
@@ -452,20 +493,24 @@ impl UserMemory {
 
     /// Allocate PTEs and physical memory to grow process to newsz, which need
     /// not be page aligned. Returns Ok(new size) or Err(()) on error.
-    pub fn alloc(&mut self, newsz: usize) -> Result<usize, ()> {
+    pub fn alloc(&mut self, newsz: usize, allocator: &Spinlock<Kmem>) -> Result<usize, ()> {
         if newsz <= self.size {
             return Ok(self.size);
         }
 
         let oldsz = self.size;
         let mut this = scopeguard::guard(self, |this| {
-            let _ = this.dealloc(oldsz);
+            let _ = this.dealloc(oldsz, allocator);
         });
         while pgroundup(this.size) < pgroundup(newsz) {
-            let mut page = this.allocator.alloc().ok_or(())?;
+            let mut page = allocator.alloc().ok_or(())?;
             page.write_bytes(0);
-            this.push_page(page, PteFlags::R | PteFlags::W | PteFlags::X | PteFlags::U)
-                .map_err(|page| this.allocator.free(page))?;
+            this.push_page(
+                page,
+                PteFlags::R | PteFlags::W | PteFlags::X | PteFlags::U,
+                allocator,
+            )
+            .map_err(|page| allocator.free(page))?;
         }
         let this = scopeguard::ScopeGuard::into_inner(this);
         this.size = newsz;
@@ -474,14 +519,14 @@ impl UserMemory {
 
     /// Deallocate user pages to bring the process size to newsz, which need
     /// not be page-aligned. Returns the new process size.
-    pub fn dealloc(&mut self, newsz: usize) -> usize {
+    pub fn dealloc(&mut self, newsz: usize, allocator: &Spinlock<Kmem>) -> usize {
         if self.size <= newsz {
             return self.size;
         }
 
         while pgroundup(newsz) < pgroundup(self.size) {
-            if let Some(page) = self.pop_page() {
-                self.allocator.free(page);
+            if let Some(page) = self.pop_page(allocator) {
+                allocator.free(page);
             }
         }
         self.size = newsz;
@@ -490,15 +535,15 @@ impl UserMemory {
 
     /// Grow or shrink process size by n bytes.
     /// Return Ok(old size) on success, Err(()) on failure.
-    pub fn resize(&mut self, n: i32) -> Result<usize, ()> {
+    pub fn resize(&mut self, n: i32, allocator: &Spinlock<Kmem>) -> Result<usize, ()> {
         let size = self.size;
         match n.cmp(&0) {
             cmp::Ordering::Equal => (),
             cmp::Ordering::Greater => {
-                let _ = self.alloc(size + n as usize)?;
+                let _ = self.alloc(size + n as usize, allocator)?;
             }
             cmp::Ordering::Less => {
-                let _ = self.dealloc(size - (-n as usize));
+                let _ = self.dealloc(size - (-n as usize), allocator);
             }
         };
         Ok(size)
@@ -506,9 +551,9 @@ impl UserMemory {
 
     /// Mark a PTE invalid for user access.
     /// Used by exec for the user stack guard page.
-    pub fn clear(&mut self, va: UVAddr) {
+    pub fn clear(&mut self, va: UVAddr, allocator: &Spinlock<Kmem>) {
         self.page_table
-            .get_mut(va, false)
+            .get_mut(va, false, allocator)
             .expect("clear")
             .clear_user();
     }
@@ -516,14 +561,19 @@ impl UserMemory {
     /// Copy from kernel to user.
     /// Copy len bytes from src to virtual address dstva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub fn copy_out_bytes(&mut self, dstva: UVAddr, src: &[u8]) -> Result<(), ()> {
+    pub fn copy_out_bytes(
+        &mut self,
+        dstva: UVAddr,
+        src: &[u8],
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<(), ()> {
         let mut dst = dstva.into_usize();
         let mut len = src.len();
         let mut offset = 0;
         while len > 0 {
             let va = pgrounddown(dst);
             let poffset = dst - va;
-            let page = self.get_slice(va.into()).ok_or(())?;
+            let page = self.get_slice(va.into(), allocator).ok_or(())?;
             let n = cmp::min(PGSIZE - poffset, len);
             page[poffset..poffset + n].copy_from_slice(&src[offset..offset + n]);
             len -= n;
@@ -536,26 +586,37 @@ impl UserMemory {
     /// Copy from kernel to user.
     /// Copy from src to virtual address dstva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub fn copy_out<T>(&mut self, dstva: UVAddr, src: &T) -> Result<(), ()> {
+    pub fn copy_out<T>(
+        &mut self,
+        dstva: UVAddr,
+        src: &T,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<(), ()> {
         self.copy_out_bytes(
             dstva,
             // SAFETY: src is a valid reference to T and
             // u8 does not have any internal structure.
             unsafe { core::slice::from_raw_parts_mut(src as *const _ as _, mem::size_of::<T>()) },
+            allocator,
         )
     }
 
     /// Copy from user to kernel.
     /// Copy len bytes to dst from virtual address srcva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub fn copy_in_bytes(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
+    pub fn copy_in_bytes(
+        &mut self,
+        dst: &mut [u8],
+        srcva: UVAddr,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<(), ()> {
         let mut src = srcva.into_usize();
         let mut len = dst.len();
         let mut offset = 0;
         while len > 0 {
             let va = pgrounddown(src);
             let poffset = src - va;
-            let page = self.get_slice(va.into()).ok_or(())?;
+            let page = self.get_slice(va.into(), allocator).ok_or(())?;
             let n = cmp::min(PGSIZE - poffset, len);
             dst[offset..offset + n].copy_from_slice(&page[poffset..poffset + n]);
             len -= n;
@@ -572,10 +633,16 @@ impl UserMemory {
     /// # Safety
     ///
     /// `T` can be safely `transmute`d to `[u8; size_of::<T>()]`.
-    pub unsafe fn copy_in<T>(&mut self, dst: &mut T, srcva: UVAddr) -> Result<(), ()> {
+    pub unsafe fn copy_in<T>(
+        &mut self,
+        dst: &mut T,
+        srcva: UVAddr,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<(), ()> {
         self.copy_in_bytes(
             unsafe { core::slice::from_raw_parts_mut(dst as *mut _ as _, mem::size_of::<T>()) },
             srcva,
+            allocator,
         )
     }
 
@@ -583,14 +650,19 @@ impl UserMemory {
     /// Copy bytes to dst from virtual address srcva in a given page table,
     /// until a '\0', or max.
     /// Return OK(()) on success, Err(()) on error.
-    pub fn copy_in_str(&mut self, dst: &mut [u8], srcva: UVAddr) -> Result<(), ()> {
+    pub fn copy_in_str(
+        &mut self,
+        dst: &mut [u8],
+        srcva: UVAddr,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<(), ()> {
         let mut src = srcva.into_usize();
         let mut offset = 0;
         let mut max = dst.len();
         while max > 0 {
             let va = pgrounddown(src);
             let poffset = src - va;
-            let page = self.get_slice(va.into()).ok_or(())?;
+            let page = self.get_slice(va.into(), allocator).ok_or(())?;
             let n = cmp::min(PGSIZE - poffset, max);
 
             let from = &page[poffset..poffset + n];
@@ -617,11 +689,11 @@ impl UserMemory {
     }
 
     /// Return a page at va as a slice. Some(page) on success, None on failure.
-    fn get_slice(&mut self, va: UVAddr) -> Option<&mut [u8]> {
+    fn get_slice(&mut self, va: UVAddr, allocator: &Spinlock<Kmem>) -> Option<&mut [u8]> {
         if va.into_usize() >= TRAPFRAME {
             return None;
         }
-        let pte = self.page_table.get_mut(va, false)?;
+        let pte = self.page_table.get_mut(va, false, allocator)?;
         if !pte.is_user() {
             return None;
         }
@@ -631,12 +703,17 @@ impl UserMemory {
 
     /// Increase the size by appending a given page with given flags.
     /// Ok(()) on success, Err(given page) on failure.
-    fn push_page(&mut self, page: Page, perm: PteFlags) -> Result<(), Page> {
+    fn push_page(
+        &mut self,
+        page: Page,
+        perm: PteFlags,
+        allocator: &Spinlock<Kmem>,
+    ) -> Result<(), Page> {
         let pa = page.into_usize();
         // The invariant is maintained because page.addr() is the address of a page.
         let size = pgroundup(self.size);
         self.page_table
-            .insert(size.into(), pa.into(), perm)
+            .insert(size.into(), pa.into(), perm, allocator)
             // SAFETY: pa is the address of a given page.
             .map_err(|_| unsafe { Page::from_usize(pa) })?;
         self.size = size + PGSIZE;
@@ -645,25 +722,34 @@ impl UserMemory {
 
     /// Decrease the size by removing the most recently appended page.
     /// Some(page) if size > 0, None if size = 0.
-    fn pop_page(&mut self) -> Option<Page> {
+    fn pop_page(&mut self, allocator: &Spinlock<Kmem>) -> Option<Page> {
         if self.size == 0 {
             return None;
         }
         self.size = pgroundup(self.size) - PGSIZE;
         let pa = self
             .page_table
-            .remove(self.size.into())
+            .remove(self.size.into(), allocator)
             .expect("pop_page")
             .into_usize();
         // SAFETY: pa is an address in page_table,
         // and, thus, it is the address of a page by the invariant.
         Some(unsafe { Page::from_usize(pa) })
     }
+
+    pub fn free(mut self, allocator: &Spinlock<Kmem>) {
+        let _ = self.dealloc(0, allocator);
+        // SAFETY: self will be dropped.
+        unsafe { self.page_table.free(allocator) };
+        mem::forget(self);
+    }
 }
 
 impl Drop for UserMemory {
     fn drop(&mut self) {
-        let _ = self.dealloc(0);
+        // HACK(@efenniht): we really need linear type here:
+        // https://github.com/rust-lang/rfcs/issues/814
+        panic!("UserMemory must never drop.");
     }
 }
 
@@ -682,8 +768,12 @@ pub struct KernelMemory {
 
 impl KernelMemory {
     /// Make a direct-map page table for the kernel.
-    pub fn new(allocator: Allocator) -> Option<Self> {
-        let mut page_table = PageTable::new(allocator)?;
+    pub fn new(allocator: &Spinlock<Kmem>) -> Option<Self> {
+        let page_table = PageTable::new(allocator)?;
+        let mut page_table = scopeguard::guard(page_table, |mut page_table| {
+            unsafe { page_table.free(allocator) };
+            mem::forget(page_table);
+        });
 
         // SiFive Test Finisher MMIO
         page_table
@@ -692,6 +782,7 @@ impl KernelMemory {
                 PGSIZE,
                 FINISHER.into(),
                 PteFlags::R | PteFlags::W,
+                allocator,
             )
             .ok()?;
 
@@ -702,6 +793,7 @@ impl KernelMemory {
                 PGSIZE,
                 UART0.into(),
                 PteFlags::R | PteFlags::W,
+                allocator,
             )
             .ok()?;
 
@@ -712,6 +804,7 @@ impl KernelMemory {
                 PGSIZE,
                 VIRTIO0.into(),
                 PteFlags::R | PteFlags::W,
+                allocator,
             )
             .ok()?;
 
@@ -722,6 +815,7 @@ impl KernelMemory {
                 0x400000,
                 PLIC.into(),
                 PteFlags::R | PteFlags::W,
+                allocator,
             )
             .ok()?;
 
@@ -734,6 +828,7 @@ impl KernelMemory {
                 et - KERNBASE,
                 KERNBASE.into(),
                 PteFlags::R | PteFlags::X,
+                allocator,
             )
             .ok()?;
 
@@ -744,6 +839,7 @@ impl KernelMemory {
                 PHYSTOP - et,
                 et.into(),
                 PteFlags::R | PteFlags::W,
+                allocator,
             )
             .ok()?;
 
@@ -756,6 +852,7 @@ impl KernelMemory {
                 // SAFETY: we assume that reading the address of trampoline is safe.
                 unsafe { trampoline.as_mut_ptr() as usize }.into(),
                 PteFlags::R | PteFlags::X,
+                allocator,
             )
             .ok()?;
 
@@ -766,11 +863,19 @@ impl KernelMemory {
             let pa = allocator.alloc()?.into_usize();
             let va: usize = kstack(i);
             page_table
-                .insert_range(va.into(), PGSIZE, pa.into(), PteFlags::R | PteFlags::W)
+                .insert_range(
+                    va.into(),
+                    PGSIZE,
+                    pa.into(),
+                    PteFlags::R | PteFlags::W,
+                    allocator,
+                )
                 .ok()?;
         }
 
-        Some(Self { page_table })
+        Some(Self {
+            page_table: scopeguard::ScopeGuard::into_inner(page_table),
+        })
     }
 
     /// Switch h/w page table register to the kernel's page table, and enable paging.


### PR DESCRIPTION
* `Allocator` 타입을 추가
  * zero-sized struct
  * unsafe 메서드인 `new_unchecked`를 통해 새 `Allocator`를 만들 수 있음
  * `alloc` 메서드는 `kernel_builer().alloc()`을 호출
  * `free` 메서드는 `kernel_builer().free()`를 호출
* `UserMemory`와 `PageTable`이 각각 `Allocator`를 가짐
  * `UserMemory`의 `Allocator`는 유저 프로세스가 사용할 페이지를 제공
  * `PageTable`의 `Allocator`는 페이지 테이블 자기 자신이 사용할 페이지를 제공
  * 두 `Allocator`의 역할이 분명히 구분되므로 `UserMemory` 안에 있는 `PageTable`이 자신만의 `Allocator`를 가진다고 해도 크게 이상하지 않음. 어차피 `Allocator`는 zero-sized struct이므로 runtime overhead도 없음.
  * Alternative designs:
    * `UserMemory`는 `Allocator`를 가지되 `PageTable`은 가지지 않음: `PageTable`의 많은 메서드가 `UserMemory`로부터 게속 `Allcoator`를 인자로 받아야 해서 코드가 장황해짐. `PageTable`의 auto drop도 불가능해짐.
    * `PageTable`은 `Allocator`를 가지되 `UserMemory`는 가지지 않음: `PageTable`은 페이지 테이블 자료 구조만을 나타내는 타입이고 `UserMemory`는 유저 프로세스의 메모리를 관리하는 타입인데, 유저 프로세스가 사용할 페이지를 구하기 위해 `PageTable`의 `Allocator`를 필요로 하는 것은 논리적으로 이상한 설계라 생각됨.