### PR TITLE
Remove some of `kernel_builder()`

### DIFF
--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -108,14 +108,16 @@ impl Kernel {
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let tx = self.file_system.begin_transaction();
-        let ptr = self.itable.namei(path, proc, &self.file_system)?;
+        let ptr = self
+            .itable
+            .namei(path, proc, &self.file_system, unsafe { self.get_bcache() })?;
         let mut ip = ptr.lock(&self.file_system);
 
         // Check ELF header
         let mut elf: ElfHdr = Default::default();
         // SAFETY: ElfHdr can be safely transmuted to [u8; _], as it
         // contains only integers, which do not have internal structures.
-        unsafe { ip.read_kernel(&mut elf, 0, &self.file_system) }?;
+        unsafe { ip.read_kernel(&mut elf, 0, &self.file_system, self.get_bcache()) }?;
         if !elf.is_valid() {
             return Err(());
         }
@@ -131,7 +133,7 @@ impl Kernel {
             let mut ph: ProgHdr = Default::default();
             // SAFETY: ProgHdr can be safely transmuted to [u8; _], as it
             // contains only integers, which do not have internal structures.
-            unsafe { ip.read_kernel(&mut ph, off as _, &self.file_system) }?;
+            unsafe { ip.read_kernel(&mut ph, off as _, &self.file_system, self.get_bcache()) }?;
             if ph.is_prog_load() {
                 if ph.memsz < ph.filesz || ph.vaddr % PGSIZE != 0 {
                     return Err(());
@@ -143,6 +145,7 @@ impl Kernel {
                     ph.off as _,
                     ph.filesz as _,
                     &self.file_system,
+                    unsafe { self.get_bcache() },
                 )?;
             }
         }

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -108,14 +108,14 @@ impl Kernel {
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
         let tx = self.file_system.begin_transaction();
-        let ptr = self.itable.namei(path, proc)?;
-        let mut ip = ptr.lock();
+        let ptr = self.itable.namei(path, proc, &self.file_system)?;
+        let mut ip = ptr.lock(&self.file_system);
 
         // Check ELF header
         let mut elf: ElfHdr = Default::default();
         // SAFETY: ElfHdr can be safely transmuted to [u8; _], as it
         // contains only integers, which do not have internal structures.
-        unsafe { ip.read_kernel(&mut elf, 0) }?;
+        unsafe { ip.read_kernel(&mut elf, 0, &self.file_system) }?;
         if !elf.is_valid() {
             return Err(());
         }
@@ -131,13 +131,19 @@ impl Kernel {
             let mut ph: ProgHdr = Default::default();
             // SAFETY: ProgHdr can be safely transmuted to [u8; _], as it
             // contains only integers, which do not have internal structures.
-            unsafe { ip.read_kernel(&mut ph, off as _) }?;
+            unsafe { ip.read_kernel(&mut ph, off as _, &self.file_system) }?;
             if ph.is_prog_load() {
                 if ph.memsz < ph.filesz || ph.vaddr % PGSIZE != 0 {
                     return Err(());
                 }
                 let _ = mem.alloc(ph.vaddr.checked_add(ph.memsz).ok_or(())?, &self.kmem)?;
-                mem.load_file(ph.vaddr.into(), &mut ip, ph.off as _, ph.filesz as _)?;
+                mem.load_file(
+                    ph.vaddr.into(),
+                    &mut ip,
+                    ph.off as _,
+                    ph.filesz as _,
+                    &self.file_system,
+                )?;
             }
         }
         drop(ip);

--- a/kernel-rs/src/exec.rs
+++ b/kernel-rs/src/exec.rs
@@ -111,7 +111,7 @@ impl Kernel {
         let ptr = self
             .itable
             .namei(path, proc, &self.file_system, unsafe { self.get_bcache() })?;
-        let mut ip = ptr.lock(&self.file_system);
+        let mut ip = ptr.lock(&self.file_system, unsafe { self.get_bcache() });
 
         // Check ELF header
         let mut elf: ElfHdr = Default::default();

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -81,7 +81,7 @@ use crate::{
     arch::addr::UVAddr,
     arena::{Arena, ArenaObject, ArrayArena, Rc},
     bio::BufData,
-    fs::{FsTransaction, Path, ROOTINO},
+    fs::{FileSystem, FsTransaction, Path, ROOTINO},
     kernel::kernel_builder,
     lock::{Sleeplock, Spinlock},
     param::ROOTDEV,
@@ -191,11 +191,11 @@ pub struct Dirent {
 }
 
 impl Dirent {
-    fn new(ip: &mut InodeGuard<'_>, off: u32) -> Result<Dirent, ()> {
+    fn new(ip: &mut InodeGuard<'_>, off: u32, fs: &FileSystem) -> Result<Dirent, ()> {
         let mut dirent = Dirent::default();
         // SAFETY: Dirent can be safely transmuted to [u8; _], as it
         // contains only u16 and u8's, which do not have internal structures.
-        unsafe { ip.read_kernel(&mut dirent, off) }?;
+        unsafe { ip.read_kernel(&mut dirent, off, fs) }?;
         Ok(dirent)
     }
 
@@ -225,6 +225,7 @@ impl Dirent {
 
 struct DirentIter<'s, 't> {
     guard: &'s mut InodeGuard<'t>,
+    fs: &'s FileSystem,
     iter: StepBy<Range<u32>>,
 }
 
@@ -233,15 +234,19 @@ impl Iterator for DirentIter<'_, '_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let off = self.iter.next()?;
-        let dirent = Dirent::new(self.guard, off).expect("DirentIter");
+        let dirent = Dirent::new(self.guard, off, self.fs).expect("DirentIter");
         Some((dirent, off))
     }
 }
 
 impl<'t> InodeGuard<'t> {
-    fn iter_dirents<'s>(&'s mut self) -> DirentIter<'s, 't> {
+    fn iter_dirents<'s>(&'s mut self, fs: &'s FileSystem) -> DirentIter<'s, 't> {
         let iter = (0..self.deref_inner().size).step_by(DIRENT_SIZE);
-        DirentIter { guard: self, iter }
+        DirentIter {
+            guard: self,
+            fs,
+            iter,
+        }
     }
 }
 
@@ -282,20 +287,21 @@ impl InodeGuard<'_> {
         inum: u32,
         tx: &FsTransaction<'_>,
         itable: &Itable,
+        fs: &FileSystem,
     ) -> Result<(), ()> {
         // Check that name is not present.
-        if let Ok((_ip, _)) = self.dirlookup(name, itable) {
+        if let Ok((_ip, _)) = self.dirlookup(name, itable, fs) {
             return Err(());
         };
 
         // Look for an empty Dirent.
         let (mut de, off) = self
-            .iter_dirents()
+            .iter_dirents(fs)
             .find(|(de, _)| de.inum == 0)
             .unwrap_or((Default::default(), self.deref_inner().size));
         de.inum = inum as _;
         de.set_name(name);
-        self.write_kernel(&de, off, tx).expect("dirlink");
+        self.write_kernel(&de, off, tx, fs).expect("dirlink");
         Ok(())
     }
 
@@ -305,10 +311,11 @@ impl InodeGuard<'_> {
         &mut self,
         name: &FileName,
         itable: &'a Itable,
+        fs: &FileSystem,
     ) -> Result<(RcInode, u32), ()> {
         assert_eq!(self.deref_inner().typ, InodeType::Dir, "dirlookup not DIR");
 
-        self.iter_dirents()
+        self.iter_dirents(fs)
             .find(|(de, _)| de.inum != 0 && de.get_name() == name)
             .map(|(de, off)| (itable.get_inode(self.dev, de.inum as u32), off))
             .ok_or(())
@@ -319,13 +326,11 @@ impl InodeGuard<'_> {
     /// Copy a modified in-memory inode to disk.
     /// Must be called after every change to an ip->xxx field
     /// that lives on disk.
-    pub fn update(&self, tx: &FsTransaction<'_>) {
-        // TODO: remove kernel_builder()
-        let mut bp = kernel_builder().file_system.log.disk.read(
-            self.dev,
-            // TODO: remove kernel_builder()
-            kernel_builder().file_system.superblock().iblock(self.inum),
-        );
+    pub fn update(&self, tx: &FsTransaction<'_>, fs: &FileSystem) {
+        let mut bp = fs
+            .log
+            .disk
+            .read(self.dev, fs.superblock().iblock(self.inum));
 
         const_assert!(IPB <= mem::size_of::<BufData>() / mem::size_of::<Dinode>());
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<Dinode>() == 0);
@@ -371,7 +376,7 @@ impl InodeGuard<'_> {
 
     /// Truncate inode (discard contents).
     /// This function is called with Inode's lock is held.
-    pub fn itrunc(&mut self, tx: &FsTransaction<'_>) {
+    pub fn itrunc(&mut self, tx: &FsTransaction<'_>, fs: &FileSystem) {
         let dev = self.dev;
         for addr in &mut self.deref_inner_mut().addr_direct {
             if *addr != 0 {
@@ -381,12 +386,7 @@ impl InodeGuard<'_> {
         }
 
         if self.deref_inner().addr_indirect != 0 {
-            // TODO: remove kernel_builder()
-            let mut bp = kernel_builder()
-                .file_system
-                .log
-                .disk
-                .read(dev, self.deref_inner().addr_indirect);
+            let mut bp = fs.log.disk.read(dev, self.deref_inner().addr_indirect);
             // SAFETY: u32 does not have internal structure.
             let (prefix, data, _) = unsafe { bp.deref_inner_mut().data.align_to_mut::<u32>() };
             debug_assert_eq!(prefix.len(), 0, "itrunc: Buf data unaligned");
@@ -401,7 +401,7 @@ impl InodeGuard<'_> {
         }
 
         self.deref_inner_mut().size = 0;
-        self.update(tx);
+        self.update(tx, fs);
     }
 
     /// Copy data into `dst` from the content of inode at offset `off`.
@@ -410,11 +410,17 @@ impl InodeGuard<'_> {
     /// # Safety
     ///
     /// `T` can be safely `transmute`d to `[u8; size_of::<T>()]`.
-    pub unsafe fn read_kernel<T>(&mut self, dst: &mut T, off: u32) -> Result<(), ()> {
+    pub unsafe fn read_kernel<T>(
+        &mut self,
+        dst: &mut T,
+        off: u32,
+        fs: &FileSystem,
+    ) -> Result<(), ()> {
         let bytes = self.read_bytes_kernel(
             // SAFETY: the safety assumption of this method.
             unsafe { core::slice::from_raw_parts_mut(dst as *mut _ as _, mem::size_of::<T>()) },
             off,
+            fs,
         );
         if bytes == mem::size_of::<T>() {
             Ok(())
@@ -425,11 +431,16 @@ impl InodeGuard<'_> {
 
     /// Copy data into `dst` from the content of inode at offset `off`.
     /// Return the number of bytes copied.
-    pub fn read_bytes_kernel(&mut self, dst: &mut [u8], off: u32) -> usize {
-        self.read_internal(off, dst.len() as u32, |off, src| {
-            dst[off as usize..off as usize + src.len()].clone_from_slice(src);
-            Ok(())
-        })
+    pub fn read_bytes_kernel(&mut self, dst: &mut [u8], off: u32, fs: &FileSystem) -> usize {
+        self.read_internal(
+            off,
+            dst.len() as u32,
+            |off, src| {
+                dst[off as usize..off as usize + src.len()].clone_from_slice(src);
+                Ok(())
+            },
+            fs,
+        )
         .expect("read: should never fail")
     }
 
@@ -443,10 +454,14 @@ impl InodeGuard<'_> {
         off: u32,
         n: u32,
         proc: &mut CurrentProc<'_>,
+        fs: &FileSystem,
     ) -> Result<usize, ()> {
-        self.read_internal(off, n, |off, src| {
-            proc.memory_mut().copy_out_bytes(dst + off as usize, src)
-        })
+        self.read_internal(
+            off,
+            n,
+            |off, src| proc.memory_mut().copy_out_bytes(dst + off as usize, src),
+            fs,
+        )
     }
 
     /// Read data from inode.
@@ -465,6 +480,7 @@ impl InodeGuard<'_> {
         mut off: u32,
         mut n: u32,
         mut f: F,
+        fs: &FileSystem,
     ) -> Result<usize, ()> {
         let inner = self.deref_inner();
         if off > inner.size || off.wrapping_add(n) < off {
@@ -475,12 +491,10 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            // TODO: remove kernel_builder()
-            let bp = kernel_builder()
-                .file_system
+            let bp = fs
                 .log
                 .disk
-                .read(self.dev, self.bmap(off as usize / BSIZE));
+                .read(self.dev, self.bmap(off as usize / BSIZE, fs));
             let m = core::cmp::min(n - tot, BSIZE as u32 - off % BSIZE as u32);
             let begin = (off % BSIZE as u32) as usize;
             let end = begin + m as usize;
@@ -493,13 +507,20 @@ impl InodeGuard<'_> {
 
     /// Copy data from `src` into the inode at offset `off`.
     /// Return Ok(()) on success, Err(()) on failure.
-    pub fn write_kernel<T>(&mut self, src: &T, off: u32, tx: &FsTransaction<'_>) -> Result<(), ()> {
+    pub fn write_kernel<T>(
+        &mut self,
+        src: &T,
+        off: u32,
+        tx: &FsTransaction<'_>,
+        fs: &FileSystem,
+    ) -> Result<(), ()> {
         let bytes = self.write_bytes_kernel(
             // SAFETY: src is a valid reference to T and
             // u8 does not have any internal structure.
             unsafe { core::slice::from_raw_parts(src as *const _ as _, mem::size_of::<T>()) },
             off,
             tx,
+            fs,
         )?;
         if bytes == mem::size_of::<T>() {
             Ok(())
@@ -515,6 +536,7 @@ impl InodeGuard<'_> {
         src: &[u8],
         off: u32,
         tx: &FsTransaction<'_>,
+        fs: &FileSystem,
     ) -> Result<usize, ()> {
         self.write_internal(
             off,
@@ -524,6 +546,7 @@ impl InodeGuard<'_> {
                 Ok(())
             },
             tx,
+            fs,
         )
     }
 
@@ -537,12 +560,14 @@ impl InodeGuard<'_> {
         n: u32,
         proc: &mut CurrentProc<'_>,
         tx: &FsTransaction<'_>,
+        fs: &FileSystem,
     ) -> Result<usize, ()> {
         self.write_internal(
             off,
             n,
             |off, dst| proc.memory_mut().copy_in_bytes(dst, src + off as usize),
             tx,
+            fs,
         )
     }
 
@@ -565,6 +590,7 @@ impl InodeGuard<'_> {
         n: u32,
         mut f: F,
         tx: &FsTransaction<'_>,
+        fs: &FileSystem,
     ) -> Result<usize, ()> {
         if off > self.deref_inner().size {
             return Err(());
@@ -574,12 +600,10 @@ impl InodeGuard<'_> {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            // TODO: remove kernel_builder()
-            let mut bp = kernel_builder()
-                .file_system
+            let mut bp = fs
                 .log
                 .disk
-                .read(self.dev, self.bmap_or_alloc(off as usize / BSIZE, tx));
+                .read(self.dev, self.bmap_or_alloc(off as usize / BSIZE, tx, fs));
             let m = core::cmp::min(n - tot, BSIZE as u32 - off % BSIZE as u32);
             let begin = (off % BSIZE as u32) as usize;
             let end = begin + m as usize;
@@ -598,7 +622,7 @@ impl InodeGuard<'_> {
         // Write the i-node back to disk even if the size didn't change
         // because the loop above might have called bmap() and added a new
         // block to self->addrs[].
-        self.update(tx);
+        self.update(tx, fs);
         Ok(tot as usize)
     }
 
@@ -610,15 +634,20 @@ impl InodeGuard<'_> {
     /// listed in block self->addr_indirect.
     /// Return the disk block address of the nth block in inode self.
     /// If there is no such block, bmap allocates one.
-    fn bmap_or_alloc(&mut self, bn: usize, tx: &FsTransaction<'_>) -> u32 {
-        self.bmap_internal(bn, Some(tx))
+    fn bmap_or_alloc(&mut self, bn: usize, tx: &FsTransaction<'_>, fs: &FileSystem) -> u32 {
+        self.bmap_internal(bn, Some(tx), fs)
     }
 
-    fn bmap(&mut self, bn: usize) -> u32 {
-        self.bmap_internal(bn, None)
+    fn bmap(&mut self, bn: usize, fs: &FileSystem) -> u32 {
+        self.bmap_internal(bn, None, fs)
     }
 
-    fn bmap_internal(&mut self, bn: usize, tx_opt: Option<&FsTransaction<'_>>) -> u32 {
+    fn bmap_internal(
+        &mut self,
+        bn: usize,
+        tx_opt: Option<&FsTransaction<'_>>,
+        fs: &FileSystem,
+    ) -> u32 {
         let inner = self.deref_inner();
 
         if bn < NDIRECT {
@@ -638,12 +667,7 @@ impl InodeGuard<'_> {
                 self.deref_inner_mut().addr_indirect = indirect;
             }
 
-            // TODO: remove kernel_builder()
-            let mut bp = kernel_builder()
-                .file_system
-                .log
-                .disk
-                .read(self.dev, indirect);
+            let mut bp = fs.log.disk.read(self.dev, indirect);
             let (prefix, data, _) = unsafe { bp.deref_inner_mut().data.align_to_mut::<u32>() };
             debug_assert_eq!(prefix.len(), 0, "bmap: Buf data unaligned");
             let mut addr = data[bn];
@@ -658,12 +682,12 @@ impl InodeGuard<'_> {
     }
 
     /// Is the directory dp empty except for "." and ".." ?
-    pub fn is_dir_empty(&mut self) -> bool {
+    pub fn is_dir_empty(&mut self, fs: &FileSystem) -> bool {
         let mut de: Dirent = Default::default();
         for off in (2 * DIRENT_SIZE as u32..self.deref_inner().size).step_by(DIRENT_SIZE) {
             // SAFETY: Dirent can be safely transmuted to [u8; _], as it
             // contains only u16 and u8's, which do not have internal structures.
-            unsafe { self.read_kernel(&mut de, off) }.expect("is_dir_empty: read_kernel");
+            unsafe { self.read_kernel(&mut de, off, fs) }.expect("is_dir_empty: read_kernel");
             if de.inum != 0 {
                 return false;
             }
@@ -691,6 +715,9 @@ impl ArenaObject for Inode {
         if self.inner.get_mut().valid && self.inner.get_mut().nlink == 0 {
             // inode has no links and no other references: truncate and free.
 
+            // TODO: remove kernel_builder()
+            let fs = &kernel_builder().file_system;
+
             // TODO(https://github.com/kaist-cp/rv6/issues/290)
             // Disk write operations must happen inside a transaction. However,
             // we cannot begin a new transaction here because beginning of a
@@ -703,22 +730,19 @@ impl ArenaObject for Inode {
             // resulting FsTransaction value is never used. Such transactions
             // can be found in finalize in file.rs, sys_chdir in sysfile.rs,
             // close_files in proc.rs, and exec in exec.rs.
-            let tx = mem::ManuallyDrop::new(FsTransaction {
-                // TODO: remove kernel_builder()
-                fs: &kernel_builder().file_system,
-            });
+            let tx = mem::ManuallyDrop::new(FsTransaction { fs });
 
             // self->ref == 1 means no other process can have self locked,
             // so this acquiresleep() won't block (or deadlock).
-            let mut ip = self.lock();
+            let mut ip = self.lock(fs);
 
             // SAFETY: `nlink` is 0. That is, there is no way to reach to inode,
             // so the `Itable` never tries to obtain an `Rc` referring this `Inode`.
             unsafe {
                 A::reacquire_after(guard, move || {
-                    ip.itrunc(&tx);
+                    ip.itrunc(&tx, fs);
                     ip.deref_inner_mut().typ = InodeType::None;
-                    ip.update(&tx);
+                    ip.update(&tx, fs);
                     ip.deref_inner_mut().valid = false;
                     drop(ip);
                 });
@@ -730,15 +754,13 @@ impl ArenaObject for Inode {
 impl Inode {
     /// Lock the given inode.
     /// Reads the inode from disk if necessary.
-    pub fn lock(&self) -> InodeGuard<'_> {
+    pub fn lock(&self, fs: &FileSystem) -> InodeGuard<'_> {
         let mut guard = self.inner.lock();
         if !guard.valid {
-            // TODO: remove kernel_builder()
-            let mut bp = kernel_builder().file_system.log.disk.read(
-                self.dev,
-                // TODO: remove kernel_builder()
-                kernel_builder().file_system.superblock().iblock(self.inum),
-            );
+            let mut bp = fs
+                .log
+                .disk
+                .read(self.dev, fs.superblock().iblock(self.inum));
 
             // SAFETY: dip is inside bp.data.
             let dip = unsafe {
@@ -834,16 +856,15 @@ impl Itable {
     /// Allocate an inode on device dev.
     /// Mark it as allocated by giving it type.
     /// Returns an unlocked but allocated and referenced inode.
-    pub fn alloc_inode(&self, dev: u32, typ: InodeType, tx: &FsTransaction<'_>) -> RcInode {
-        // TODO: remove kernel_builder()
-        for inum in 1..kernel_builder().file_system.superblock().ninodes {
-            // TODO: remove kernel_builder()
-            let mut bp = kernel_builder()
-                .file_system
-                .log
-                .disk
-                // TODO: remove kernel_builder()
-                .read(dev, kernel_builder().file_system.superblock().iblock(inum));
+    pub fn alloc_inode(
+        &self,
+        dev: u32,
+        typ: InodeType,
+        tx: &FsTransaction<'_>,
+        fs: &FileSystem,
+    ) -> RcInode {
+        for inum in 1..fs.superblock().ninodes {
+            let mut bp = fs.log.disk.read(dev, fs.superblock().iblock(inum));
 
             const_assert!(IPB <= mem::size_of::<BufData>() / mem::size_of::<Dinode>());
             const_assert!(mem::align_of::<BufData>() % mem::align_of::<Dinode>() == 0);
@@ -884,16 +905,22 @@ impl Itable {
         self.get_inode(ROOTDEV, ROOTINO)
     }
 
-    pub fn namei(&self, path: &Path, proc: &CurrentProc<'_>) -> Result<RcInode, ()> {
-        Ok(self.namex(path, false, proc)?.0)
+    pub fn namei(
+        &self,
+        path: &Path,
+        proc: &CurrentProc<'_>,
+        fs: &FileSystem,
+    ) -> Result<RcInode, ()> {
+        Ok(self.namex(path, false, proc, fs)?.0)
     }
 
     pub fn nameiparent<'s>(
         &self,
         path: &'s Path,
         proc: &CurrentProc<'_>,
+        fs: &FileSystem,
     ) -> Result<(RcInode, &'s FileName), ()> {
-        let (ip, name_in_path) = self.namex(path, true, proc)?;
+        let (ip, name_in_path) = self.namex(path, true, proc, fs)?;
         let name_in_path = name_in_path.ok_or(())?;
         Ok((ip, name_in_path))
     }
@@ -903,6 +930,7 @@ impl Itable {
         mut path: &'s Path,
         parent: bool,
         proc: &CurrentProc<'_>,
+        fs: &FileSystem,
     ) -> Result<(RcInode, Option<&'s FileName>), ()> {
         let mut ptr = if path.is_absolute() {
             self.root()
@@ -913,7 +941,7 @@ impl Itable {
         while let Some((new_path, name)) = path.skipelem() {
             path = new_path;
 
-            let mut ip = ptr.lock();
+            let mut ip = ptr.lock(fs);
             if ip.deref_inner().typ != InodeType::Dir {
                 return Err(());
             }
@@ -922,7 +950,7 @@ impl Itable {
                 drop(ip);
                 return Ok((ptr, Some(name)));
             }
-            let next = ip.dirlookup(name, self);
+            let next = ip.dirlookup(name, self, fs);
             drop(ip);
             ptr = next?.0
         }

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -1163,7 +1163,9 @@ unsafe fn forkret() {
     // File system initialization must be run in the context of a
     // regular process (e.g., because it calls sleep), and thus cannot
     // be run from main().
-    kernel.file_system.init(ROOTDEV);
+    kernel
+        .file_system
+        .init(ROOTDEV, unsafe { kernel.get_bcache() });
 
     unsafe { usertrapret(proc) };
 }

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -10,7 +10,7 @@ use crate::{
         kstack, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, TRAPFRAME, UART0, VIRTIO0,
     },
     arch::riscv::{make_satp, sfence_vma, w_satp},
-    fs::InodeGuard,
+    fs::{FileSystem, InodeGuard},
     kalloc::Kmem,
     lock::Spinlock,
     page::Page,
@@ -433,6 +433,7 @@ impl UserMemory {
         ip: &mut InodeGuard<'_>,
         offset: u32,
         sz: u32,
+        fs: &FileSystem,
     ) -> Result<(), ()> {
         assert!(va.is_page_aligned(), "load_file: va must be page aligned");
         for i in num_iter::range_step(0, sz, PGSIZE as _) {
@@ -440,7 +441,7 @@ impl UserMemory {
                 .get_slice(va + i as usize)
                 .expect("load_file: address should exist");
             let n = cmp::min((sz - i) as usize, PGSIZE);
-            let bytes_read = ip.read_bytes_kernel(&mut dst[..n], offset + i);
+            let bytes_read = ip.read_bytes_kernel(&mut dst[..n], offset + i, fs);
             if bytes_read != n {
                 return Err(());
             }

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -10,9 +10,9 @@ use crate::{
         kstack, FINISHER, KERNBASE, PHYSTOP, PLIC, TRAMPOLINE, TRAPFRAME, UART0, VIRTIO0,
     },
     arch::riscv::{make_satp, sfence_vma, w_satp},
-    bio::Bcache,
-    fs::{FileSystem, InodeGuard},
+    fs::InodeGuard,
     kalloc::Kmem,
+    kernel::Kernel,
     lock::Spinlock,
     page::Page,
     param::NPROC,
@@ -434,8 +434,7 @@ impl UserMemory {
         ip: &mut InodeGuard<'_>,
         offset: u32,
         sz: u32,
-        fs: &FileSystem,
-        bcache: &Bcache,
+        kernel: &Kernel,
     ) -> Result<(), ()> {
         assert!(va.is_page_aligned(), "load_file: va must be page aligned");
         for i in num_iter::range_step(0, sz, PGSIZE as _) {
@@ -443,7 +442,7 @@ impl UserMemory {
                 .get_slice(va + i as usize)
                 .expect("load_file: address should exist");
             let n = cmp::min((sz - i) as usize, PGSIZE);
-            let bytes_read = ip.read_bytes_kernel(&mut dst[..n], offset + i, fs, bcache);
+            let bytes_read = ip.read_bytes_kernel(&mut dst[..n], offset + i, kernel);
             if bytes_read != n {
                 return Err(());
             }


### PR DESCRIPTION
#490 과는 conflict가 있습니다. #490 을 바탕으로 `kernel_builder` 호출을 줄이는 리팩토링을 진행하다 보니 문제가 생겨서(https://github.com/kaist-cp/rv6/issues/483#issuecomment-820937140 에서 설명한 문제와 동일), `KernelCtx` 없이 `kernel_builder` 호출을 줄이는 이 PR을 만들어 보았습니다.

* `inode.rs`의 메서드들이 디스크에서 읽기 위해 `&FileSystem`을 필요로 하므로 `&FileSystem`을 인자로 받도록 했습니다.
* `FsTransaction::bzero`가 `&Bcache`를 필요로 하므로 `&Bcache`를 인자로 받도록 했습니다.
* `Disk::read`가 `&Bcache`를 필요로 하므로 `&Bcache`를 인자로 받도록 했습니다.
* `inode.rs`의 메서드들이 인자를 너무 많이 받아서(`&FileSystem`과 `&Bcache`를 받음. 여기에 더해 `&Itable`을 받기도 함), 그냥 `&Kernel`을 받도록 했습니다.

여러 PR로 쪼갤 수 있기는 하겠지만, 각각의 변경 사항이 다 `inode.rs`를 많이 건드려서 PR 하나에서 다 하는 것이 낫다고 판단했습니다.