### PR TITLE
Remove unnecessary allocator arguments

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -51,8 +51,7 @@ impl Console {
                 .current_proc()
                 .expect("No current proc")
                 .memory_mut()
-                // TODO: remove kernel_builder()
-                .copy_in_bytes(&mut c, src + i as usize, &kernel_builder().kmem)
+                .copy_in_bytes(&mut c, src + i as usize)
                 .is_err()
             {
                 return i;
@@ -100,8 +99,7 @@ impl Console {
                     .current_proc()
                     .expect("No current proc")
                     .memory_mut()
-                    // TODO: remove kernel_builder()
-                    .copy_out_bytes(dst, &cbuf, &kernel_builder().kmem)
+                    .copy_out_bytes(dst, &cbuf)
                     .is_err()
                 {
                     break;

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -136,13 +136,7 @@ impl Kernel {
                     return Err(());
                 }
                 let _ = mem.alloc(ph.vaddr.checked_add(ph.memsz).ok_or(())?, &self.kmem)?;
-                mem.load_file(
-                    ph.vaddr.into(),
-                    &mut ip,
-                    ph.off as _,
-                    ph.filesz as _,
-                    &self.kmem,
-                )?;
+                mem.load_file(ph.vaddr.into(), &mut ip, ph.off as _, ph.filesz as _)?;
             }
         }
         drop(ip);
@@ -152,7 +146,7 @@ impl Kernel {
         // Use the second as the user stack.
         let mut sz = pgroundup(mem.size());
         sz = mem.alloc(sz + 2 * PGSIZE, &self.kmem)?;
-        mem.clear((sz - 2 * PGSIZE).into(), &self.kmem);
+        mem.clear((sz - 2 * PGSIZE).into());
         let mut sp: usize = sz;
         let stackbase: usize = sp - PGSIZE;
 
@@ -172,7 +166,7 @@ impl Kernel {
                 return Err(());
             }
 
-            mem.copy_out_bytes(sp.into(), bytes, &self.kmem)?;
+            mem.copy_out_bytes(sp.into(), bytes)?;
             *stack = sp;
         }
         let argc: usize = args.len();
@@ -187,7 +181,7 @@ impl Kernel {
         }
         // SAFETY: any byte can be considered as a valid u8.
         let (_, ustack, _) = unsafe { ustack.align_to::<u8>() };
-        mem.copy_out_bytes(sp.into(), &ustack[..argv_size], &self.kmem)?;
+        mem.copy_out_bytes(sp.into(), &ustack[..argv_size])?;
 
         // Save program name for debugging.
         let path_str = path.as_bytes();

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -963,12 +963,7 @@ impl Procs {
 
     /// Wait for a child process to exit and return its pid.
     /// Return Err(()) if this process has no children.
-    pub fn wait(
-        &self,
-        addr: UVAddr,
-        proc: &mut CurrentProc<'_>,
-        allocator: &Spinlock<Kmem>,
-    ) -> Result<Pid, ()> {
+    pub fn wait(&self, addr: UVAddr, proc: &mut CurrentProc<'_>) -> Result<Pid, ()> {
         // Assumes that the process_pool has at least 1 element.
         let some_proc = self.process_pool().next().unwrap();
         let mut parent_guard = some_proc.parent().lock();
@@ -988,7 +983,7 @@ impl Procs {
                         if !addr.is_null()
                             && proc
                                 .memory_mut()
-                                .copy_out(addr, &np.deref_info().xstate, allocator)
+                                .copy_out(addr, &np.deref_info().xstate)
                                 .is_err()
                         {
                             return Err(());

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -45,70 +45,62 @@ impl Kernel {
             }
         }
     }
+}
 
+impl CurrentProc<'_> {
     /// Fetch the usize at addr from the current process.
     /// Returns Ok(fetched integer) on success, Err(()) on error.
-    pub fn fetchaddr(&self, addr: UVAddr, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+    pub fn fetchaddr(&mut self, addr: UVAddr) -> Result<usize, ()> {
         let mut ip = 0;
         let sz = mem::size_of::<usize>();
-        if addr.into_usize() >= proc.memory().size()
-            || addr.into_usize() + sz > proc.memory().size()
+        if addr.into_usize() >= self.memory().size()
+            || addr.into_usize() + sz > self.memory().size()
         {
             return Err(());
         }
         // SAFETY: usize does not have any internal structure.
-        unsafe { proc.memory_mut().copy_in(&mut ip, addr, &self.kmem) }?;
+        unsafe { self.memory_mut().copy_in(&mut ip, addr) }?;
         Ok(ip)
     }
 
     /// Fetch the nul-terminated string at addr from the current process.
     /// Returns reference to the string in the buffer.
-    pub fn fetchstr<'a>(
-        &self,
-        addr: UVAddr,
-        buf: &'a mut [u8],
-        proc: &mut CurrentProc<'_>,
-    ) -> Result<&'a CStr, ()> {
-        proc.memory_mut().copy_in_str(buf, addr, &self.kmem)?;
+    pub fn fetchstr<'a>(&mut self, addr: UVAddr, buf: &'a mut [u8]) -> Result<&'a CStr, ()> {
+        self.memory_mut().copy_in_str(buf, addr)?;
 
         // SAFETY: buf contains '\0' as copy_in_str has succeeded.
         Ok(unsafe { CStr::from_ptr(buf.as_ptr()) })
     }
 
-    fn argraw(&self, n: usize, proc: &CurrentProc<'_>) -> usize {
+    fn argraw(&self, n: usize) -> usize {
         match n {
-            0 => proc.trap_frame().a0,
-            1 => proc.trap_frame().a1,
-            2 => proc.trap_frame().a2,
-            3 => proc.trap_frame().a3,
-            4 => proc.trap_frame().a4,
-            5 => proc.trap_frame().a5,
+            0 => self.trap_frame().a0,
+            1 => self.trap_frame().a1,
+            2 => self.trap_frame().a2,
+            3 => self.trap_frame().a3,
+            4 => self.trap_frame().a4,
+            5 => self.trap_frame().a5,
             _ => panic!("argraw"),
         }
     }
 
     /// Fetch the nth 32-bit system call argument.
-    pub fn argint(&self, n: usize, proc: &CurrentProc<'_>) -> Result<i32, ()> {
-        Ok(self.argraw(n, proc) as i32)
+    pub fn argint(&self, n: usize) -> Result<i32, ()> {
+        Ok(self.argraw(n) as i32)
     }
 
     /// Retrieve an argument as a pointer.
     /// Doesn't check for legality, since
     /// copyin/copyout will do that.
-    pub fn argaddr(&self, n: usize, proc: &CurrentProc<'_>) -> Result<usize, ()> {
-        Ok(self.argraw(n, proc))
+    pub fn argaddr(&self, n: usize) -> Result<usize, ()> {
+        Ok(self.argraw(n))
     }
 
     /// Fetch the nth word-sized system call argument as a null-terminated string.
     /// Copies into buf, at most max.
     /// Returns reference to the string in the buffer.
-    pub fn argstr<'a>(
-        &self,
-        n: usize,
-        buf: &'a mut [u8],
-        proc: &mut CurrentProc<'_>,
-    ) -> Result<&'a CStr, ()> {
-        let addr = self.argaddr(n, proc)?;
-        self.fetchstr(addr.into(), buf, proc)
+    pub fn argstr<'a>(&mut self, n: usize, buf: &'a mut [u8]) -> Result<&'a CStr, ()> {
+        let addr = self.argaddr(n)?;
+        self.fetchstr(addr.into(), buf)
     }
 }


### PR DESCRIPTION
* #458 에서 `UserMemory`의 일부 메서드(`copy_in`, `copy_out` 등)는 `&Spinlock<Kmem>`을 인자로 받을 필요가 없는데도 인자를  받도록 잘못 수정해 버렸습니다. 인자를 받지 않도록 다시 고쳐 이를 해결했습니다.
* `argstr` 등의 syscall 인자를 가져 오는 함수가 예전에는 전역 함수로 정의되어 있었는데, #458 에서 `kmem`에 접근할 필요가 있어 `Kernel`의 메서드로 옮겼습니다. 이제 `kmem`이 필요하지 않기 때문에 `Kernel`의 메서드일 필요는 없어졌는데, 전역 함수보다는 `CurrentProc`의 메서드로 간주하는 것이 더 합리적인 설계라 생각하여 그렇게 수정했습니다.