### PR TITLE
make kernel more object-like

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -118,7 +118,7 @@ impl Console {
     unsafe fn intr(
         this: &mut SleepablelockGuard<'_, Self>,
         mut cin: i32,
-        kernel: &KernelRef<'_, '_>,
+        kernel: KernelRef<'_, '_>,
     ) {
         match cin {
             // Print process list.
@@ -255,7 +255,7 @@ fn consoleread(dst: UVAddr, n: i32) -> i32 {
 /// uartintr() calls this for input character.
 /// Do erase/kill processing, append to CONS.buf,
 /// wake up consoleread() if a whole line has arrived.
-pub unsafe fn consoleintr(cin: i32, kernel: &KernelRef<'_, '_>) {
+pub unsafe fn consoleintr(cin: i32, kernel: KernelRef<'_, '_>) {
     let mut console = kernel.console.lock();
     unsafe { Console::intr(&mut console, cin, kernel) };
 }

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -163,7 +163,7 @@ impl Console {
                         // Wake up consoleread() if a whole line (or end-of-file)
                         // has arrived.
                         this.w = this.e;
-                        this.wakeup();
+                        this.wakeup(kernel);
                     }
                 }
             }

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -6,7 +6,7 @@ use crate::{
     arch::addr::UVAddr,
     arena::{Arena, ArenaObject, ArrayArena, Rc},
     fs::{InodeGuard, RcInode},
-    kernel::kernel_builder,
+    kernel::kernel_ref,
     lock::Spinlock,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
     pipe::AllocatedPipe,
@@ -206,29 +206,29 @@ impl ArenaObject for File {
     fn finalize<'s, A: Arena>(&'s mut self, guard: &'s mut A::Guard<'_>) {
         // SAFETY: `FileTable` does not use `Arena::find_or_alloc`.
         unsafe {
-            A::reacquire_after(guard, || {
-                let typ = mem::replace(&mut self.typ, FileType::None);
-                match typ {
-                    FileType::Pipe { pipe } => {
-                        if let Some(page) = pipe.close(self.writable) {
-                            // TODO: remove kernel_builder()
-                            kernel_builder().kmem.free(page);
+            kernel_ref(|kref| {
+                A::reacquire_after(guard, || {
+                    let typ = mem::replace(&mut self.typ, FileType::None);
+                    match typ {
+                        FileType::Pipe { pipe } => {
+                            if let Some(page) = pipe.close(self.writable, kref) {
+                                kref.kmem.free(page);
+                            }
                         }
+                        FileType::Inode {
+                            inner: InodeFileType { ip, .. },
+                        }
+                        | FileType::Device { ip, .. } => {
+                            // TODO(https://github.com/kaist-cp/rv6/issues/290)
+                            // The inode ip will be dropped by drop(ip). Deallocation
+                            // of an inode may cause disk write operations, so we must
+                            // begin a transaction here.
+                            let _tx = kref.file_system.begin_transaction();
+                            drop(ip);
+                        }
+                        _ => (),
                     }
-                    FileType::Inode {
-                        inner: InodeFileType { ip, .. },
-                    }
-                    | FileType::Device { ip, .. } => {
-                        // TODO(https://github.com/kaist-cp/rv6/issues/290)
-                        // The inode ip will be dropped by drop(ip). Deallocation
-                        // of an inode may cause disk write operations, so we must
-                        // begin a transaction here.
-                        // TODO: remove kernel_builder()
-                        let _tx = kernel_builder().file_system.begin_transaction();
-                        drop(ip);
-                    }
-                    _ => (),
-                }
+                });
             });
         }
     }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -6,7 +6,7 @@
 //! list of blocks holding the file's content.
 //!
 //! The inodes are laid out sequentially on disk at
-//! kernel().file_system.superblock.startinode. Each inode has a number, indicating its
+//! kernel.file_system.superblock.startinode. Each inode has a number, indicating its
 //! position on the disk.
 //!
 //! The kernel keeps a table of in-use inodes in memory
@@ -58,10 +58,10 @@
 //! have locked the inodes involved; this lets callers create
 //! multi-step atomic operations.
 //!
-//! The kernel().itable.lock spin-lock protects the allocation of itable
+//! The kernel.itable.lock spin-lock protects the allocation of itable
 //! entries. Since ip->ref indicates whether an entry is free,
 //! and ip->dev and ip->inum indicate which i-node an entry
-//! holds, one must hold kernel().itable.lock while using any of those fields.
+//! holds, one must hold kernel.itable.lock while using any of those fields.
 //!
 //! An ip->lock sleep-lock protects all ip-> fields other than ref,
 //! dev, and inum.  One must hold ip->lock in order to

--- a/kernel-rs/src/fs/log.rs
+++ b/kernel-rs/src/fs/log.rs
@@ -160,7 +160,7 @@ impl Log {
 
         // begin_op() may be waiting for LOG space, and decrementing log.outstanding has decreased
         // the amount of reserved space.
-        guard.wakeup();
+        guard.wakeup(ctx.kernel());
     }
 }
 

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -111,7 +111,7 @@ impl FsTransaction<'_> {
     /// commit()/write_log() will do the disk write.
     ///
     /// write() replaces write(); a typical use is:
-    ///   bp = kernel().file_system.disk.read(...)
+    ///   bp = kernel.file_system.disk.read(...)
     ///   modify bp->data[]
     ///   write(bp)
     fn write(&self, b: Buf) {

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -98,7 +98,7 @@ impl Drop for FsTransaction<'_> {
     fn drop(&mut self) {
         // Called at the end of each FS system call.
         // Commits if this was the last outstanding operation.
-        // TODO: remove kernel_ctx
+        // TODO: remove kernel_ctx()
         unsafe {
             kernel_ctx(|ctx| self.fs.log.end_op(&ctx));
         }

--- a/kernel-rs/src/lock/sleepablelock.rs
+++ b/kernel-rs/src/lock/sleepablelock.rs
@@ -2,7 +2,10 @@
 use core::cell::UnsafeCell;
 
 use super::{spinlock::RawSpinlock, Guard, Lock, RawLock};
-use crate::proc::{kernel_ctx, WaitChannel};
+use crate::{
+    kernel::KernelRef,
+    proc::{kernel_ctx, WaitChannel},
+};
 
 /// Mutual exclusion spin locks that can sleep.
 pub struct RawSleepablelock {
@@ -56,7 +59,7 @@ impl<T> SleepablelockGuard<'_, T> {
         unsafe { kernel_ctx(|ctx| self.lock.lock.waitchannel.sleep(self, &ctx)) };
     }
 
-    pub fn wakeup(&self) {
-        self.lock.lock.waitchannel.wakeup();
+    pub fn wakeup(&self, kernel: KernelRef<'_, '_>) {
+        self.lock.lock.waitchannel.wakeup(kernel);
     }
 }

--- a/kernel-rs/src/lock/sleeplock.rs
+++ b/kernel-rs/src/lock/sleeplock.rs
@@ -2,7 +2,7 @@
 use core::cell::UnsafeCell;
 
 use super::{Guard, Lock, RawLock, Sleepablelock};
-use crate::proc::kernel_ctx;
+use crate::{kernel::kernel_ref, proc::kernel_ctx};
 
 /// Long-term locks for processes
 pub struct RawSleeplock {
@@ -40,7 +40,7 @@ impl RawLock for RawSleeplock {
     fn release(&self) {
         let mut guard = self.locked.lock();
         *guard = -1;
-        guard.wakeup();
+        unsafe { kernel_ref(|kref| guard.wakeup(kref)) };
     }
 
     fn holding(&self) -> bool {

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -346,7 +346,7 @@ pub struct ProcBuilder {
 /// arguments. Otherwise, methods can take only one of `&Kernel` and `CurrentProc` as arguments.
 pub struct KernelCtx<'id, 'p> {
     kernel: KernelRef<'id, 'p>,
-    pub proc: CurrentProc<'id, 'p>,
+    proc: CurrentProc<'id, 'p>,
 }
 
 impl<'id, 'p> KernelCtx<'id, 'p> {

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -83,7 +83,7 @@ impl KernelCtx<'_, '_> {
             let syscall_no = self.proc_mut().trap_frame_mut().a7 as i32;
             self.proc_mut().trap_frame_mut().a0 = ok_or!(self.syscall(syscall_no), usize::MAX);
         } else {
-            which_dev = unsafe { self.kernel().dev_intr(&self.kernel()) };
+            which_dev = unsafe { self.kernel().dev_intr(self.kernel()) };
             if which_dev == 0 {
                 println!(
                     "usertrap(): unexpected scause {:018p} pid={}",
@@ -172,7 +172,7 @@ impl KernelCtx<'_, '_> {
 
 impl KernelRef<'_, '_> {
     /// `kernel_trap` can be reached from the kernel mode, so it is a method of `Kernel`.
-    unsafe fn kernel_trap(&self) {
+    unsafe fn kernel_trap(self) {
         let sepc = r_sepc();
         let sstatus = Sstatus::read();
         let scause = r_scause();
@@ -223,7 +223,7 @@ impl KernelRef<'_, '_> {
     /// Returns 2 if timer interrupt,
     /// 1 if other device,
     /// 0 if not recognized.
-    unsafe fn dev_intr(&self, kernel: &KernelRef<'_, '_>) -> i32 {
+    unsafe fn dev_intr(&self, kernel: KernelRef<'_, '_>) -> i32 {
         let scause: usize = r_scause();
 
         if scause & 0x8000000000000000 != 0 && scause & 0xff == 9 {

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -197,7 +197,7 @@ impl KernelRef<'_, '_> {
         // Give up the CPU if this is a timer interrupt.
         if which_dev == 2 {
             // TODO: safety?
-            if let Some(mut ctx) = unsafe { self.get_ctx() } {
+            if let Some(ctx) = unsafe { self.get_ctx() } {
                 // SAFETY:
                 // Reading state without lock is safe because `proc_yield` and `sched`
                 // is called after we check if current process is `RUNNING`.

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -196,12 +196,12 @@ impl KernelRef<'_, '_> {
 
         // Give up the CPU if this is a timer interrupt.
         if which_dev == 2 {
-            if let Some(proc) = unsafe { self.current_proc() } {
+            if let Some(ctx) = unsafe { self.get_ctx() } {
                 // SAFETY:
                 // Reading state without lock is safe because `proc_yield` and `sched`
                 // is called after we check if current process is `RUNNING`.
-                if unsafe { (*proc.info.get_mut_raw()).state } == Procstate::RUNNING {
-                    unsafe { proc.yield_cpu() };
+                if unsafe { (*ctx.proc.info.get_mut_raw()).state } == Procstate::RUNNING {
+                    unsafe { ctx.proc.yield_cpu() };
                 }
             }
         }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -83,7 +83,7 @@ impl KernelCtx<'_, '_> {
             let syscall_no = self.proc_mut().trap_frame_mut().a7 as i32;
             self.proc_mut().trap_frame_mut().a0 = ok_or!(self.syscall(syscall_no), usize::MAX);
         } else {
-            which_dev = unsafe { self.kernel().dev_intr(self.kernel()) };
+            which_dev = unsafe { self.kernel().dev_intr() };
             if which_dev == 0 {
                 println!(
                     "usertrap(): unexpected scause {:018p} pid={}",
@@ -183,7 +183,7 @@ impl KernelRef<'_, '_> {
         );
         assert!(!intr_get(), "kerneltrap: interrupts enabled");
 
-        let which_dev = unsafe { self.dev_intr(self) };
+        let which_dev = unsafe { self.dev_intr() };
         if which_dev == 0 {
             println!("scause {:018p}", scause as *const u8);
             println!(
@@ -201,7 +201,7 @@ impl KernelRef<'_, '_> {
                 // SAFETY:
                 // Reading state without lock is safe because `proc_yield` and `sched`
                 // is called after we check if current process is `RUNNING`.
-                if unsafe { (*ctx.proc.info.get_mut_raw()).state } == Procstate::RUNNING {
+                if unsafe { (*ctx.proc().info.get_mut_raw()).state } == Procstate::RUNNING {
                     ctx.yield_cpu();
                 }
             }
@@ -224,7 +224,7 @@ impl KernelRef<'_, '_> {
     /// Returns 2 if timer interrupt,
     /// 1 if other device,
     /// 0 if not recognized.
-    unsafe fn dev_intr(&self, kernel: KernelRef<'_, '_>) -> i32 {
+    unsafe fn dev_intr(self) -> i32 {
         let scause: usize = r_scause();
 
         if scause & 0x8000000000000000 != 0 && scause & 0xff == 9 {
@@ -234,9 +234,9 @@ impl KernelRef<'_, '_> {
             let irq = unsafe { plic_claim() };
 
             if irq as usize == UART0_IRQ {
-                self.uart.intr(kernel);
+                self.uart.intr(self);
             } else if irq as usize == VIRTIO0_IRQ {
-                self.file_system.log.disk.lock().intr(kernel);
+                self.file_system.log.disk.lock().intr(self);
             } else if irq != 0 {
                 // Use `panic!` instead of `println` to prevent stack overflow.
                 // https://github.com/kaist-cp/rv6/issues/311

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -8,7 +8,7 @@ use self::UartCtrlRegs::{FCR, IER, ISR, LCR, LSR, RBR, THR};
 use crate::arch::memlayout::UART0;
 use crate::{
     console::consoleintr,
-    kernel::kernel_builder,
+    kernel::{kernel_builder, KernelRef},
     lock::{pop_off, push_off, Sleepablelock, SleepablelockGuard},
     util::spin_loop,
 };
@@ -235,7 +235,7 @@ impl Uart {
     /// Handle a uart interrupt, raised because input has
     /// arrived, or the uart is ready for more output, or
     /// both. Called from trap.c.
-    pub fn intr(&self) {
+    pub fn intr(&self, kernel: &KernelRef<'_, '_>) {
         // Read and process incoming characters.
         loop {
             let c = Uart::getc();
@@ -243,7 +243,7 @@ impl Uart {
                 break;
             }
             unsafe {
-                consoleintr(c);
+                consoleintr(c, kernel);
             }
         }
 

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -235,7 +235,7 @@ impl Uart {
     /// Handle a uart interrupt, raised because input has
     /// arrived, or the uart is ready for more output, or
     /// both. Called from trap.c.
-    pub fn intr(&self, kernel: &KernelRef<'_, '_>) {
+    pub fn intr(&self, kernel: KernelRef<'_, '_>) {
         // Read and process incoming characters.
         loop {
             let c = Uart::getc();

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -8,7 +8,7 @@ use self::UartCtrlRegs::{FCR, IER, ISR, LCR, LSR, RBR, THR};
 use crate::arch::memlayout::UART0;
 use crate::{
     console::consoleintr,
-    kernel::{kernel_builder, KernelRef},
+    kernel::{kernel_builder, kernel_ref, KernelRef},
     lock::{pop_off, push_off, Sleepablelock, SleepablelockGuard},
     util::spin_loop,
 };
@@ -213,7 +213,11 @@ impl Uart {
             guard.r += 1;
 
             // Maybe uartputc() is waiting for space in the buffer.
-            guard.wakeup();
+            unsafe {
+                kernel_ref(|kref| {
+                    guard.wakeup(kref);
+                })
+            };
 
             THR.write(c);
         }

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -214,6 +214,7 @@ impl Uart {
 
             // Maybe uartputc() is waiting for space in the buffer.
             unsafe {
+                // TODO: remove kernel_ref()
                 kernel_ref(|kref| {
                     guard.wakeup(kref);
                 })


### PR DESCRIPTION
구체적으론 init 하는 부분을 함수로 만들었습니다. 아직 주석 등을 작성하지 않아서 머지는 못합니다. 참고로 봐주셨으면 합니다.

제 생각에 이 일은 좀더 큰 맥락에서 다음과 같은 일들과 관련이 있습니다.
- `'static` 사용 없애기 #428 , `kernel()` 사용 없애기 #kernel #267 : 이러한 사용은 kernel을 object로 이해하지 못했다는 증거가 됩니다.
- multiarch support #381 : 이 일을 하려면 arch-dependent, arch-independent 파트를 명확히 나눠야 하고, 이를 위해서는 kernel을 좀더 modular하게 object로 이해하는게 필요하리라 생각합니다.

앞으로 #428, #267 의 우선순위를 높여 관심을 기울이면 어떨까 합니다. 큰 디자인 변경사항이다보니 모듈별 개선보다 먼저 이뤄지면 좋겠습니다.