### PR TITLE
Small fix

### DIFF
--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -42,7 +42,6 @@ impl BufEntry {
     }
 }
 
-#[rustfmt::skip] // Need this if lower than rustfmt 1.4.34
 impl const Default for BufEntry {
     fn default() -> Self {
         Self::zero()

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -198,7 +198,6 @@ impl File {
     }
 }
 
-#[rustfmt::skip] // Need this if lower than rustfmt 1.4.34
 impl const Default for File {
     fn default() -> Self {
         Self::zero()

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -672,7 +672,6 @@ impl InodeGuard<'_> {
     }
 }
 
-#[rustfmt::skip] // Need this if lower than rustfmt 1.4.34
 impl const Default for Inode {
     fn default() -> Self {
         Self::zero()

--- a/kernel-rs/src/lock/remotelock.rs
+++ b/kernel-rs/src/lock/remotelock.rs
@@ -26,7 +26,7 @@ impl<'s, R: RawLock, U, T> RemoteLock<'s, R, U, T> {
     ///
     /// ```rust,no_run
     /// let spinlock: Spinlock<usize> = Spinlock::new("spinlock", 10);
-    /// let spinlock_remote: RemoteSpinlock<'_, usize, isize> = RemoteLock::new(&spinlock, -20);
+    /// let spinlock_remote: RemoteLock<'_, RawSpinlock, usize, isize> = RemoteLock::new(&spinlock, -20);
     /// ```
     pub const fn new(lock: &'s Lock<R, U>, data: T) -> Self {
         Self {


### PR DESCRIPTION
매우 간단한 PR입니다. 바로 merge해주셔도 될 것 같습니다.

* Fix for https://github.com/kaist-cp/rv6/pull/480#discussion_r611357234
* Fix for https://github.com/kaist-cp/rv6/pull/469#discussion_r604642222
  * rustfmt version이 1.4.36-nightly로 업데이트되어, 더 이상 `#[rustfmt::skip]`을 붙일 필요가 없습니다.