### PR TITLE
Add `KernelCtx`

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -8,10 +8,9 @@ use itertools::*;
 use crate::{
     arch::addr::{pgroundup, PAddr, PGSIZE},
     fs::Path,
-    kernel::Kernel,
     page::Page,
     param::MAXARG,
-    proc::CurrentProc,
+    proc::KernelCtx,
     vm::UserMemory,
 };
 
@@ -91,13 +90,8 @@ impl ProgHdr {
     }
 }
 
-impl Kernel {
-    pub fn exec(
-        &self,
-        path: &Path,
-        args: &[Page],
-        proc: &mut CurrentProc<'_>,
-    ) -> Result<usize, ()> {
+impl KernelCtx<'_> {
+    pub fn exec(&mut self, path: &Path, args: &[Page]) -> Result<usize, ()> {
         if args.len() > MAXARG {
             return Err(());
         }
@@ -107,8 +101,8 @@ impl Kernel {
         // value, ptr, will be dropped when this method returns. Deallocation
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
-        let tx = self.file_system.begin_transaction();
-        let ptr = self.itable.namei(path, proc)?;
+        let tx = self.kernel.file_system.begin_transaction();
+        let ptr = self.kernel.itable.namei(path, self)?;
         let mut ip = ptr.lock();
 
         // Check ELF header
@@ -120,9 +114,10 @@ impl Kernel {
             return Err(());
         }
 
-        let trap_frame: PAddr = (proc.trap_frame() as *const _ as usize).into();
-        let mem = UserMemory::new(trap_frame, None, &self.kmem).ok_or(())?;
-        let mut mem = scopeguard::guard(mem, |mem| mem.free(&self.kmem));
+        let trap_frame: PAddr = (self.proc.trap_frame() as *const _ as usize).into();
+        let mem = UserMemory::new(trap_frame, None, &self.kernel.kmem).ok_or(())?;
+        let kmem = &self.kernel.kmem;
+        let mut mem = scopeguard::guard(mem, |mem| mem.free(kmem));
         // Load program into memory.
         // TODO(rv6): use iterator
         for i in 0..elf.phnum as usize {
@@ -136,7 +131,7 @@ impl Kernel {
                 if ph.memsz < ph.filesz || ph.vaddr % PGSIZE != 0 {
                     return Err(());
                 }
-                let _ = mem.alloc(ph.vaddr.checked_add(ph.memsz).ok_or(())?, &self.kmem)?;
+                let _ = mem.alloc(ph.vaddr.checked_add(ph.memsz).ok_or(())?, &self.kernel.kmem)?;
                 mem.load_file(ph.vaddr.into(), &mut ip, ph.off as _, ph.filesz as _)?;
             }
         }
@@ -146,7 +141,7 @@ impl Kernel {
         // Allocate two pages at the next page boundary.
         // Use the second as the user stack.
         let mut sz = pgroundup(mem.size());
-        sz = mem.alloc(sz + 2 * PGSIZE, &self.kmem)?;
+        sz = mem.alloc(sz + 2 * PGSIZE, &self.kernel.kmem)?;
         mem.clear((sz - 2 * PGSIZE).into());
         let mut sp: usize = sz;
         let stackbase: usize = sp - PGSIZE;
@@ -191,7 +186,7 @@ impl Kernel {
             .rposition(|c| *c == b'/')
             .map(|i| &path_str[(i + 1)..])
             .unwrap_or(path_str);
-        let proc_name = &mut proc.deref_mut_data().name;
+        let proc_name = &mut self.proc.deref_mut_data().name;
         let len = cmp::min(proc_name.len(), name.len());
         proc_name[..len].copy_from_slice(&name[..len]);
         if len < proc_name.len() {
@@ -199,18 +194,22 @@ impl Kernel {
         }
 
         // Commit to the user image.
-        mem::replace(proc.memory_mut(), scopeguard::ScopeGuard::into_inner(mem)).free(&self.kmem);
+        mem::replace(
+            self.proc.memory_mut(),
+            scopeguard::ScopeGuard::into_inner(mem),
+        )
+        .free(&self.kernel.kmem);
 
         // arguments to user main(argc, argv)
         // argc is returned via the system call return
         // value, which goes in a0.
-        proc.trap_frame_mut().a1 = sp;
+        self.proc.trap_frame_mut().a1 = sp;
 
         // initial program counter = main
-        proc.trap_frame_mut().epc = elf.entry;
+        self.proc.trap_frame_mut().epc = elf.entry;
 
         // initial stack pointer
-        proc.trap_frame_mut().sp = sp;
+        self.proc.trap_frame_mut().sp = sp;
 
         // this ends up in a0, the first argument to main(argc, argv)
         Ok(argc)

--- a/kernel-rs/src/lock/sleepablelock.rs
+++ b/kernel-rs/src/lock/sleepablelock.rs
@@ -2,7 +2,7 @@
 use core::cell::UnsafeCell;
 
 use super::{spinlock::RawSpinlock, Guard, Lock, RawLock};
-use crate::{kernel::kernel_builder, proc::WaitChannel};
+use crate::proc::{kernel_ctx, WaitChannel};
 
 /// Mutual exclusion spin locks that can sleep.
 pub struct RawSleepablelock {
@@ -54,8 +54,8 @@ impl<T> SleepablelockGuard<'_, T> {
     pub fn sleep(&mut self) {
         self.lock.lock.waitchannel.sleep(
             self,
-            // TODO: remove kernel_builder()
-            &kernel_builder().current_proc().expect("No current proc"),
+            // TODO: remove kernel_ctx()
+            &unsafe { kernel_ctx() },
         );
     }
 

--- a/kernel-rs/src/lock/sleeplock.rs
+++ b/kernel-rs/src/lock/sleeplock.rs
@@ -2,7 +2,7 @@
 use core::cell::UnsafeCell;
 
 use super::{Guard, Lock, RawLock, Sleepablelock};
-use crate::kernel::kernel_builder;
+use crate::proc::kernel_ctx;
 
 /// Long-term locks for processes
 pub struct RawSleeplock {
@@ -33,11 +33,8 @@ impl RawLock for RawSleeplock {
         while *guard != -1 {
             guard.sleep();
         }
-        // TODO: remove kernel_builder()
-        *guard = kernel_builder()
-            .current_proc()
-            .expect("No current proc")
-            .pid();
+        // TODO: remove kernel_ctx()
+        *guard = unsafe { kernel_ctx() }.proc.pid();
     }
 
     fn release(&self) {
@@ -48,12 +45,8 @@ impl RawLock for RawSleeplock {
 
     fn holding(&self) -> bool {
         let guard = self.locked.lock();
-        // TODO: remove kernel_builder()
-        *guard
-            == kernel_builder()
-                .current_proc()
-                .expect("No current proc")
-                .pid()
+        // TODO: remove kernel_ctx()
+        *guard == unsafe { kernel_ctx() }.proc.pid()
     }
 }
 

--- a/kernel-rs/src/syscall/mod.rs
+++ b/kernel-rs/src/syscall/mod.rs
@@ -4,44 +4,43 @@ use cstr_core::CStr;
 
 use crate::{
     arch::addr::{Addr, UVAddr},
-    kernel::Kernel,
     println,
-    proc::CurrentProc,
+    proc::{CurrentProc, KernelCtx},
 };
 
 mod file;
 mod proc;
 
-impl Kernel {
-    pub fn syscall(&'static self, num: i32, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
+impl KernelCtx<'_> {
+    pub fn syscall(&mut self, num: i32) -> Result<usize, ()> {
         match num {
-            1 => self.sys_fork(proc),
-            2 => self.sys_exit(proc),
-            3 => self.sys_wait(proc),
-            4 => self.sys_pipe(proc),
-            5 => self.sys_read(proc),
-            6 => self.sys_kill(proc),
-            7 => self.sys_exec(proc),
-            8 => self.sys_fstat(proc),
-            9 => self.sys_chdir(proc),
-            10 => self.sys_dup(proc),
-            11 => self.sys_getpid(proc),
-            12 => self.sys_sbrk(proc),
-            13 => self.sys_sleep(proc),
-            14 => self.sys_uptime(proc),
-            15 => self.sys_open(proc),
-            16 => self.sys_write(proc),
-            17 => self.sys_mknod(proc),
-            18 => self.sys_unlink(proc),
-            19 => self.sys_link(proc),
-            20 => self.sys_mkdir(proc),
-            21 => self.sys_close(proc),
-            22 => self.sys_poweroff(proc),
+            1 => self.sys_fork(),
+            2 => self.sys_exit(),
+            3 => self.sys_wait(),
+            4 => self.sys_pipe(),
+            5 => self.sys_read(),
+            6 => self.sys_kill(),
+            7 => self.sys_exec(),
+            8 => self.sys_fstat(),
+            9 => self.sys_chdir(),
+            10 => self.sys_dup(),
+            11 => self.sys_getpid(),
+            12 => self.sys_sbrk(),
+            13 => self.sys_sleep(),
+            14 => self.sys_uptime(),
+            15 => self.sys_open(),
+            16 => self.sys_write(),
+            17 => self.sys_mknod(),
+            18 => self.sys_unlink(),
+            19 => self.sys_link(),
+            20 => self.sys_mkdir(),
+            21 => self.sys_close(),
+            22 => self.sys_poweroff(),
             _ => {
                 println!(
                     "{} {}: unknown sys call {}",
-                    proc.pid(),
-                    str::from_utf8(&proc.deref_data().name).unwrap_or("???"),
+                    self.proc.pid(),
+                    str::from_utf8(&self.proc.deref_data().name).unwrap_or("???"),
                     num
                 );
                 Err(())

--- a/kernel-rs/src/syscall/proc.rs
+++ b/kernel-rs/src/syscall/proc.rs
@@ -1,45 +1,45 @@
-use crate::{arch::poweroff, kernel::Kernel, proc::CurrentProc};
+use crate::{arch::poweroff, proc::KernelCtx};
 
-impl Kernel {
+impl KernelCtx<'_> {
     /// Terminate the current process; status reported to wait(). No return.
-    pub fn sys_exit(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
-        let n = proc.argint(0)?;
-        self.procs().exit_current(n, proc);
+    pub fn sys_exit(&mut self) -> Result<usize, ()> {
+        let n = self.proc.argint(0)?;
+        self.kernel.procs().exit_current(n, self);
     }
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub fn sys_fork(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
-        Ok(self.procs().fork(proc, &self.kmem)? as _)
+    pub fn sys_fork(&mut self) -> Result<usize, ()> {
+        Ok(self.kernel.procs().fork(self)? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
-    pub fn sys_wait(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
-        let p = proc.argaddr(0)?;
-        Ok(self.procs().wait(p.into(), proc)? as _)
+    pub fn sys_wait(&mut self) -> Result<usize, ()> {
+        let p = self.proc.argaddr(0)?;
+        Ok(self.kernel.procs().wait(p.into(), self)? as _)
     }
 
     /// Return the current process’s PID.
-    pub fn sys_getpid(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
-        Ok(proc.pid() as _)
+    pub fn sys_getpid(&self) -> Result<usize, ()> {
+        Ok(self.proc.pid() as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
-    pub fn sys_sbrk(&self, proc: &mut CurrentProc<'_>) -> Result<usize, ()> {
-        let n = proc.argint(0)?;
-        proc.memory_mut().resize(n, &self.kmem)
+    pub fn sys_sbrk(&mut self) -> Result<usize, ()> {
+        let n = self.proc.argint(0)?;
+        self.proc.memory_mut().resize(n, &self.kernel.kmem)
     }
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_sleep(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
-        let n = proc.argint(0)?;
-        let mut ticks = self.ticks.lock();
+    pub fn sys_sleep(&self) -> Result<usize, ()> {
+        let n = self.proc.argint(0)?;
+        let mut ticks = self.kernel.ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
-            if proc.killed() {
+            if self.proc.killed() {
                 return Err(());
             }
             ticks.sleep();
@@ -49,21 +49,21 @@ impl Kernel {
 
     /// Terminate process PID.
     /// Returns Ok(0) on success, Err(()) on error.
-    pub fn sys_kill(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
-        let pid = proc.argint(0)?;
-        self.procs().kill(pid)?;
+    pub fn sys_kill(&self) -> Result<usize, ()> {
+        let pid = self.proc.argint(0)?;
+        self.kernel.procs().kill(pid)?;
         Ok(0)
     }
 
     /// Return how many clock tick interrupts have occurred
     /// since start.
-    pub fn sys_uptime(&self, _proc: &CurrentProc<'_>) -> Result<usize, ()> {
-        Ok(*self.ticks.lock() as usize)
+    pub fn sys_uptime(&self) -> Result<usize, ()> {
+        Ok(*self.kernel.ticks.lock() as usize)
     }
 
     /// Shutdowns this machine, discarding all unsaved data. No return.
-    pub fn sys_poweroff(&self, proc: &CurrentProc<'_>) -> Result<usize, ()> {
-        let exitcode = proc.argint(0)?;
+    pub fn sys_poweroff(&self) -> Result<usize, ()> {
+        let exitcode = self.proc.argint(0)?;
         poweroff::machine_poweroff(exitcode as _);
     }
 }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     kernel::{kernel, Kernel},
     ok_or, println,
-    proc::{cpuid, CurrentProc, Procstate},
+    proc::{cpuid, kernel_ctx, KernelCtx, Procstate},
 };
 
 extern "C" {
@@ -36,224 +36,236 @@ pub unsafe fn trapinithart() {
 /// Called from trampoline.S.
 #[no_mangle]
 pub unsafe extern "C" fn usertrap() {
-    let mut which_dev: i32 = 0;
-
-    assert!(
-        !Sstatus::read().contains(Sstatus::SPP),
-        "usertrap: not from user mode"
-    );
-
-    // Send interrupts and exceptions to kerneltrap(),
-    // since we're now in the kernel.
-    unsafe { w_stvec(kernelvec as _) };
-
-    // SAFETY: usertrap can be reached only after the initialization of the kernel
-    let kernel = unsafe { kernel() };
-    let mut proc = kernel.current_proc().expect("No current proc");
-
-    // Save user program counter.
-    proc.trap_frame_mut().epc = r_sepc();
-    if r_scause() == 8 {
-        // system call
-
-        if proc.killed() {
-            kernel.procs().exit_current(-1, &mut proc);
-        }
-
-        // sepc points to the ecall instruction,
-        // but we want to return to the next instruction.
-        proc.trap_frame_mut().epc = (proc.trap_frame().epc).wrapping_add(4);
-
-        // An interrupt will change sstatus &c registers,
-        // so don't enable until done with those registers.
-        unsafe { intr_on() };
-        proc.trap_frame_mut().a0 = ok_or!(
-            kernel.syscall(proc.trap_frame_mut().a7 as i32, &mut proc),
-            usize::MAX
-        );
-    } else {
-        which_dev = unsafe { devintr(&kernel) };
-        if which_dev == 0 {
-            println!(
-                "usertrap(): unexpected scause {:018p} pid={}",
-                r_scause() as *const u8,
-                proc.pid()
-            );
-            println!(
-                "            sepc={:018p} stval={:018p}",
-                r_sepc() as *const u8,
-                r_stval() as *const u8
-            );
-            proc.kill();
-        }
-    }
-
-    if proc.killed() {
-        kernel.procs().exit_current(-1, &mut proc);
-    }
-
-    // Give up the CPU if this is a timer interrupt.
-    if which_dev == 2 {
-        unsafe { proc.proc_yield() };
-    }
-
-    unsafe { usertrapret(proc) };
-}
-
-/// Return to user space.
-pub unsafe fn usertrapret(mut proc: CurrentProc<'_>) {
-    // We're about to switch the destination of traps from
-    // kerneltrap() to usertrap(), so turn off interrupts until
-    // we're back in user space, where usertrap() is correct.
-    unsafe { intr_off() };
-
-    // Send syscalls, interrupts, and exceptions to trampoline.S.
-    unsafe {
-        w_stvec(
-            TRAMPOLINE
-                .wrapping_add(uservec.as_mut_ptr().offset_from(trampoline.as_mut_ptr()) as usize),
-        )
-    };
-
-    // Set up trapframe values that uservec will need when
-    // the process next re-enters the kernel.
-
-    // kernel page table
-    proc.trap_frame_mut().kernel_satp = r_satp();
-
-    // process's kernel stack
-    proc.trap_frame_mut().kernel_sp = proc.deref_mut_data().kstack + PGSIZE;
-    proc.trap_frame_mut().kernel_trap = usertrap as usize;
-
-    // hartid for cpuid()
-    proc.trap_frame_mut().kernel_hartid = r_tp();
-
-    // Set up the registers that trampoline.S's sret will use
-    // to get to user space.
-
-    // Set S Previous Privilege mode to User.
-    let mut x = Sstatus::read();
-
-    // Clear SPP to 0 for user mode.
-    x.remove(Sstatus::SPP);
-
-    // Enable interrupts in user mode.
-    x.insert(Sstatus::SPIE);
-    unsafe { x.write() };
-
-    // Set S Exception Program Counter to the saved user pc.
-    unsafe { w_sepc(proc.trap_frame().epc) };
-
-    // Tell trampoline.S the user page table to switch to.
-    let satp: usize = proc.memory().satp();
-
-    // Jump to trampoline.S at the top of memory, which
-    // switches to the user page table, restores user registers,
-    // and switches to user mode with sret.
-    let fn_0: usize =
-        TRAMPOLINE + unsafe { userret.as_ptr().offset_from(trampoline.as_ptr()) } as usize;
-    let fn_0 = unsafe { mem::transmute::<_, unsafe extern "C" fn(usize, usize) -> ()>(fn_0) };
-    unsafe { fn_0(TRAPFRAME, satp) };
+    // SAFETY
+    // * usertrap can be reached only after the initialization of the kernel.
+    // * It's the beginning of this thread, so there's no exsiting `KernelCtx` or `CurrentProc`.
+    let ctx = unsafe { kernel_ctx() };
+    unsafe { ctx.user_trap() };
 }
 
 /// Interrupts and exceptions from kernel code go here via kernelvec,
 /// on whatever the current kernel stack is.
 #[no_mangle]
 pub unsafe fn kerneltrap() {
-    let sepc = r_sepc();
-    let sstatus = Sstatus::read();
-    let scause = r_scause();
-
-    assert!(
-        sstatus.contains(Sstatus::SPP),
-        "kerneltrap: not from supervisor mode"
-    );
-    assert!(!intr_get(), "kerneltrap: interrupts enabled");
-
-    // SAFETY: kerneltrap can be reached only after the initialization of the kernel
+    // SAFETY: kerneltrap can be reached only after the initialization of the kernel.
     let kernel = unsafe { kernel() };
+    unsafe { kernel.kernel_trap() };
+}
 
-    let which_dev = unsafe { devintr(&kernel) };
-    if which_dev == 0 {
-        println!("scause {:018p}", scause as *const u8);
-        println!(
-            "sepc={:018p} stval={:018p}",
-            r_sepc() as *const u8,
-            r_stval() as *const u8
+impl KernelCtx<'_> {
+    /// `user_trap` can be reached only from the user mode, so it is a method of `KernelCtx`.
+    unsafe fn user_trap(mut self) {
+        assert!(
+            !Sstatus::read().contains(Sstatus::SPP),
+            "usertrap: not from user mode"
         );
-        panic!("kerneltrap");
-    }
 
-    // Give up the CPU if this is a timer interrupt.
-    if which_dev == 2 {
-        if let Some(proc) = kernel.current_proc() {
-            // SAFETY:
-            // Reading state without lock is safe because `proc_yield` and `sched`
-            // is called after we check if current process is `RUNNING`.
-            if unsafe { (*proc.info.get_mut_raw()).state } == Procstate::RUNNING {
-                unsafe { proc.proc_yield() };
+        // Send interrupts and exceptions to kerneltrap(),
+        // since we're now in the kernel.
+        unsafe { w_stvec(kernelvec as _) };
+
+        let mut which_dev: i32 = 0;
+
+        // Save user program counter.
+        self.proc.trap_frame_mut().epc = r_sepc();
+        if r_scause() == 8 {
+            // system call
+
+            if self.proc.killed() {
+                self.kernel.procs().exit_current(-1, &mut self);
+            }
+
+            // sepc points to the ecall instruction,
+            // but we want to return to the next instruction.
+            self.proc.trap_frame_mut().epc = (self.proc.trap_frame().epc).wrapping_add(4);
+
+            // An interrupt will change sstatus &c registers,
+            // so don't enable until done with those registers.
+            unsafe { intr_on() };
+            let syscall_no = self.proc.trap_frame_mut().a7 as i32;
+            self.proc.trap_frame_mut().a0 = ok_or!(self.syscall(syscall_no), usize::MAX);
+        } else {
+            which_dev = unsafe { self.kernel.dev_intr() };
+            if which_dev == 0 {
+                println!(
+                    "usertrap(): unexpected scause {:018p} pid={}",
+                    r_scause() as *const u8,
+                    self.proc.pid()
+                );
+                println!(
+                    "            sepc={:018p} stval={:018p}",
+                    r_sepc() as *const u8,
+                    r_stval() as *const u8
+                );
+                self.proc.kill();
             }
         }
+
+        if self.proc.killed() {
+            self.kernel.procs().exit_current(-1, &mut self);
+        }
+
+        // Give up the CPU if this is a timer interrupt.
+        if which_dev == 2 {
+            unsafe { self.proc.yield_cpu() };
+        }
+
+        unsafe { self.user_trap_ret() };
     }
 
-    // The yield() may have caused some traps to occur,
-    // so restore trap registers for use by kernelvec.S's sepc instruction.
-    unsafe { w_sepc(sepc) };
-    unsafe { sstatus.write() };
+    /// Return to user space.
+    pub unsafe fn user_trap_ret(mut self) {
+        // We're about to switch the destination of traps from
+        // kerneltrap() to usertrap(), so turn off interrupts until
+        // we're back in user space, where usertrap() is correct.
+        unsafe { intr_off() };
+
+        // Send syscalls, interrupts, and exceptions to trampoline.S.
+        unsafe {
+            w_stvec(
+                TRAMPOLINE.wrapping_add(
+                    uservec.as_mut_ptr().offset_from(trampoline.as_mut_ptr()) as usize
+                ),
+            )
+        };
+
+        // Set up trapframe values that uservec will need when
+        // the process next re-enters the kernel.
+
+        // kernel page table
+        self.proc.trap_frame_mut().kernel_satp = r_satp();
+
+        // process's kernel stack
+        self.proc.trap_frame_mut().kernel_sp = self.proc.deref_mut_data().kstack + PGSIZE;
+        self.proc.trap_frame_mut().kernel_trap = usertrap as usize;
+
+        // hartid for cpuid()
+        self.proc.trap_frame_mut().kernel_hartid = r_tp();
+
+        // Set up the registers that trampoline.S's sret will use
+        // to get to user space.
+
+        // Set S Previous Privilege mode to User.
+        let mut x = Sstatus::read();
+
+        // Clear SPP to 0 for user mode.
+        x.remove(Sstatus::SPP);
+
+        // Enable interrupts in user mode.
+        x.insert(Sstatus::SPIE);
+        unsafe { x.write() };
+
+        // Set S Exception Program Counter to the saved user pc.
+        unsafe { w_sepc(self.proc.trap_frame().epc) };
+
+        // Tell trampoline.S the user page table to switch to.
+        let satp: usize = self.proc.memory().satp();
+
+        // Jump to trampoline.S at the top of memory, which
+        // switches to the user page table, restores user registers,
+        // and switches to user mode with sret.
+        let fn_0: usize =
+            TRAMPOLINE + unsafe { userret.as_ptr().offset_from(trampoline.as_ptr()) } as usize;
+        let fn_0 = unsafe { mem::transmute::<_, unsafe extern "C" fn(usize, usize) -> ()>(fn_0) };
+        unsafe { fn_0(TRAPFRAME, satp) };
+    }
 }
 
-fn clockintr(kernel: &Kernel) {
-    let mut ticks = kernel.ticks.lock();
-    *ticks = ticks.wrapping_add(1);
-    ticks.wakeup();
-}
+impl Kernel {
+    /// `kernel_trap` can be reached from the kernel mode, so it is a method of `Kernel`.
+    unsafe fn kernel_trap(&self) {
+        let sepc = r_sepc();
+        let sstatus = Sstatus::read();
+        let scause = r_scause();
 
-/// Check if it's an external interrupt or software interrupt,
-/// and handle it.
-/// Returns 2 if timer interrupt,
-/// 1 if other device,
-/// 0 if not recognized.
-unsafe fn devintr(kernel: &Kernel) -> i32 {
-    let scause: usize = r_scause();
+        assert!(
+            sstatus.contains(Sstatus::SPP),
+            "kerneltrap: not from supervisor mode"
+        );
+        assert!(!intr_get(), "kerneltrap: interrupts enabled");
 
-    if scause & 0x8000000000000000 != 0 && scause & 0xff == 9 {
-        // This is a supervisor external interrupt, via PLIC.
-
-        // irq indicates which device interrupted.
-        let irq = unsafe { plic_claim() };
-
-        if irq as usize == UART0_IRQ {
-            kernel.uart.intr();
-        } else if irq as usize == VIRTIO0_IRQ {
-            kernel.file_system.log.disk.lock().intr();
-        } else if irq != 0 {
-            // Use `panic!` instead of `println` to prevent stack overflow.
-            // https://github.com/kaist-cp/rv6/issues/311
-            panic!("unexpected interrupt irq={}\n", irq);
+        let which_dev = unsafe { self.dev_intr() };
+        if which_dev == 0 {
+            println!("scause {:018p}", scause as *const u8);
+            println!(
+                "sepc={:018p} stval={:018p}",
+                r_sepc() as *const u8,
+                r_stval() as *const u8
+            );
+            panic!("kerneltrap");
         }
 
-        // The PLIC allows each device to raise at most one
-        // interrupt at a time; tell the PLIC the device is
-        // now allowed to interrupt again.
-        if irq != 0 {
-            unsafe { plic_complete(irq) };
+        // Give up the CPU if this is a timer interrupt.
+        if which_dev == 2 {
+            if let Some(proc) = unsafe { self.current_proc() } {
+                // SAFETY:
+                // Reading state without lock is safe because `proc_yield` and `sched`
+                // is called after we check if current process is `RUNNING`.
+                if unsafe { (*proc.info.get_mut_raw()).state } == Procstate::RUNNING {
+                    unsafe { proc.yield_cpu() };
+                }
+            }
         }
 
-        1
-    } else if scause == 0x8000000000000001 {
-        // Software interrupt from a machine-mode timer interrupt,
-        // forwarded by timervec in kernelvec.S.
+        // The yield() may have caused some traps to occur,
+        // so restore trap registers for use by kernelvec.S's sepc instruction.
+        unsafe { w_sepc(sepc) };
+        unsafe { sstatus.write() };
+    }
 
-        if cpuid() == 0 {
-            clockintr(kernel);
+    fn clock_intr(&self) {
+        let mut ticks = self.ticks.lock();
+        *ticks = ticks.wrapping_add(1);
+        ticks.wakeup();
+    }
+
+    /// Check if it's an external interrupt or software interrupt,
+    /// and handle it.
+    /// Returns 2 if timer interrupt,
+    /// 1 if other device,
+    /// 0 if not recognized.
+    unsafe fn dev_intr(&self) -> i32 {
+        let scause: usize = r_scause();
+
+        if scause & 0x8000000000000000 != 0 && scause & 0xff == 9 {
+            // This is a supervisor external interrupt, via PLIC.
+
+            // irq indicates which device interrupted.
+            let irq = unsafe { plic_claim() };
+
+            if irq as usize == UART0_IRQ {
+                self.uart.intr();
+            } else if irq as usize == VIRTIO0_IRQ {
+                self.file_system.log.disk.lock().intr();
+            } else if irq != 0 {
+                // Use `panic!` instead of `println` to prevent stack overflow.
+                // https://github.com/kaist-cp/rv6/issues/311
+                panic!("unexpected interrupt irq={}\n", irq);
+            }
+
+            // The PLIC allows each device to raise at most one
+            // interrupt at a time; tell the PLIC the device is
+            // now allowed to interrupt again.
+            if irq != 0 {
+                unsafe { plic_complete(irq) };
+            }
+
+            1
+        } else if scause == 0x8000000000000001 {
+            // Software interrupt from a machine-mode timer interrupt,
+            // forwarded by timervec in selfvec.S.
+
+            if cpuid() == 0 {
+                self.clock_intr();
+            }
+
+            // Acknowledge the software interrupt by clearing
+            // the SSIP bit in sip.
+            unsafe { w_sip(r_sip() & !2) };
+
+            2
+        } else {
+            0
         }
-
-        // Acknowledge the software interrupt by clearing
-        // the SSIP bit in sip.
-        unsafe { w_sip(r_sip() & !2) };
-
-        2
-    } else {
-        0
     }
 }

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -17,9 +17,10 @@ use super::{
 use crate::{
     arch::addr::{PGSHIFT, PGSIZE},
     bio::Buf,
-    kernel::kernel_builder,
+    kernel::kernel,
     lock::{Sleepablelock, SleepablelockGuard},
     param::BSIZE,
+    proc::kernel_ctx,
 };
 
 // It must be page-aligned.
@@ -165,8 +166,8 @@ impl Sleepablelock<Disk> {
     /// Return a locked Buf with the `latest` contents of the indicated block.
     /// If buf.valid is true, we don't need to access Disk.
     pub fn read(&self, dev: u32, blockno: u32) -> Buf {
-        // TODO: remove kernel_builder()
-        let mut buf = unsafe { kernel_builder().get_bcache() }
+        // TODO: remove kernel()
+        let mut buf = unsafe { kernel().get_bcache() }
             .get_buf(dev, blockno)
             .lock();
         if !buf.deref_inner().valid {
@@ -323,8 +324,8 @@ impl Disk {
         while b.deref_inner().disk {
             (*b).vdisk_request_waitchannel.sleep(
                 this,
-                // TODO: remove kernel_builder()
-                &kernel_builder().current_proc().expect("No current proc"),
+                // TODO: remove kernel_ctx()
+                &unsafe { kernel_ctx() },
             );
         }
         // As it assigns null, the invariant of inflight is maintained even if


### PR DESCRIPTION
현재의 커널 스레드가 어떤 커널의 스레드이며 어떤 유저 프로세스를 위한 것인지 나타내는 `KernelCtx` 타입을 추가했습니다.

```rust
pub struct KernelCtx<'p> {
    pub kernel: &'p Kernel,
    pub proc: CurrentProc<'p>,
}
```

`CurrentProc`은 mutable하게 접근하면서 `Kernel`에는 immutable하게 접근해야 하는 경우가 꽤 있기 때문에, lifetime 문제가 생기지 않도록 두 필드를 각각 접근해야 합니다. 그래서 `CurrentProc` 안에 `&Kernel`을 넣는 대신 `&Kernel`과 `CurrentProc`을 모두 가지고 있는 타입인 `KernelCtx`를 새로 만들고, 기존에 `CurrentProc`을 전달하던 곳에서 `KernelCtx`를 전달하도록 수정했습니다.