### PR TITLE
[Closes #444] Remove lifetime from `Rc`, `RcInode`, `RcFile`

### DIFF
--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -1,5 +1,4 @@
 use core::convert::TryFrom;
-use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
 use core::ops::Deref;
 use core::pin::Pin;
@@ -29,18 +28,18 @@ pub trait Arena: Sized {
         &self,
         c: C,
         n: N,
-    ) -> Option<Rc<'_, Self, &Self>> {
+    ) -> Option<Rc<Self::Data, Self>> {
         let inner = self.find_or_alloc_handle(c, n)?;
-        // SAFETY: becuase inner has been allocated from self.
+        // SAFETY: `inner` was allocated from `self`.
         Some(unsafe { Rc::from_unchecked(self, inner) })
     }
 
     /// Failable allocation.
     fn alloc_handle<F: FnOnce(&mut Self::Data)>(&self, f: F) -> Option<Ref<Self::Data>>;
 
-    fn alloc<F: FnOnce(&mut Self::Data)>(&self, f: F) -> Option<Rc<'_, Self, &Self>> {
+    fn alloc<F: FnOnce(&mut Self::Data)>(&self, f: F) -> Option<Rc<Self::Data, Self>> {
         let inner = self.alloc_handle(f)?;
-        // SAFETY: becuase inner has been allocated from self.
+        // SAFETY: `inner` was allocated from `self`.
         Some(unsafe { Rc::from_unchecked(self, inner) })
     }
 
@@ -106,19 +105,22 @@ pub struct MruArena<T, const CAPACITY: usize> {
     list: List<MruEntry<T>>,
 }
 
+/// A thread-safe reference counted pointer, where `T` was allocated from `A: Arena`.
+///
 /// # Safety
 ///
-/// `inner` is allocated from `tag`
-pub struct Rc<'s, A: Arena, T: Deref<Target = A>> {
-    tag: T,
+/// `inner` is allocated from `arena`.
+/// We can safely dereference `arena` until `inner` gets dropped,
+/// because we panic if the arena drops earlier than `inner`.
+pub struct Rc<T, A: Arena<Data = T>> {
+    arena: *const A,
     inner: ManuallyDrop<Ref<A::Data>>,
-    _marker: PhantomData<&'s A>, // TODO: Remove after #444
 }
 
 // `Rc` is `Send` because it does not impl `DerefMut`,
 // and when we access the inner `Arena`, we do it after acquiring `Arena`'s lock.
 // Also, `Rc` does not point to thread-local data.
-unsafe impl<'s, S: Sync, A: Arena<Data = S>, T: Deref<Target = A>> Send for Rc<'s, A, T> {}
+unsafe impl<T: Sync, A: Arena<Data = T>> Send for Rc<T, A> {}
 
 impl<T, const CAPACITY: usize> ArrayArena<T, CAPACITY> {
     // TODO(https://github.com/kaist-cp/rv6/issues/371): unsafe...
@@ -341,73 +343,44 @@ impl<T: 'static + ArenaObject + Unpin, const CAPACITY: usize> Arena
     }
 }
 
-impl<'s, A: Arena, T: Deref<Target = A>> Deref for Rc<'s, A, T> {
-    type Target = A::Data;
+impl<T, A: Arena<Data = T>> Rc<T, A> {
+    /// # Safety
+    ///
+    /// `inner` must be allocated from `arena`
+    pub unsafe fn from_unchecked(arena: &A, inner: Ref<T>) -> Self {
+        let inner = ManuallyDrop::new(inner);
+        Self { arena, inner }
+    }
 
-    fn deref(&self) -> &Self::Target {
+    /// Returns a reference to the arena that the `Rc` was allocated from.
+    fn get_arena(&self) -> &A {
+        // SAFETY: Safe because of `Rc`'s invariant.
+        unsafe { &*self.arena }
+    }
+}
+
+impl<T, A: Arena<Data = T>> Deref for Rc<T, A> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
         self.inner.deref()
     }
 }
 
