### PR TITLE
[Closes #471] Add `const_assert_generics` module

### DIFF
--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -14,6 +14,7 @@ test = []
 [profile.dev]
 panic = "abort"
 opt-level = 1
+incremental = false
 
 [profile.release]
 panic = "abort"

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -45,6 +45,8 @@
 #![feature(const_fn)]
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_fn_union)]
+#![feature(const_generics)]
+#![feature(const_evaluatable_checked)]
 #![feature(const_precise_live_drops)]
 #![feature(const_trait_impl)]
 #![feature(generic_associated_types)]

--- a/kernel-rs/src/util/const_assert_generics.rs
+++ b/kernel-rs/src/util/const_assert_generics.rs
@@ -1,0 +1,25 @@
+//! Types that let you compile-time assert in `where` clauses,
+//! especially about the input generic parameters.
+//!
+//! # Example
+//! ```rust,no_run
+//! # use core::mem;
+//! #![feature(const_generics)]
+//! #![feature(const_evaluatable_checked)]
+//!
+//! fn transmute<T, U>(_t: T) -> U
+//! where
+//!     Assert2<
+//!         { mem::size_of::<T>() == mem::size_of::<U>() },
+//!         { mem::align_of::<T>() == mem::align_of::<U>() },
+//!     >: True;
+//! ```
+
+pub struct Assert<const EXPR: bool>;
+pub struct Assert2<const EXPR: bool, const EXPR2: bool>;
+pub struct Assert3<const EXPR: bool, const EXPR2: bool, const EXPR3: bool>;
+
+pub trait True {}
+impl True for Assert<true> {}
+impl True for Assert2<true, true> {}
+impl True for Assert3<true, true, true> {}

--- a/kernel-rs/src/util/const_assert_generics.rs
+++ b/kernel-rs/src/util/const_assert_generics.rs
@@ -7,12 +7,15 @@
 //! #![feature(const_generics)]
 //! #![feature(const_evaluatable_checked)]
 //!
-//! fn transmute<T, U>(_t: T) -> U
+//! unsafe fn transmute<T, U>(t: T) -> U
 //! where
 //!     Assert2<
 //!         { mem::size_of::<T>() == mem::size_of::<U>() },
 //!         { mem::align_of::<T>() == mem::align_of::<U>() },
-//!     >: True;
+//!     >: True
+//! {
+//!     /* Omitted */
+//! }
 //! ```
 
 pub struct Assert<const EXPR: bool>;

--- a/kernel-rs/src/util/mod.rs
+++ b/kernel-rs/src/util/mod.rs
@@ -3,6 +3,7 @@
 // TODO(https://github.com/kaist-cp/rv6/issues/120)
 #![allow(dead_code)]
 
+pub mod const_assert_generics;
 pub mod etrace;
 pub mod list;
 pub mod pinned_array;


### PR DESCRIPTION
Partially resolves #471 

# Changes
* `fn`이나 `impl`의 `where` clause에서 compile-time assertion을 할 수 있게 해주는 `const_assert_generics` module을 추가했습니다.
  * 특히, 이러면 input generics에 대하여 compile-time assert을 할 수 있게 됩니다.
* ICE가 일어나지 않도록 하기 위해서 `incremental = false`로 세팅했습니다.
* 아쉽게도, 이를 `const_assert_generics!`와 같은 형태의 macro로 만들 수는 없는 것으로 보입니다.

참고: 기존에는 ICE가 일어나서 이를 못했었는데, https://github.com/rust-lang/rust/issues/77708 에 의하면 incremental=false로 해놓고 compile을 하거나, release mode에서 compile을 하면 ICE가 일어나지 않는다고 합니다.