### PR TITLE
Use `List` for `Kmem`

### DIFF
--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -1,11 +1,12 @@
 use core::{
     mem,
+    mem::MaybeUninit,
     ops::{Deref, DerefMut},
     ptr,
     ptr::NonNull,
 };
 
-use crate::{println, riscv::PGSIZE, vm::PAddr};
+use crate::{riscv::PGSIZE, vm::PAddr};
 
 /// Page type.
 #[repr(align(4096))]
@@ -71,6 +72,23 @@ impl Page {
             inner: unsafe { NonNull::new_unchecked(addr as *mut _) },
         }
     }
+
+    pub fn as_uninit_mut<T>(&mut self) -> &mut MaybeUninit<T> {
+        // TODO(https://github.com/kaist-cp/rv6/issues/471):
+        // Use const_assert! (or equivalent) instead. Currently, use of T inside const_assert!
+        // incurs a compile error: "can't use generic parameters from outer function".
+        // Also, there's a workaround using feature(const_generics) and
+        // feature(const_evaluatable_checked). However, using them makes the compiler panic.
+        // When the compiler becomes updated, we will fix the following lines to use static checks.
+        assert!(mem::size_of::<T>() <= PGSIZE);
+        assert_eq!(PGSIZE % mem::align_of::<T>(), 0);
+
+        // SAFETY: self.inner is an array of length PGSIZE aligned with PGSIZE bytes.
+        // The above assertions show that it can contain a value of T. As it contains arbitrary
+        // data, we cannot treat it as &mut T. Instead, we use &mut MaybeUninit<T>. It's ok because
+        // T and MaybeUninit<T> have the same size, alignment, and ABI.
+        unsafe { &mut *(self.inner.as_ptr() as *mut MaybeUninit<T>) }
+    }
 }
 
 impl Deref for Page {
@@ -91,7 +109,6 @@ impl Drop for Page {
     fn drop(&mut self) {
         // HACK(@efenniht): we really need linear type here:
         // https://github.com/rust-lang/rfcs/issues/814
-        println!("page must never drop.");
         panic!("Page must never drop.");
     }
 }


### PR DESCRIPTION
원래 `Kmem`은 자체적인 intrusive linked list를 사용하도록 구현되어 있었는데, 이를 이미 rv6가 가지고 있는 instrusive linked list 타입인 `List`를 사용하도록 수정했습니다. 원래 `Kmem`에서는 singly linked list를 사용하지만 `List` 타입은 doubly linked list인 것 등의 사소한 차이가 있고, 이로 인해 약간의 runtime overhead가 추가될 수는 있겠으나 무시할 수 있을 정도라고 생각합니다. 어차피 핵심은 `Kmem`이 intrusive linked list로 구현되어야 한다는 점이니, `Kmem`을 이미 존재하는 `List` 타입을 사용해 구현하는 것이 더 바람직한 방향인 것 같습니다.