-impl<'s, A: Arena, T: Deref<Target = A>> Drop for Rc<'s, A, T> {
+impl<T, A: Arena<Data = T>> Drop for Rc<T, A> {
     fn drop(&mut self) {
-        // SAFETY: inner is allocated from tag.
-        unsafe { self.tag.dealloc(ManuallyDrop::take(&mut self.inner)) };
+        // SAFETY: `inner` was allocated from `arena`.
+        unsafe { (&*self.arena).dealloc(ManuallyDrop::take(&mut self.inner)) };
     }
 }
 
-impl<'s, A: Arena, T: Deref<Target = A>> Rc<'s, A, T> {
-    /// # Safety
-    ///
-    /// `inner` must be allocated from `tag`
-    pub unsafe fn from_unchecked(tag: T, inner: Ref<A::Data>) -> Self {
-        let inner = ManuallyDrop::new(inner);
-        Self {
-            tag,
-            inner,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<'s, A: Arena, T: Clone + Deref<Target = A>> Clone for Rc<'s, A, T> {
+impl<T, A: Arena<Data = T>> Clone for Rc<T, A> {
     fn clone(&self) -> Self {
-        let tag = self.tag.clone();
-        // SAFETY: inner is allocated from tag.
-        let inner = ManuallyDrop::new(unsafe { tag.dup(&self.inner) });
+        // SAFETY: `inner` was allocated from `arena`.
+        let inner = ManuallyDrop::new(unsafe { self.get_arena().dup(&self.inner) });
         Self {
-            tag,
+            arena: self.arena,
             inner,
-            _marker: PhantomData,
-        }
-    }
-}
-
-// Rc is invariant to its lifetime parameter. The reason is that Rc has A::Handle<'s> where A
-// implements Arena and A::Handle is an arbitrary type constructor, which should be considered
-// invariant. When Rc is instantiated with ArrayArena, A::Handle is ArrayPtr, which is covariant. In
-// this case, we want Rc<'b, A, T> <: Rc<'a, A, T>. To make this subtyping possible, we define
-// narrow_lifetime to upcast Rc<'b, A, T> to Rc<'a, A, T>. This method can be removed when we remove
-// lifetimes from Rc.
-// TODO(https://github.com/kaist-cp/rv6/issues/444): remove narrow_lifetime
-impl<
-        'b,
-        T: 'static + ArenaObject + Unpin,
-        S: Clone + Deref<Target = Spinlock<ArrayArena<T, CAPACITY>>>,
-        const CAPACITY: usize,
-    > Rc<'b, Spinlock<ArrayArena<T, CAPACITY>>, S>
-{
-    pub fn narrow_lifetime<'a>(mut self) -> Rc<'a, Spinlock<ArrayArena<T, CAPACITY>>, S>
-    where
-        'b: 'a,
-    {
-        let tag = self.tag.clone();
-        let inner = ManuallyDrop::new(unsafe { ManuallyDrop::take(&mut self.inner) });
-        mem::forget(self);
-        Rc {
-            tag,
-            inner,
-            _marker: PhantomData,
         }
     }
 }

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -94,7 +94,7 @@ impl BufInner {
 pub type Bcache = Spinlock<MruArena<BufEntry, NBUF>>;
 
 /// A reference counted smart pointer to a `BufEntry`.
-pub type BufUnlocked = Rc<BufEntry, Bcache>;
+pub type BufUnlocked = Rc<Bcache>;
 
 /// A locked `BufEntry`.
 ///

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -93,17 +93,19 @@ impl BufInner {
 
 pub type Bcache = Spinlock<MruArena<BufEntry, NBUF>>;
 
-/// We can consider it as BufEntry.
-pub type BufUnlocked<'s> = Rc<'s, Bcache, &'s Bcache>;
+/// A reference counted smart pointer to a `BufEntry`.
+pub type BufUnlocked = Rc<BufEntry, Bcache>;
 
+/// A locked `BufEntry`.
+///
 /// # Safety
 ///
 /// (inner: BufEntry).inner is locked.
-pub struct Buf<'s> {
-    inner: ManuallyDrop<BufUnlocked<'s>>,
+pub struct Buf {
+    inner: ManuallyDrop<BufUnlocked>,
 }
 
-impl<'s> Buf<'s> {
+impl Buf {
     pub fn deref_inner(&self) -> &BufInner {
         let entry: &BufEntry = &self.inner;
         // SAFETY: inner.inner is locked.
@@ -116,9 +118,8 @@ impl<'s> Buf<'s> {
         unsafe { &mut *entry.inner.get_mut_raw() }
     }
 
-    pub fn unlock(mut self) -> BufUnlocked<'s> {
-        // SAFETY: this method consumes self and self.inner will not
-        // be used again.
+    pub fn unlock(mut self) -> BufUnlocked {
+        // SAFETY: this method consumes self and self.inner will not be used again.
         let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
         // SAFETY: this method consumes self.
         unsafe { inner.inner.unlock() };
@@ -127,7 +128,7 @@ impl<'s> Buf<'s> {
     }
 }
 
-impl Deref for Buf<'_> {
+impl Deref for Buf {
     type Target = BufEntry;
 
     fn deref(&self) -> &Self::Target {
@@ -135,7 +136,7 @@ impl Deref for Buf<'_> {
     }
 }
 
-impl Drop for Buf<'_> {
+impl Drop for Buf {
     fn drop(&mut self) {
         // SAFETY: self will be dropped and self.inner will not be
         // used again.
@@ -157,7 +158,7 @@ impl Bcache {
     }
 
     /// Return a unlocked buf with the contents of the indicated block.
-    pub fn get_buf(&self, dev: u32, blockno: u32) -> BufUnlocked<'_> {
+    pub fn get_buf(&self, dev: u32, blockno: u32) -> BufUnlocked {
         self.find_or_alloc(
             |buf| buf.dev == dev && buf.blockno == blockno,
             |buf| {
@@ -170,8 +171,8 @@ impl Bcache {
     }
 }
 
-impl<'s> BufUnlocked<'s> {
-    pub fn lock(self) -> Buf<'s> {
+impl BufUnlocked {
+    pub fn lock(self) -> Buf {
         mem::forget(self.inner.lock());
         Buf {
             inner: ManuallyDrop::new(self),

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -57,7 +57,8 @@ pub struct Devsw {
     pub write: Option<fn(_: UVAddr, _: i32) -> i32>,
 }
 
-pub type RcFile = Rc<File, FileTable>;
+/// A reference counted smart pointer to a `File`.
+pub type RcFile = Rc<FileTable>;
 
 impl Default for FileType {
     fn default() -> Self {

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -18,16 +18,9 @@ use crate::{
 
 pub enum FileType {
     None,
-    Pipe {
-        pipe: AllocatedPipe,
-    },
-    Inode {
-        inner: InodeFileType,
-    },
-    Device {
-        ip: RcInode<'static>,
-        major: &'static Devsw,
-    },
+    Pipe { pipe: AllocatedPipe },
+    Inode { inner: InodeFileType },
+    Device { ip: RcInode, major: &'static Devsw },
 }
 
 /// It has an inode and an offset.
@@ -36,7 +29,7 @@ pub enum FileType {
 ///
 /// The offset should be accessed only when the inode is locked.
 pub struct InodeFileType {
-    pub ip: RcInode<'static>,
+    pub ip: RcInode,
     // It should be accessed only when `ip` is locked.
     pub off: UnsafeCell<u32>,
 }
@@ -64,7 +57,7 @@ pub struct Devsw {
     pub write: Option<fn(_: UVAddr, _: i32) -> i32>,
 }
 
-pub type RcFile<'s> = Rc<'s, FileTable, &'s FileTable>;
+pub type RcFile = Rc<File, FileTable>;
 
 impl Default for FileType {
     fn default() -> Self {
@@ -248,12 +241,7 @@ impl FileTable {
     }
 
     /// Allocate a file structure.
-    pub fn alloc_file(
-        &self,
-        typ: FileType,
-        readable: bool,
-        writable: bool,
-    ) -> Result<RcFile<'_>, ()> {
+    pub fn alloc_file(&self, typ: FileType, readable: bool, writable: bool) -> Result<RcFile, ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/372): idiomatic initialization.
         self.alloc(|p| *p = File::new(typ, readable, writable))
             .ok_or(())

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -169,7 +169,7 @@ pub struct Dinode {
 pub type Itable = Spinlock<ArrayArena<Inode, NINODE>>;
 
 /// A reference counted smart pointer to an `Inode`.
-pub type RcInode = Rc<Inode, Itable>;
+pub type RcInode = Rc<Itable>;
 
 /// InodeGuard implies that `Sleeplock<InodeInner>` is held by current thread.
 ///

--- a/kernel-rs/src/fs/log.rs
+++ b/kernel-rs/src/fs/log.rs
@@ -72,7 +72,7 @@ pub struct LogInner {
     committing: bool,
 
     /// Contents of the header block, used to keep track in memory of logged block# before commit.
-    bufs: ArrayVec<[BufUnlocked<'static>; LOGSIZE]>,
+    bufs: ArrayVec<[BufUnlocked; LOGSIZE]>,
 }
 
 /// Contents of the header block, used for the on-disk header block.
@@ -287,7 +287,7 @@ impl LogLocked<'_> {
     ///   bp = Disk::read(...)
     ///   modify bp->data[]
     ///   write(bp)
-    pub fn write(&mut self, b: Buf<'static>) {
+    pub fn write(&mut self, b: Buf) {
         assert!(
             !(self.bufs.len() >= LOGSIZE || self.bufs.len() as i32 >= self.size - 1),
             "too big a transaction"

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -105,7 +105,7 @@ impl FsTransaction<'_> {
     ///   bp = kernel().file_system.disk.read(...)
     ///   modify bp->data[]
     ///   write(bp)
-    fn write(&self, b: Buf<'static>) {
+    fn write(&self, b: Buf) {
         self.fs.log.lock().write(b);
     }
 

--- a/kernel-rs/src/fs/superblock.rs
+++ b/kernel-rs/src/fs/superblock.rs
@@ -52,7 +52,7 @@ pub const BPB: usize = BSIZE * 8;
 
 impl Superblock {
     /// Read the super block.
-    pub fn new(buf: &Buf<'static>) -> Self {
+    pub fn new(buf: &Buf) -> Self {
         const_assert!(mem::size_of::<Superblock>() <= BSIZE);
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<Superblock>() == 0);
         // SAFETY:

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -133,7 +133,7 @@ impl Deref for AllocatedPipe {
 }
 
 impl Kernel {
-    pub fn allocate_pipe(&self) -> Result<(RcFile<'_>, RcFile<'_>), ()> {
+    pub fn allocate_pipe(&self) -> Result<(RcFile, RcFile), ()> {
         let page = self.alloc().ok_or(())?;
         // SAFETY: by the invariant of `Page`, `page` is always non-null.
         let mut ptr = unsafe { NonNull::new_unchecked(page.into_usize() as *mut Pipe) };

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -292,10 +292,10 @@ pub struct ProcData {
     context: Context,
 
     /// Open files.
-    pub open_files: [Option<RcFile<'static>>; NOFILE],
+    pub open_files: [Option<RcFile>; NOFILE],
 
     /// Current directory.
-    cwd: MaybeUninit<RcInode<'static>>,
+    cwd: MaybeUninit<RcInode>,
 
     /// Process name (debugging).
     pub name: [u8; MAXPROCNAME],
@@ -387,13 +387,13 @@ impl<'p> CurrentProc<'p> {
         unsafe { self.deref_mut_data().memory.assume_init_mut() }
     }
 
-    pub fn cwd(&self) -> &RcInode<'static> {
+    pub fn cwd(&self) -> &RcInode {
         // SAFETY: cwd has been initialized according to the invariants
         // of ProcBuilder and CurrentProc.
         unsafe { self.deref_data().cwd.assume_init_ref() }
     }
 
-    pub fn cwd_mut(&mut self) -> &mut RcInode<'static> {
+    pub fn cwd_mut(&mut self) -> &mut RcInode {
         // SAFETY: cwd has been initialized according to the invariants
         // of ProcBuilder and CurrentProc.
         unsafe { self.deref_mut_data().cwd.assume_init_mut() }

--- a/kernel-rs/src/sysfile.rs
+++ b/kernel-rs/src/sysfile.rs
@@ -266,8 +266,7 @@ impl Kernel {
 
     /// Change the current directory.
     /// Returns Ok(()) on success, Err(()) on error.
-    // TODO(https://github.com/kaist-cp/rv6/issues/444): &'static self -> &self
-    fn chdir(&'static self, dirname: &CStr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
+    fn chdir(&self, dirname: &CStr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
         // TODO(https://github.com/kaist-cp/rv6/issues/290)
         // The method namei can drop inodes. If namei succeeds, its return
         // value, ptr, will be dropped when this method returns. Deallocation
@@ -286,7 +285,7 @@ impl Kernel {
 
     /// Create a pipe, put read/write file descriptors in fd0 and fd1.
     /// Returns Ok(()) on success, Err(()) on error.
-    fn pipe(&'static self, fdarray: UVAddr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
+    fn pipe(&self, fdarray: UVAddr, proc: &mut CurrentProc<'_>) -> Result<(), ()> {
         let (pipereader, pipewriter) = self.allocate_pipe()?;
 
         let fd0 = pipereader.fdalloc(proc).map_err(|_| ())?;
@@ -411,7 +410,7 @@ impl Kernel {
 
     /// Change the current directory.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_chdir(&'static self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_chdir(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         let mut path: [u8; MAXPATH] = [0; MAXPATH];
         let path = argstr(0, &mut path, proc)?;
         self.chdir(path, proc)?;
@@ -461,7 +460,7 @@ impl Kernel {
 
     /// Create a pipe.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_pipe(&'static self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn sys_pipe(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
         // user pointer to array of two integers
         let fdarray = argaddr(0, proc)?.into();
         self.pipe(fdarray, proc)?;

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -70,7 +70,7 @@ struct DiskInfo {
 /// `b` refers to a valid `Buf` unless it is null.
 #[derive(Copy, Clone)]
 struct InflightInfo {
-    b: *mut Buf<'static>,
+    b: *mut Buf,
     status: bool,
 }
 
@@ -164,7 +164,7 @@ impl Drop for Descriptor {
 impl Sleepablelock<Disk> {
     /// Return a locked Buf with the `latest` contents of the indicated block.
     /// If buf.valid is true, we don't need to access Disk.
-    pub fn read(&self, dev: u32, blockno: u32) -> Buf<'static> {
+    pub fn read(&self, dev: u32, blockno: u32) -> Buf {
         // TODO: remove kernel_builder()
         let mut buf = unsafe { kernel_builder().get_bcache() }
             .get_buf(dev, blockno)
@@ -176,7 +176,7 @@ impl Sleepablelock<Disk> {
         buf
     }
 
-    pub fn write(&self, b: &mut Buf<'static>) {
+    pub fn write(&self, b: &mut Buf) {
         Disk::rw(&mut self.lock(), b, true)
     }
 }
@@ -233,7 +233,7 @@ impl Disk {
     // By the construction of the kernel page table in KernelMemory::new, the
     // virtual addresses of the MMIO registers are mapped to the proper physical
     // addresses. Therefore, this method is safe.
-    fn rw(this: &mut SleepablelockGuard<'_, Self>, b: &mut Buf<'static>, write: bool) {
+    fn rw(this: &mut SleepablelockGuard<'_, Self>, b: &mut Buf, write: bool) {
         let sector: usize = (*b).blockno as usize * (BSIZE / 512);
 
         // The spec's Section 5.2 says that legacy block operations use


### PR DESCRIPTION
Closes #444 
* `Rc`, `RcInode`, `RcFile`의 lifetime parameter를 모두 없앴습니다.
  * `Rc<'s, A, &A>` -> `Rc<T, A>`. 여기서 `T`는 `A`의 `Data` type입니다.
  * `RcInode<'s>` -> `RcInode`
  * `RcFile<'s>` -> `RcFile`
* sysfile.rs에 정의되어 있던 `Kernel`의 method들 중에서, `&'static self`를 받을 필요가 없는 method들을 `&self`로 변경했습니다.