### PR TITLE
[Closes #442] namei & nameiparent: Path -> Itable

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -108,7 +108,7 @@ impl Kernel {
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let tx = self.file_system.begin_transaction();
-        let ptr = path.namei(proc, &self.itable)?;
+        let ptr = self.itable.namei(path, proc)?;
         let mut ip = ptr.lock();
 
         // Check ELF header


### PR DESCRIPTION
`namei`와 `nameiparent`를 `Path`에서 `Itable`로 옮겼습니다.