### PR TITLE
[Closes #479] Use `Branded` to remove (potential) unsafe in `Procs`

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -48,12 +48,14 @@ impl Console {
         for i in 0..n {
             let mut c = [0u8];
             // TODO: remove kernel_ctx()
-            if unsafe { kernel_ctx() }
-                .proc_mut()
-                .memory_mut()
-                .copy_in_bytes(&mut c, src + i as usize)
-                .is_err()
-            {
+            if unsafe {
+                kernel_ctx(|mut ctx| {
+                    ctx.proc_mut()
+                        .memory_mut()
+                        .copy_in_bytes(&mut c, src + i as usize)
+                        .is_err()
+                })
+            } {
                 return i;
             }
             // TODO(https://github.com/kaist-cp/rv6/issues/298): Temporarily using global function kernel().
@@ -70,7 +72,7 @@ impl Console {
             // input into CONS.buffer.
             while this.r == this.w {
                 // TODO: remove kernel_ctx()
-                if unsafe { kernel_ctx() }.proc().killed() {
+                if unsafe { kernel_ctx(|ctx| ctx.proc().killed()) } {
                     return -1;
                 }
                 this.sleep();
@@ -91,12 +93,14 @@ impl Console {
                 // Copy the input byte to the user-space buffer.
                 let cbuf = [cin as u8];
                 // TODO: remove kernel_ctx()
-                if unsafe { kernel_ctx() }
-                    .proc_mut()
-                    .memory_mut()
-                    .copy_out_bytes(dst, &cbuf)
-                    .is_err()
-                {
+                if unsafe {
+                    kernel_ctx(|mut ctx| {
+                        ctx.proc_mut()
+                            .memory_mut()
+                            .copy_out_bytes(dst, &cbuf)
+                            .is_err()
+                    })
+                } {
                     break;
                 }
                 dst = dst + 1;

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -90,7 +90,7 @@ impl ProgHdr {
     }
 }
 
-impl KernelCtx<'_> {
+impl KernelCtx<'_, '_> {
     pub fn exec(&mut self, path: &Path, args: &[Page]) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
@@ -101,7 +101,7 @@ impl KernelCtx<'_> {
         // value, ptr, will be dropped when this method returns. Deallocation
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
-        let tx = self.kernel().file_system.begin_transaction();
+        let tx = self.kernel().fs().begin_transaction();
         let ptr = self.kernel().itable.namei(path, self)?;
         let mut ip = ptr.lock();
 

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -101,7 +101,7 @@ impl File {
 
     /// Get metadata about file self.
     /// addr is a user virtual address, pointing to a struct stat.
-    pub fn stat(&self, addr: UVAddr, ctx: &mut KernelCtx<'_>) -> Result<(), ()> {
+    pub fn stat(&self, addr: UVAddr, ctx: &mut KernelCtx<'_, '_>) -> Result<(), ()> {
         match &self.typ {
             FileType::Inode {
                 inner: InodeFileType { ip, .. },
@@ -116,7 +116,7 @@ impl File {
 
     /// Read from file self.
     /// addr is a user virtual address.
-    pub fn read(&self, addr: UVAddr, n: i32, ctx: &mut KernelCtx<'_>) -> Result<usize, ()> {
+    pub fn read(&self, addr: UVAddr, n: i32, ctx: &mut KernelCtx<'_, '_>) -> Result<usize, ()> {
         if !self.readable {
             return Err(());
         }
@@ -141,7 +141,7 @@ impl File {
 
     /// Write to file self.
     /// addr is a user virtual address.
-    pub fn write(&self, addr: UVAddr, n: i32, ctx: &mut KernelCtx<'_>) -> Result<usize, ()> {
+    pub fn write(&self, addr: UVAddr, n: i32, ctx: &mut KernelCtx<'_, '_>) -> Result<usize, ()> {
         if !self.writable {
             return Err(());
         }
@@ -162,7 +162,7 @@ impl File {
                 let mut bytes_written: usize = 0;
                 while bytes_written < n {
                     let bytes_to_write = cmp::min(n - bytes_written, max);
-                    let tx = ctx.kernel().file_system.begin_transaction();
+                    let tx = ctx.kernel().fs().begin_transaction();
                     let mut ip = inner.lock();
                     let curr_off = *ip.off;
                     let r = ip

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -442,7 +442,7 @@ impl InodeGuard<'_> {
         dst: UVAddr,
         off: u32,
         n: u32,
-        ctx: &mut KernelCtx<'_>,
+        ctx: &mut KernelCtx<'_, '_>,
     ) -> Result<usize, ()> {
         self.read_internal(off, n, |off, src| {
             ctx.proc_mut()
@@ -537,7 +537,7 @@ impl InodeGuard<'_> {
         src: UVAddr,
         off: u32,
         n: u32,
-        ctx: &mut KernelCtx<'_>,
+        ctx: &mut KernelCtx<'_, '_>,
         tx: &FsTransaction<'_>,
     ) -> Result<usize, ()> {
         self.write_internal(
@@ -890,14 +890,14 @@ impl Itable {
         self.get_inode(ROOTDEV, ROOTINO)
     }
 
-    pub fn namei(&self, path: &Path, proc: &KernelCtx<'_>) -> Result<RcInode, ()> {
+    pub fn namei(&self, path: &Path, proc: &KernelCtx<'_, '_>) -> Result<RcInode, ()> {
         Ok(self.namex(path, false, proc)?.0)
     }
 
     pub fn nameiparent<'s>(
         &self,
         path: &'s Path,
-        ctx: &KernelCtx<'_>,
+        ctx: &KernelCtx<'_, '_>,
     ) -> Result<(RcInode, &'s FileName), ()> {
         let (ip, name_in_path) = self.namex(path, true, ctx)?;
         let name_in_path = name_in_path.ok_or(())?;
@@ -908,7 +908,7 @@ impl Itable {
         &self,
         mut path: &'s Path,
         parent: bool,
-        ctx: &KernelCtx<'_>,
+        ctx: &KernelCtx<'_, '_>,
     ) -> Result<(RcInode, Option<&'s FileName>), ()> {
         let mut ptr = if path.is_absolute() {
             self.root()

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -22,6 +22,7 @@ use crate::{
     proc::{cpuid, scheduler, Cpu, Procs, ProcsBuilder},
     trap::{trapinit, trapinithart},
     uart::Uart,
+    util::branded::Branded,
     vm::KernelMemory,
 };
 
@@ -31,15 +32,22 @@ static mut KERNEL: KernelBuilder = KernelBuilder::zero();
 /// After intialized, the kernel is safe to immutably access.
 // TODO: make it unsafe
 #[inline]
-pub fn kernel_builder() -> &'static KernelBuilder {
+pub fn kernel_builder<'s>() -> &'s KernelBuilder {
     unsafe { &KERNEL }
 }
 
 #[inline]
-pub unsafe fn kernel() -> &'static Kernel {
+pub unsafe fn kernel<'s>() -> &'s Kernel {
     // SAFETY: Safe to cast &KernelBuilder into &Kernel
     // since Kernel has a transparent memory layout.
     unsafe { &*(kernel_builder() as *const _ as *const _) }
+}
+
+/// Creates a `KernelRef` that has a fresh `'id` and points to the `Kernel`.
+/// The `KernelRef` can be used only inside the given closure.
+pub unsafe fn kernel_ref<'s, F: for<'new_id> FnOnce(KernelRef<'new_id, 's>) -> R, R>(f: F) -> R {
+    let kernel = unsafe { kernel() };
+    Branded::new(kernel, |bkernel| f(KernelRef(bkernel)))
 }
 
 /// Returns a pinned mutable reference to the `KERNEL`.
@@ -80,7 +88,7 @@ pub struct KernelBuilder {
     /// The kernel's memory manager.
     memory: MaybeUninit<KernelMemory>,
 
-    pub ticks: Sleepablelock<u32>,
+    ticks: Sleepablelock<u32>,
 
     /// Current process system.
     #[pin]
@@ -94,12 +102,13 @@ pub struct KernelBuilder {
     #[pin]
     bcache: Bcache,
 
-    pub devsw: [Devsw; NDEV],
+    devsw: [Devsw; NDEV],
 
     pub ftable: FileTable,
 
     pub itable: Itable,
 
+    // TODO: Make this private and always use `KernelRef::fs` instead.
     pub file_system: FileSystem,
 }
 
@@ -123,6 +132,41 @@ impl Deref for Kernel {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+/// A branded reference to a `Kernel`.
+/// The `'id` is always different between different `Kernel` instances.
+#[derive(Clone, Copy)]
+pub struct KernelRef<'id, 's>(Branded<'id, &'s Kernel>);
+
+impl<'id, 's> KernelRef<'id, 's> {
+    pub fn get_inner(&self) -> &Branded<'id, &'s Kernel> {
+        &self.0
+    }
+
+    /// Returns a reference to the kernel's ticks.
+    pub fn ticks(&self) -> &'s Sleepablelock<u32> {
+        &self.0.ticks
+    }
+
+    /// Returns a reference to the kernel's `Devsw` array.
+    pub fn devsw(&self) -> &'s [Devsw; NDEV] {
+        &self.0.devsw
+    }
+
+    /// Returns a reference to the kernel's `FileSystem`.
+    // Need this to prevent lifetime confusions.
+    pub fn fs(&self) -> &'s FileSystem {
+        &self.0.file_system
+    }
+}
+
+impl<'id, 's> Deref for KernelRef<'id, 's> {
+    type Target = Kernel;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -153,8 +153,9 @@ impl Deref for Kernel {
 pub struct KernelRef<'id, 's>(Branded<'id, &'s Kernel>);
 
 impl<'id, 's> KernelRef<'id, 's> {
-    pub fn get_inner(&self) -> &Branded<'id, &'s Kernel> {
-        &self.0
+    /// Returns a `Branded` that wraps `data` and has the same `'id` tag with `self`.
+    pub fn brand<T>(&self, data: T) -> Branded<'id, T> {
+        self.0.brand(data)
     }
 
     /// Returns a reference to the kernel's ticks.

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -42,6 +42,7 @@
 #![allow(incomplete_features)]
 #![allow(clippy::upper_case_acronyms)]
 #![feature(asm)]
+#![feature(arbitrary_self_types)]
 #![feature(const_fn)]
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_fn_union)]

--- a/kernel-rs/src/lock/sleepablelock.rs
+++ b/kernel-rs/src/lock/sleepablelock.rs
@@ -52,11 +52,8 @@ impl<T> Sleepablelock<T> {
 
 impl<T> SleepablelockGuard<'_, T> {
     pub fn sleep(&mut self) {
-        self.lock.lock.waitchannel.sleep(
-            self,
-            // TODO: remove kernel_ctx()
-            &unsafe { kernel_ctx() },
-        );
+        // TODO: remove kernel_ctx()
+        unsafe { kernel_ctx(|ctx| self.lock.lock.waitchannel.sleep(self, &ctx)) };
     }
 
     pub fn wakeup(&self) {

--- a/kernel-rs/src/lock/sleeplock.rs
+++ b/kernel-rs/src/lock/sleeplock.rs
@@ -34,7 +34,7 @@ impl RawLock for RawSleeplock {
             guard.sleep();
         }
         // TODO: remove kernel_ctx()
-        *guard = unsafe { kernel_ctx() }.proc().pid();
+        *guard = unsafe { kernel_ctx(|ctx| ctx.proc().pid()) };
     }
 
     fn release(&self) {
@@ -46,7 +46,7 @@ impl RawLock for RawSleeplock {
     fn holding(&self) -> bool {
         let guard = self.locked.lock();
         // TODO: remove kernel_ctx()
-        *guard == unsafe { kernel_ctx() }.proc().pid()
+        *guard == unsafe { kernel_ctx(|ctx| ctx.proc().pid()) }
     }
 }
 

--- a/kernel-rs/src/pipe.rs
+++ b/kernel-rs/src/pipe.rs
@@ -42,7 +42,7 @@ impl Pipe {
     /// If successfully read i > 0 bytes, wakeups the `write_waitchannel` and returns `Ok(i: usize)`.
     /// If the pipe was empty, sleeps at `read_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn read(&self, addr: UVAddr, n: usize, ctx: &mut KernelCtx<'_>) -> Result<usize, ()> {
+    pub fn read(&self, addr: UVAddr, n: usize, ctx: &mut KernelCtx<'_, '_>) -> Result<usize, ()> {
         let mut inner = self.inner.lock();
         loop {
             match inner.try_read(addr, n, ctx) {
@@ -66,7 +66,7 @@ impl Pipe {
     /// Note that we may have i < `n` if an copy-in error happened.
     /// If the pipe was full, sleeps at `write_waitchannel` and tries again after wakeup.
     /// If an error happened, returns `Err(())`.
-    pub fn write(&self, addr: UVAddr, n: usize, ctx: &mut KernelCtx<'_>) -> Result<usize, ()> {
+    pub fn write(&self, addr: UVAddr, n: usize, ctx: &mut KernelCtx<'_, '_>) -> Result<usize, ()> {
         let mut written = 0;
         let mut inner = self.inner.lock();
         loop {
@@ -201,7 +201,7 @@ impl PipeInner {
         &mut self,
         addr: UVAddr,
         n: usize,
-        ctx: &mut KernelCtx<'_>,
+        ctx: &mut KernelCtx<'_, '_>,
     ) -> Result<usize, PipeError> {
         let mut ch = [0u8];
         if !self.readopen || ctx.proc().killed() {
@@ -234,7 +234,7 @@ impl PipeInner {
         &mut self,
         addr: UVAddr,
         n: usize,
-        ctx: &mut KernelCtx<'_>,
+        ctx: &mut KernelCtx<'_, '_>,
     ) -> Result<usize, PipeError> {
         //DOC: pipe-empty
         if self.nread == self.nwrite && self.writeopen {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -951,7 +951,7 @@ impl Procs {
     /// Create a new process, copying the parent.
     /// Sets up child kernel stack to return as if from fork() system call.
     /// Returns Ok(new process id) on success, Err(()) on error.
-    pub fn fork(&self, ctx: &mut KernelCtx<'_, '_>) -> Result<Pid, ()> {
+    pub fn fork<'id>(self: &ProcsRef<'id, '_>, ctx: &mut KernelCtx<'id, '_>) -> Result<Pid, ()> {
         let allocator = &ctx.kernel.kmem;
         // Allocate trap frame.
         let trap_frame =
@@ -1009,7 +1009,11 @@ impl Procs {
 
     /// Wait for a child process to exit and return its pid.
     /// Return Err(()) if this process has no children.
-    pub fn wait(&self, addr: UVAddr, ctx: &mut KernelCtx<'_, '_>) -> Result<Pid, ()> {
+    pub fn wait<'id>(
+        self: ProcsRef<'id, '_>,
+        addr: UVAddr,
+        ctx: &mut KernelCtx<'id, '_>,
+    ) -> Result<Pid, ()> {
         // Assumes that the process_pool has at least 1 element.
         let some_proc = self.process_pool().next().unwrap();
         let mut parent_guard = some_proc.parent().lock();
@@ -1073,7 +1077,11 @@ impl Procs {
     /// Exit the current process.  Does not return.
     /// An exited process remains in the zombie state
     /// until its parent calls wait().
-    pub fn exit_current(&self, status: i32, ctx: &mut KernelCtx<'_, '_>) -> ! {
+    pub fn exit_current<'id>(
+        self: &ProcsRef<'id, '_>,
+        status: i32,
+        ctx: &mut KernelCtx<'id, '_>,
+    ) -> ! {
         assert_ne!(
             ctx.proc.deref() as *const _,
             self.initial_proc() as _,

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -1245,7 +1245,7 @@ impl Kernel {
         // This is safe because p is non-null and current Cpu's proc.
         unsafe { proc.as_ref() }.map(|proc| {
             CurrentProc {
-                inner: self.get_inner().brand(proc),
+                inner: self.brand(proc),
             }
         })
     }
@@ -1253,8 +1253,8 @@ impl Kernel {
 
 impl<'id, 's> KernelRef<'id, 's> {
     /// Returns a `ProcsRef` that points to the kernel's `Procs`.
-    pub fn procs(&self) -> ProcsRef<'id, 's> {
-        ProcsRef(self.get_inner().brand(self.get_inner().procs()))
+    pub fn procs(&self) -> ProcsRef<'id, '_> {
+        ProcsRef(self.brand(self.deref().procs()))
     }
 }
 

--- a/kernel-rs/src/syscall/mod.rs
+++ b/kernel-rs/src/syscall/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 mod file;
 mod proc;
 
-impl KernelCtx<'_> {
+impl KernelCtx<'_, '_> {
     pub fn syscall(&mut self, num: i32) -> Result<usize, ()> {
         match num {
             1 => self.sys_fork(),
@@ -49,7 +49,7 @@ impl KernelCtx<'_> {
     }
 }
 
-impl CurrentProc<'_> {
+impl CurrentProc<'_, '_> {
     /// Fetch the usize at addr from the current process.
     /// Returns Ok(fetched integer) on success, Err(()) on error.
     pub fn fetchaddr(&mut self, addr: UVAddr) -> Result<usize, ()> {

--- a/kernel-rs/src/syscall/proc.rs
+++ b/kernel-rs/src/syscall/proc.rs
@@ -4,20 +4,20 @@ impl KernelCtx<'_, '_> {
     /// Terminate the current process; status reported to wait(). No return.
     pub fn sys_exit(&mut self) -> Result<usize, ()> {
         let n = self.proc().argint(0)?;
-        self.kernel().procs().exit_current(n, self);
+        self.kernel().procs_ref().exit_current(n, self);
     }
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub fn sys_fork(&mut self) -> Result<usize, ()> {
-        Ok(self.kernel().procs().fork(self)? as _)
+        Ok(self.kernel().procs_ref().fork(self)? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub fn sys_wait(&mut self) -> Result<usize, ()> {
         let p = self.proc().argaddr(0)?;
-        Ok(self.kernel().procs().wait(p.into(), self)? as _)
+        Ok(self.kernel().procs_ref().wait(p.into(), self)? as _)
     }
 
     /// Return the current process’s PID.

--- a/kernel-rs/src/syscall/proc.rs
+++ b/kernel-rs/src/syscall/proc.rs
@@ -4,20 +4,20 @@ impl KernelCtx<'_, '_> {
     /// Terminate the current process; status reported to wait(). No return.
     pub fn sys_exit(&mut self) -> Result<usize, ()> {
         let n = self.proc().argint(0)?;
-        self.kernel().procs_ref().exit_current(n, self);
+        self.kernel().procs().exit_current(n, self);
     }
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub fn sys_fork(&mut self) -> Result<usize, ()> {
-        Ok(self.kernel().procs_ref().fork(self)? as _)
+        Ok(self.kernel().procs().fork(self)? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub fn sys_wait(&mut self) -> Result<usize, ()> {
         let p = self.proc().argaddr(0)?;
-        Ok(self.kernel().procs_ref().wait(p.into(), self)? as _)
+        Ok(self.kernel().procs().wait(p.into(), self)? as _)
     }
 
     /// Return the current process’s PID.

--- a/kernel-rs/src/syscall/proc.rs
+++ b/kernel-rs/src/syscall/proc.rs
@@ -1,6 +1,6 @@
 use crate::{arch::poweroff, proc::KernelCtx};
 
-impl KernelCtx<'_> {
+impl KernelCtx<'_, '_> {
     /// Terminate the current process; status reported to wait(). No return.
     pub fn sys_exit(&mut self) -> Result<usize, ()> {
         let n = self.proc().argint(0)?;
@@ -37,7 +37,7 @@ impl KernelCtx<'_> {
     /// Returns Ok(0) on success, Err(()) on error.
     pub fn sys_sleep(&self) -> Result<usize, ()> {
         let n = self.proc().argint(0)?;
-        let mut ticks = self.kernel().ticks.lock();
+        let mut ticks = self.kernel().ticks().lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
             if self.proc().killed() {
@@ -59,7 +59,7 @@ impl KernelCtx<'_> {
     /// Return how many clock tick interrupts have occurred
     /// since start.
     pub fn sys_uptime(&self) -> Result<usize, ()> {
-        Ok(*self.kernel().ticks.lock() as usize)
+        Ok(*self.kernel().ticks().lock() as usize)
     }
 
     /// Shutdowns this machine, discarding all unsaved data. No return.

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -70,7 +70,7 @@ impl KernelCtx<'_, '_> {
             // system call
 
             if self.proc().killed() {
-                self.kernel().procs().exit_current(-1, &mut self);
+                self.kernel().procs_ref().exit_current(-1, &mut self);
             }
 
             // sepc points to the ecall instruction,
@@ -100,7 +100,7 @@ impl KernelCtx<'_, '_> {
         }
 
         if self.proc().killed() {
-            self.kernel().procs().exit_current(-1, &mut self);
+            self.kernel().procs_ref().exit_current(-1, &mut self);
         }
 
         // Give up the CPU if this is a timer interrupt.
@@ -235,7 +235,7 @@ impl KernelRef<'_, '_> {
             if irq as usize == UART0_IRQ {
                 self.uart.intr();
             } else if irq as usize == VIRTIO0_IRQ {
-                self.fs().log.disk.lock().intr();
+                self.file_system.log.disk.lock().intr();
             } else if irq != 0 {
                 // Use `panic!` instead of `println` to prevent stack overflow.
                 // https://github.com/kaist-cp/rv6/issues/311

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -235,7 +235,7 @@ impl KernelRef<'_, '_> {
             if irq as usize == UART0_IRQ {
                 self.uart.intr();
             } else if irq as usize == VIRTIO0_IRQ {
-                self.file_system.log.disk.lock().intr();
+                self.fs().log.disk.lock().intr();
             } else if irq != 0 {
                 // Use `panic!` instead of `println` to prevent stack overflow.
                 // https://github.com/kaist-cp/rv6/issues/311

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -70,7 +70,7 @@ impl KernelCtx<'_, '_> {
             // system call
 
             if self.proc().killed() {
-                self.kernel().procs_ref().exit_current(-1, &mut self);
+                self.kernel().procs().exit_current(-1, &mut self);
             }
 
             // sepc points to the ecall instruction,
@@ -100,7 +100,7 @@ impl KernelCtx<'_, '_> {
         }
 
         if self.proc().killed() {
-            self.kernel().procs_ref().exit_current(-1, &mut self);
+            self.kernel().procs().exit_current(-1, &mut self);
         }
 
         // Give up the CPU if this is a timer interrupt.

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -322,11 +322,8 @@ impl Disk {
 
         // Wait for virtio_disk_intr() to say request has finished.
         while b.deref_inner().disk {
-            (*b).vdisk_request_waitchannel.sleep(
-                this,
-                // TODO: remove kernel_ctx()
-                &unsafe { kernel_ctx() },
-            );
+            // TODO: remove kernel_ctx()
+            unsafe { kernel_ctx(|ctx| (*b).vdisk_request_waitchannel.sleep(this, &ctx)) };
         }
         // As it assigns null, the invariant of inflight is maintained even if
         // b: &mut Buf becomes invalid after this method returns.


### PR DESCRIPTION
Partially resolves #479 
Partially resolves #494 

# Motivation
#479 에서 설명한 것처럼, `Procs::{fork, wait, exit_current}`와 같은 method들은 여러개의 `Procs`가 존재할 수 있다면 memory safety bug가 생길 수 있습니다.
* ex1: 현재 `Procs::{fork, wait, exit_current}` method들에서는 먼저 `Procs::wait_lock`을 acquire한 후 `CurrentProc`의 parent field를 변경합니다
  * 만약 엉뚱한 `Procs`의 `wait_lock`을 acquire하게되면, `CurrentProc`의 parent field를 lock을 잡지 않고도 read/write할 수 있게 됩니다.
  * 그러므로, 지금은 `Proc`의 내부에 `Procs`의 `wait_lock`을 가리키는 reference를 별도로 저장해놓고 있습니다. (즉, 추가적인 runtime cost를 사용하고 있습니다.)
  * 이 runtime cost를 safe하게 없애려면, `Procs`와 `CurrentProc`이 서로 연결되어 있음을 `Branded`를 통해 표현해야 합니다. 이러면, `Proc`의 내부에 추가적인 field를 저장할 필요가 없어집니다. (추가적으로, 이렇게 하면 `ProcsBuilder::init`의 unsafe를 어느정도 줄일 수 있을 것 같습니다.)
* ex2: `Procs::fork`는 새로운 `Proc`을 만든 후, `Proc::parent` field가 `CurrentProc`을 가리키게 합니다.
  * 만약 `Procs`와 `KernelCtx`가 서로 다른 `Kernel`로부터 온 것이며, `KernelCtx`의 `Kernel`이 먼저 drop해버리면, `Proc`의 `parent` field를 읽을때 UB가 발생하게 됩니다. (ex: `Procs::{wait, exit_current}`).
* ex3: `Procs::fork`는 주어진 `KernelCtx`로부터 `Kernel::Kmem`에 접근한 후, 그곳으로부터 trap frame을 저장할 공간을 할당받습니다. 이후, 새로 만들어지는 `Proc`이 그 trap frame을 사용하도록 합니다.
  * 만약 `Procs`와 `KernelCtx`가 서로 다른 `Kernel`로부터 온 것이며, `KernelCtx`의 `Kernel`이 먼저 drop해버리면, `Proc`의 trap frame을 access할때 UB가 발생합니다.
  * 다만, 만약에 `Kernel`들로부터 `Kmem`을 분리한 후, `Kmem`은 global하게 하나만 두게 되면, 문제가 없어질 수도 있습니다.
* TODO: Find more memory safety bugs

그러므로, 올바른 방법으로만 사용하도록 `Branded`를 이용해서 제한해야 합니다.

# Changes
* https://github.com/kaist-cp/rv6/issues/479#issuecomment-818762919 에서 discuss한대로, `Branded`를 그대로 쓰지 말고 wrap해서 사용하였습니다.
  * `KernelRef<'id, 's>` 추가 (wraps `Branded<'id, &'s Kernel>`)
  * `ProcsRef<'id, 's>` 추가 (wraps `Branded<'id, &'s Procs>`)
  * `CurrentProc<'p>` -> `CurrentProc<'id, 'p>`
    * 이전
    ```Rust
    pub struct CurrentProc<'p> {
        inner: &'p Proc,
    }
    ```
    * 이후
    ```Rust
    pub struct CurrentProc<'id, 'p> {
        inner: Branded<'id, &'p Proc>,
    }
    ```
  * `KernelCtx<'p>` -> `KernelCtx<'id, 'p>`
    * 이전
    ```Rust
    pub struct KernelCtx {
       pub kernel: &'p Kernel,
       pub proc: CurrentProc<'p>,
    }
    ```
    * 이후
    ```Rust
    pub struct KernelCtx<'id, 'p> {
        pub kernel: KernelRef<'id, 'p>,
        pub proc: CurrentProc<'id, 'p>,
    }
    ```
* `Procs::{fork, wait, exit_current}` method들이 `ProcsRef`를 사용하도록 변경했습니다. 0a3e47d
  * 참고: 지금은 `Procs`만 변경했지만, 어차피 이제는 `KernelCtx`가 `KernelRef<'id, 'p>`, `CurrentProc<'id, 'p`>를 저장하므로, 다른 곳을 바꾸는 것도 매우 간단할 것 같습니다.

