### PR TITLE
[Closes #311] Use `panic!` instead of `println!` in `devintr`.

### DIFF
--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -227,7 +227,9 @@ unsafe fn devintr(kernel: &Kernel) -> i32 {
         } else if irq as usize == VIRTIO0_IRQ {
             kernel.file_system.log.disk.lock().intr();
         } else if irq != 0 {
-            println!("unexpected interrupt irq={}\n", irq);
+            // Use `panic!` instead of `println` to prevent stack overflow.
+            // https://github.com/kaist-cp/rv6/issues/311
+            panic!("unexpected interrupt irq={}\n", irq);
         }
 
         // The PLIC allows each device to raise at most one


### PR DESCRIPTION
Closes #311 

기존처럼 `devintr()`안에서 `println!`을 쓰면 아주 가끔씩 stack overflow가 발생하는 것으로 보입니다.
xv6의 semantics를 그대로 따르려면 `println!`을 써야겠지만,
stack overflow가 자주 발생하는 것 같아 이를 `panic!`으로 변경한 후 관련 주석을 추가했습니다.