### PR TITLE
[#426]use AsBytes+FromBytes

### DIFF
--- a/kernel-rs/Cargo.lock
+++ b/kernel-rs/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cstr_core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +149,7 @@ dependencies = [
  "scopeguard",
  "spin",
  "static_assertions",
+ "zerocopy",
 ]
 
 [[package]]
@@ -175,7 +182,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "zerocopy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
+]

--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -30,6 +30,7 @@ array-macro = "2.0.0"
 static_assertions = "1.1.0"
 itertools = { version = "0.10.0", default-features = false }
 pin-project = "1"
+zerocopy = { version = "0.3.0", default-features = false }
 
 # Compiler options for sysroot packages.
 # Cargo currently warns following packages are not dependencies.

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -4,7 +4,7 @@ use core::{cmp, mem};
 
 use bitflags::bitflags;
 use itertools::*;
-use zerocopy::FromBytes;
+use zerocopy::{AsBytes, FromBytes};
 
 use crate::{
     fs::Path,
@@ -23,11 +23,12 @@ const ELF_MAGIC: u32 = 0x464c457f;
 const ELF_PROG_LOAD: u32 = 1;
 
 /// File header
-#[derive(Default, Clone, FromBytes)]
+#[derive(Default, Clone, AsBytes, FromBytes)]
 // It needs repr(C) because it's struct for in-disk representation
 // which should follow C(=machine) representation
 // https://github.com/kaist-cp/rv6/issues/52
-// repr(C) is also required for FromBytes.
+// repr(C) is also required for AsBytes & FromBytes.
+// https://docs.rs/zerocopy/0.3.0/zerocopy/trait.AsBytes.html
 // https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html
 #[repr(C)]
 struct ElfHdr {
@@ -50,8 +51,11 @@ struct ElfHdr {
 }
 
 bitflags! {
-    #[derive(FromBytes)]
+    #[derive(AsBytes, FromBytes)]
     /// Flag bits for ProgHdr flags
+    // It needs repr(C) for AsBytes & FromBytes.
+    // https://docs.rs/zerocopy/0.3.0/zerocopy/trait.AsBytes.html
+    // https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html
     #[repr(C)]
     struct ProgFlags: u32 {
         const EXEC = 1;
@@ -67,11 +71,12 @@ impl Default for ProgFlags {
 }
 
 /// Program section header
-#[derive(Default, Clone, FromBytes)]
+#[derive(Default, Clone, AsBytes, FromBytes)]
 // It needs repr(C) because it's struct for in-disk representation
 // which should follow C(=machine) representation
 // https://github.com/kaist-cp/rv6/issues/52
-// repr(C) is also required for FromBytes.
+// repr(C) is also required for AsBytes & FromBytes.
+// https://docs.rs/zerocopy/0.3.0/zerocopy/trait.AsBytes.html
 // https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html
 #[repr(C)]
 struct ProgHdr {

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -132,8 +132,6 @@ impl Kernel {
             let off = elf.phoff + i * mem::size_of::<ProgHdr>();
 
             let mut ph: ProgHdr = Default::default();
-            // It is safe becuase ProgHdr can be safely transmuted to [u8; _], as it
-            // contains only integers, which do not have internal structures.
             ip.read_kernel(&mut ph, off as _)?;
             if ph.is_prog_load() {
                 if ph.memsz < ph.filesz || ph.vaddr % PGSIZE != 0 {

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -76,6 +76,7 @@ use core::{
 
 use array_macro::array;
 use static_assertions::const_assert;
+use zerocopy::FromBytes;
 
 use super::{FileName, IPB, MAXFILE, NDIRECT, NINDIRECT};
 use crate::{
@@ -185,7 +186,11 @@ pub struct InodeGuard<'a> {
     pub inode: &'a Inode,
 }
 
-#[derive(Default)]
+#[derive(Default, FromBytes)]
+// It needs repr(C) for deriving zerocopy::FromBytes trait.
+// DIRSIZ should match conditions for FromBytes.
+// https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html
+#[repr(C)]
 pub struct Dirent {
     pub inum: u16,
     name: [u8; DIRSIZ],
@@ -194,9 +199,7 @@ pub struct Dirent {
 impl Dirent {
     fn new(ip: &mut InodeGuard<'_>, off: u32) -> Result<Dirent, ()> {
         let mut dirent = Dirent::default();
-        // It is safe becuase Dirent can be safely transmuted to [u8; _], as it
-        // contains only u16 and u8's, which do not have internal structures.
-        unsafe { ip.read_kernel(&mut dirent, off) }?;
+        ip.read_kernel(&mut dirent, off)?;
         Ok(dirent)
     }
 
@@ -407,13 +410,10 @@ impl InodeGuard<'_> {
 
     /// Copy data into `dst` from the content of inode at offset `off`.
     /// Return Ok(()) on success, Err(()) on failure.
-    ///
-    /// # Safety
-    ///
-    /// `T` can be safely `transmute`d to `[u8; size_of::<T>()]`.
-    pub unsafe fn read_kernel<T>(&mut self, dst: &mut T, off: u32) -> Result<(), ()> {
+    pub fn read_kernel<T:FromBytes>(&mut self, dst: &mut T, off: u32) -> Result<(), ()> {
         let bytes = self.read_bytes_kernel(
-            // It is safe because of the safety assumption of this method.
+            // SAFETY: It's safe because T implements FromBytes trait.
+            // https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html
             unsafe { core::slice::from_raw_parts_mut(dst as *mut _ as _, mem::size_of::<T>()) },
             off,
         );
@@ -662,9 +662,7 @@ impl InodeGuard<'_> {
     pub fn is_dir_empty(&mut self) -> bool {
         let mut de: Dirent = Default::default();
         for off in (2 * DIRENT_SIZE as u32..self.deref_inner().size).step_by(DIRENT_SIZE) {
-            // It is safe becuase Dirent can be safely transmuted to [u8; _], as it
-            // contains only u16 and u8's, which do not have internal structures.
-            unsafe { self.read_kernel(&mut de, off) }.expect("is_dir_empty: read_kernel");
+            self.read_kernel(&mut de, off).expect("is_dir_empty: read_kernel");
             if de.inum != 0 {
                 return false;
             }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -410,7 +410,7 @@ impl InodeGuard<'_> {
 
     /// Copy data into `dst` from the content of inode at offset `off`.
     /// Return Ok(()) on success, Err(()) on failure.
-    pub fn read_kernel<T:FromBytes>(&mut self, dst: &mut T, off: u32) -> Result<(), ()> {
+    pub fn read_kernel<T: FromBytes>(&mut self, dst: &mut T, off: u32) -> Result<(), ()> {
         let bytes = self.read_bytes_kernel(
             // SAFETY: It's safe because T implements FromBytes trait.
             // https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html
@@ -662,7 +662,8 @@ impl InodeGuard<'_> {
     pub fn is_dir_empty(&mut self) -> bool {
         let mut de: Dirent = Default::default();
         for off in (2 * DIRENT_SIZE as u32..self.deref_inner().size).step_by(DIRENT_SIZE) {
-            self.read_kernel(&mut de, off).expect("is_dir_empty: read_kernel");
+            self.read_kernel(&mut de, off)
+                .expect("is_dir_empty: read_kernel");
             if de.inum != 0 {
                 return false;
             }

--- a/kernel-rs/src/stat.rs
+++ b/kernel-rs/src/stat.rs
@@ -1,5 +1,7 @@
+use zerocopy::{AsBytes, FromBytes};
+
 use crate::fs::InodeType;
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct Stat {
     /// File system's disk device

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -17,8 +17,7 @@ pub fn fetchaddr(addr: UVAddr, proc: &mut CurrentProc<'_>) -> Result<usize, ()> 
     if addr.into_usize() >= proc.memory().size() || addr.into_usize() + sz > proc.memory().size() {
         return Err(());
     }
-    // Safe since usize does not have any internal structure.
-    unsafe { proc.memory_mut().copy_in(&mut ip, addr) }?;
+    proc.memory_mut().copy_in(&mut ip, addr)?;
     Ok(ip)
 }
 

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -567,11 +567,7 @@ impl UserMemory {
     /// Copy from user to kernel.
     /// Copy to dst from virtual address srcva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    ///
-    /// # Safety
-    ///
-    /// It is safe to transmute `T` to `[u8; size_of::<T>()]`.
-    pub unsafe fn copy_in<T:FromBytes>(&mut self, dst: &mut T, srcva: UVAddr) -> Result<(), ()> {
+    pub fn copy_in<T:FromBytes>(&mut self, dst: &mut T, srcva: UVAddr) -> Result<(), ()> {
         self.copy_in_bytes(
             unsafe { core::slice::from_raw_parts_mut(dst as *mut _ as _, mem::size_of::<T>()) },
             srcva,

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -1,4 +1,5 @@
 use core::{cmp, marker::PhantomData, mem, ops::Add, slice};
+use zerocopy::FromBytes;
 
 use crate::{
     fs::InodeGuard,
@@ -569,8 +570,8 @@ impl UserMemory {
     ///
     /// # Safety
     ///
-    /// `T` can be safely `transmute`d to `[u8; size_of::<T>()]`.
-    pub unsafe fn copy_in<T>(&mut self, dst: &mut T, srcva: UVAddr) -> Result<(), ()> {
+    /// It is safe to transmute `T` to `[u8; size_of::<T>()]`.
+    pub unsafe fn copy_in<T:FromBytes>(&mut self, dst: &mut T, srcva: UVAddr) -> Result<(), ()> {
         self.copy_in_bytes(
             unsafe { core::slice::from_raw_parts_mut(dst as *mut _ as _, mem::size_of::<T>()) },
             srcva,

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -569,6 +569,8 @@ impl UserMemory {
     /// Return Ok(()) on success, Err(()) on error.
     pub fn copy_in<T:FromBytes>(&mut self, dst: &mut T, srcva: UVAddr) -> Result<(), ()> {
         self.copy_in_bytes(
+            // SAFETY: It's safe because T implements FromBytes trait.
+            // https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html
             unsafe { core::slice::from_raw_parts_mut(dst as *mut _ as _, mem::size_of::<T>()) },
             srcva,
         )

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -1,4 +1,5 @@
 use core::{cmp, marker::PhantomData, mem, ops::Add, slice};
+
 use zerocopy::FromBytes;
 
 use crate::{
@@ -567,7 +568,7 @@ impl UserMemory {
     /// Copy from user to kernel.
     /// Copy to dst from virtual address srcva in a given page table.
     /// Return Ok(()) on success, Err(()) on error.
-    pub fn copy_in<T:FromBytes>(&mut self, dst: &mut T, srcva: UVAddr) -> Result<(), ()> {
+    pub fn copy_in<T: FromBytes>(&mut self, dst: &mut T, srcva: UVAddr) -> Result<(), ()> {
         self.copy_in_bytes(
             // SAFETY: It's safe because T implements FromBytes trait.
             // https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html


### PR DESCRIPTION
- `copy_in`, `read_kernenl`에 FromBytes trait을 적용했습니다.
- `copy_out`에 `AsBytes::as_bytes_mut`을 적용하여 내부의 unsafe block을 제거하려면 `copy_out`의 input이 되는 `T`들이 `FromBytes`와 `AsBytes`를 derive 해야합니다.
- 이 과정에서 https://github.com/kaist-cp/rv6/blob/95db5cc5e8a24659934190a2be3492014bfbbdf1/kernel-rs/src/file.rs#L119 `st`의 type인 `Stat`에 해당 trait을 derive 하려면 `InodeType`을 C-like enum으로 수정해야 합니다.

https://docs.rs/zerocopy/0.3.0/zerocopy/trait.FromBytes.html
https://docs.rs/zerocopy/0.3.0/zerocopy/trait.AsBytes.html

해당 enum은 #228 #331 등을 거치면서 추가 및 수정 되었고, FromBytes, AsBytes를 적용하기 위해서는 해당 수정 중 상당수를 롤백하거나 다른 방향으로 수정해야 합니다. 어떤 방향으로 수정하는 것이 좋을지 판단이 필요합니다. 저도 조금 더 고민하겠습니다.

@Medowhill