### PR TITLE
[Closes #371] Use `const Default` trait in arena.

### DIFF
--- a/kernel-rs/Cargo.lock
+++ b/kernel-rs/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "array-macro"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "971f4e6bd8c03058ca7562baf83b44396dbcc65476eba33071700cdc24e9c5eb"
+checksum = "4a08c8f180019011a1d94e5eebcbfaa548736815f636fadc10955f1b622b4c71"
 
 [[package]]
 name = "arrayvec"

--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -26,7 +26,7 @@ scopeguard = { version = "1.1.0", default-features = false }
 arrayvec = { version = "0.5.2", default-features = false }
 cstr_core = { version = "0.2.2", default-features = false }
 spin = { version = "0.7.1", default-features = false }
-array-macro = "2.0.0"
+array-macro = "2.1.0"
 static_assertions = "1.1.0"
 itertools = { version = "0.10.0", default-features = false }
 pin-project = "1"

--- a/kernel-rs/src/arena.rs
+++ b/kernel-rs/src/arena.rs
@@ -125,21 +125,21 @@ pub struct Rc<A: Arena> {
 unsafe impl<T: Sync, A: Arena<Data = T>> Send for Rc<A> {}
 
 impl<T, const CAPACITY: usize> ArrayArena<T, CAPACITY> {
-    /// Returns an `ArrayArena` of size `CAPACITY` that is wrapped by a `Spinlock`
-    /// and filled with `D`'s const default value. Note that `D` must `impl const [Default]`.
+    /// Returns an `ArrayArena` of size `CAPACITY` that is filled with `D`'s const default value.
+    /// Note that `D` must `impl const Default`.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let arr_arena = ArrayArena::<D, 100>::new_locked("arr_arena");
+    /// let arr_arena = ArrayArena::<D, 100>::new();
     /// ```
-    pub const fn new_locked<D: Default>(name: &'static str) -> Spinlock<ArrayArena<D, CAPACITY>> {
-        Spinlock::new(
-            name,
-            ArrayArena {
-                entries: array![_ => RcCell::new(Default::default()); CAPACITY],
-            },
-        )
+    // Note: We cannot use the generic `T` in the following function, since we need to only allow
+    // types that `impl const Default`, not just `impl Default`.
+    #[allow(clippy::new_ret_no_self)]
+    pub const fn new<D: Default>() -> ArrayArena<D, CAPACITY> {
+        ArrayArena {
+            entries: array![_ => RcCell::new(Default::default()); CAPACITY],
+        }
     }
 }
 
@@ -259,22 +259,22 @@ unsafe impl<T> ListNode for MruEntry<T> {
 }
 
 impl<T, const CAPACITY: usize> MruArena<T, CAPACITY> {
-    /// Returns an `MruArena` of size `CAPACITY` that is wrapped by a `Spinlock`
-    /// and filled with `D`'s const default value. Note that `D` must `impl const [Default]`.
+    /// Returns an `MruArena` of size `CAPACITY` that is filled with `D`'s const default value.
+    /// Note that `D` must `impl const Default`.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let mru_arena = MruArena::<D, 100>::new_locked("mru_arena");
+    /// let mru_arena = MruArena::<D, 100>::new();
     /// ```
-    pub const fn new_locked<D: Default>(name: &'static str) -> Spinlock<MruArena<D, CAPACITY>> {
-        Spinlock::new(
-            name,
-            MruArena {
-                entries: array![_ => MruEntry::new(Default::default()); CAPACITY],
-                list: unsafe { List::new() },
-            },
-        )
+    // Note: We cannot use the generic `T` in the following function, since we need to only allow
+    // types that `impl const Default`, not just `impl Default`.
+    #[allow(clippy::new_ret_no_self)]
+    pub const fn new<D: Default>() -> MruArena<D, CAPACITY> {
+        MruArena {
+            entries: array![_ => MruEntry::new(Default::default()); CAPACITY],
+            list: unsafe { List::new() },
+        }
     }
 
     pub fn init(self: Pin<&mut Self>) {

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -42,7 +42,7 @@ impl BufEntry {
     }
 }
 
-#[rustfmt::skip] // Need this to use #![feature(const_trait_impl)]
+#[rustfmt::skip] // Need this if lower than rustfmt 1.4.34
 impl const Default for BufEntry {
     fn default() -> Self {
         Self::zero()
@@ -154,7 +154,7 @@ impl Bcache {
     ///
     /// The caller should make sure that `Bcache` never gets moved.
     pub const unsafe fn zero() -> Self {
-        MruArena::<BufEntry, NBUF>::new_locked("BCACHE")
+        Spinlock::new("BCACHE", MruArena::<BufEntry, NBUF>::new())
     }
 
     /// Return a unlocked buf with the contents of the indicated block.

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -14,10 +14,8 @@
 use core::mem::{self, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
 
-use array_macro::array;
-
 use crate::{
-    arena::{Arena, ArenaObject, MruArena, MruEntry, Rc},
+    arena::{Arena, ArenaObject, MruArena, Rc},
     lock::{Sleeplock, Spinlock},
     param::{BSIZE, NBUF},
     proc::WaitChannel,
@@ -41,6 +39,13 @@ impl BufEntry {
             vdisk_request_waitchannel: WaitChannel::new(),
             inner: Sleeplock::new("buffer", BufInner::zero()),
         }
+    }
+}
+
+#[rustfmt::skip] // Need this to use #![feature(const_trait_impl)]
+impl const Default for BufEntry {
+    fn default() -> Self {
+        Self::zero()
     }
 }
 
@@ -149,12 +154,7 @@ impl Bcache {
     ///
     /// The caller should make sure that `Bcache` never gets moved.
     pub const unsafe fn zero() -> Self {
-        unsafe {
-            Spinlock::new(
-                "BCACHE",
-                MruArena::new(array![_ => MruEntry::new(BufEntry::zero()); NBUF]),
-            )
-        }
+        MruArena::<BufEntry, NBUF>::new_locked("BCACHE")
     }
 
     /// Return a unlocked buf with the contents of the indicated block.

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -198,7 +198,7 @@ impl File {
     }
 }
 
-#[rustfmt::skip] // Need this to use #![feature(const_trait_impl)]
+#[rustfmt::skip] // Need this if lower than rustfmt 1.4.34
 impl const Default for File {
     fn default() -> Self {
         Self::zero()
@@ -239,7 +239,7 @@ impl ArenaObject for File {
 
 impl FileTable {
     pub const fn zero() -> Self {
-        ArrayArena::<File, NFILE>::new_locked("FTABLE")
+        Spinlock::new("FTABLE", ArrayArena::<File, NFILE>::new())
     }
 
     /// Allocate a file structure.

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -673,7 +673,7 @@ impl InodeGuard<'_> {
     }
 }
 
-#[rustfmt::skip] // Need this to use #![feature(const_trait_impl)]
+#[rustfmt::skip] // Need this if lower than rustfmt 1.4.34
 impl const Default for Inode {
     fn default() -> Self {
         Self::zero()
@@ -815,7 +815,7 @@ impl Inode {
 
 impl Itable {
     pub const fn zero() -> Self {
-        ArrayArena::<Inode, NINODE>::new_locked("ITABLE")
+        Spinlock::new("ITABLE", ArrayArena::<Inode, NINODE>::new())
     }
 
     /// Find the inode with number inum on device dev

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -49,6 +49,8 @@
 #![feature(array_value_iter)]
 #![feature(const_fn)]
 #![feature(const_fn_union)]
+#![feature(const_trait_impl)]
+#![feature(const_precise_live_drops)]
 #![feature(maybe_uninit_extra)]
 #![feature(generic_associated_types)]
 #![feature(unsafe_block_in_unsafe_fn)]


### PR DESCRIPTION
Closes #371 
### Changes
`ArrayArena`/`MruArena`의 `new` method를 변경했습니다.
기존:
```Rust
pub const fn new(entries: [RcCell<T>; CAPACITY]) -> Self; // ArrayArena
pub const fn new(entries: [MruEntry<T>; CAPACITY]) -> Self; // MruArena
```

변경 후:
```Rust
pub const fn new<D: Default>() -> Self; // ArrayArena
pub const fn new<D: Default>() -> Self; // MruArena
```
-----
* 기존에는 caller가 직접 초기화된 배열을 제공하는 형태였기 때문에, caller가 malicious한 배열을 제공하게 되면 문제가 생길 수 있었습니다.
* 변경 후에는 `ArrayArena`/`MruArena`가 직접 배열을 만들고 초기화합니다.
  * 이를 위해서, `Default` trait을 요구하도록 변경했습니다. (`const fn`안에서는 closure나 function pointer를 사용할 수 없는 것으로 보입니다.)
  * 특히, `Default` trait을 `const fn`안에서 사용하기 위해서, `#![feature(const_impl_trait)]`을 사용했습니다.