### PR TITLE
Make `KernelCtx::{kernel, proc}` fields into private

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -49,7 +49,7 @@ impl Console {
             let mut c = [0u8];
             // TODO: remove kernel_ctx()
             if unsafe { kernel_ctx() }
-                .proc
+                .proc_mut()
                 .memory_mut()
                 .copy_in_bytes(&mut c, src + i as usize)
                 .is_err()
@@ -70,7 +70,7 @@ impl Console {
             // input into CONS.buffer.
             while this.r == this.w {
                 // TODO: remove kernel_ctx()
-                if unsafe { kernel_ctx() }.proc.killed() {
+                if unsafe { kernel_ctx() }.proc().killed() {
                     return -1;
                 }
                 this.sleep();
@@ -92,7 +92,7 @@ impl Console {
                 let cbuf = [cin as u8];
                 // TODO: remove kernel_ctx()
                 if unsafe { kernel_ctx() }
-                    .proc
+                    .proc_mut()
                     .memory_mut()
                     .copy_out_bytes(dst, &cbuf)
                     .is_err()

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -162,7 +162,7 @@ impl File {
                 let mut bytes_written: usize = 0;
                 while bytes_written < n {
                     let bytes_to_write = cmp::min(n - bytes_written, max);
-                    let tx = ctx.kernel.file_system.begin_transaction();
+                    let tx = ctx.kernel().file_system.begin_transaction();
                     let mut ip = inner.lock();
                     let curr_off = *ip.off;
                     let r = ip

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -108,7 +108,7 @@ impl File {
             }
             | FileType::Device { ip, .. } => {
                 let st = ip.stat();
-                ctx.proc.memory_mut().copy_out(addr, &st)
+                ctx.proc_mut().memory_mut().copy_out(addr, &st)
             }
             _ => Err(()),
         }

--- a/kernel-rs/src/fs/inode.rs
+++ b/kernel-rs/src/fs/inode.rs
@@ -445,7 +445,7 @@ impl InodeGuard<'_> {
         ctx: &mut KernelCtx<'_>,
     ) -> Result<usize, ()> {
         self.read_internal(off, n, |off, src| {
-            ctx.proc
+            ctx.proc_mut()
                 .memory_mut()
                 .copy_out_bytes(dst + off as usize, src)
         })
@@ -543,7 +543,11 @@ impl InodeGuard<'_> {
         self.write_internal(
             off,
             n,
-            |off, dst| ctx.proc.memory_mut().copy_in_bytes(dst, src + off as usize),
+            |off, dst| {
+                ctx.proc_mut()
+                    .memory_mut()
+                    .copy_in_bytes(dst, src + off as usize)
+            },
             tx,
         )
     }
@@ -909,7 +913,7 @@ impl Itable {
         let mut ptr = if path.is_absolute() {
             self.root()
         } else {
-            ctx.proc.cwd().clone()
+            ctx.proc().cwd().clone()
         };
 
         while let Some((new_path, name)) = path.skipelem() {

--- a/kernel-rs/src/lock/sleeplock.rs
+++ b/kernel-rs/src/lock/sleeplock.rs
@@ -34,7 +34,7 @@ impl RawLock for RawSleeplock {
             guard.sleep();
         }
         // TODO: remove kernel_ctx()
-        *guard = unsafe { kernel_ctx() }.proc.pid();
+        *guard = unsafe { kernel_ctx() }.proc().pid();
     }
 
     fn release(&self) {
@@ -46,7 +46,7 @@ impl RawLock for RawSleeplock {
     fn holding(&self) -> bool {
         let guard = self.locked.lock();
         // TODO: remove kernel_ctx()
-        *guard == unsafe { kernel_ctx() }.proc.pid()
+        *guard == unsafe { kernel_ctx() }.proc().pid()
     }
 }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -229,7 +229,7 @@ impl WaitChannel {
         // so it's okay to release lk.
 
         //DOC: sleeplock1
-        let mut guard = ctx.proc().lock();
+        let mut guard = ctx.proc.lock();
         // Release the lock while we sleep on the waitchannel, and reacquire after the process wakes up.
         lock_guard.reacquire_after(move || {
             // Go to sleep.
@@ -958,7 +958,7 @@ impl Procs {
 
         // Copy saved user registers.
         // SAFETY: trap_frame has been initialized by alloc.
-        unsafe { *npdata.trap_frame = *ctx.proc().trap_frame() };
+        unsafe { *npdata.trap_frame = *ctx.proc.trap_frame() };
 
         // Cause fork to return 0 in the child.
         // SAFETY: trap_frame has been initialized by alloc.
@@ -967,15 +967,15 @@ impl Procs {
         // Increment reference counts on open file descriptors.
         for (nf, f) in izip!(
             npdata.open_files.iter_mut(),
-            ctx.proc().deref_data().open_files.iter()
+            ctx.proc.deref_data().open_files.iter()
         ) {
             if let Some(file) = f {
                 *nf = Some(file.clone());
             }
         }
-        let _ = npdata.cwd.write(ctx.proc_mut().cwd_mut().clone());
+        let _ = npdata.cwd.write(ctx.proc.cwd_mut().clone());
 
-        npdata.name.copy_from_slice(&ctx.proc().deref_data().name);
+        npdata.name.copy_from_slice(&ctx.proc.deref_data().name);
 
         let pid = np.deref_mut_info().pid;
 
@@ -984,7 +984,7 @@ impl Procs {
         np.reacquire_after(|np| {
             // Acquire the `wait_lock`, and write the parent field.
             let mut parent_guard = np.parent().lock();
-            *np.parent().get_mut(&mut parent_guard) = &**ctx.proc();
+            *np.parent().get_mut(&mut parent_guard) = ctx.proc.deref();
         });
 
         // Set the process's state to RUNNABLE.
@@ -1005,7 +1005,7 @@ impl Procs {
             // Scan through pool looking for exited children.
             let mut havekids = false;
             for np in self.process_pool() {
-                if *np.parent().get_mut(&mut parent_guard) == &**ctx.proc() {
+                if *np.parent().get_mut(&mut parent_guard) == ctx.proc.deref() {
                     // Found a child.
                     // Make sure the child isn't still in exit() or swtch().
                     let mut np = np.lock();
@@ -1031,13 +1031,13 @@ impl Procs {
             }
 
             // No point waiting if we don't have any children.
-            if !havekids || ctx.proc().killed() {
+            if !havekids || ctx.proc.killed() {
                 return Err(());
             }
 
             // Wait for a child to exit.
             //DOC: wait-sleep
-            ctx.proc().child_waitchannel.sleep(&mut parent_guard, ctx);
+            ctx.proc.child_waitchannel.sleep(&mut parent_guard, ctx);
         }
     }
 
@@ -1062,12 +1062,12 @@ impl Procs {
     /// until its parent calls wait().
     pub fn exit_current(&self, status: i32, ctx: &mut KernelCtx<'_>) -> ! {
         assert_ne!(
-            &**ctx.proc() as *const _,
+            ctx.proc.deref() as *const _,
             self.initial_proc() as _,
             "init exiting"
         );
 
-        for file in &mut ctx.proc_mut().deref_mut_data().open_files {
+        for file in &mut ctx.proc.deref_mut_data().open_files {
             *file = None;
         }
 
@@ -1079,15 +1079,15 @@ impl Procs {
         let tx = kernel_builder().file_system.begin_transaction();
         // SAFETY: CurrentProc's cwd has been initialized.
         // It's ok to drop cwd as proc will not be used any longer.
-        unsafe { ctx.proc_mut().deref_mut_data().cwd.assume_init_drop() };
+        unsafe { ctx.proc.deref_mut_data().cwd.assume_init_drop() };
         drop(tx);
 
         // Give all children to init.
-        let mut parent_guard = ctx.proc().parent().lock();
-        self.reparent(&**ctx.proc(), &mut parent_guard);
+        let mut parent_guard = ctx.proc.parent().lock();
+        self.reparent(ctx.proc.deref(), &mut parent_guard);
 
         // Parent might be sleeping in wait().
-        let parent = *ctx.proc().parent().get_mut(&mut parent_guard);
+        let parent = *ctx.proc.parent().get_mut(&mut parent_guard);
         // TODO: this assertion is actually unneccessary because parent is null
         // only when proc is the initial process, which cannot be the case.
         assert!(!parent.is_null());
@@ -1095,7 +1095,7 @@ impl Procs {
         // ProcBuilder and CurrentProc.
         unsafe { (*parent).child_waitchannel.wakeup() };
 
-        let mut guard = ctx.proc().lock();
+        let mut guard = ctx.proc.lock();
 
         guard.deref_mut_info().xstate = status;
         guard.deref_mut_info().state = Procstate::ZOMBIE;
@@ -1190,7 +1190,7 @@ pub unsafe fn scheduler() -> ! {
 unsafe fn forkret() {
     let ctx = unsafe { kernel_ctx() };
     // Still holding p->lock from scheduler.
-    unsafe { ctx.proc().info.unlock() };
+    unsafe { ctx.proc.info.unlock() };
 
     // File system initialization must be run in the context of a
     // regular process (e.g., because it calls sleep), and thus cannot

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -342,8 +342,14 @@ pub struct ProcBuilder {
 /// Methods that (possibly) need to access both `&Kernel` and `CurrentProc` take `KernelCtx` as
 /// arguments. Otherwise, methods can take only one of `&Kernel` and `CurrentProc` as arguments.
 pub struct KernelCtx<'p> {
-    pub kernel: &'p Kernel,
+    kernel: &'p Kernel,
     pub proc: CurrentProc<'p>,
+}
+
+impl<'p> KernelCtx<'p> {
+    pub fn kernel(&self) -> &'p Kernel {
+        &self.kernel
+    }
 }
 
 /// CurrentProc wraps mutable pointer of current CPU's proc.

--- a/kernel-rs/src/syscall/file.rs
+++ b/kernel-rs/src/syscall/file.rs
@@ -59,9 +59,9 @@ impl KernelCtx<'_> {
     where
         F: FnOnce(&mut InodeGuard<'_>) -> T,
     {
-        let (ptr, name) = self.kernel.itable.nameiparent(path, self)?;
+        let (ptr, name) = self.kernel().itable.nameiparent(path, self)?;
         let mut dp = ptr.lock();
-        if let Ok((ptr2, _)) = dp.dirlookup(&name, &self.kernel.itable) {
+        if let Ok((ptr2, _)) = dp.dirlookup(&name, &self.kernel().itable) {
             drop(dp);
             if typ != InodeType::File {
                 return Err(());
@@ -74,7 +74,7 @@ impl KernelCtx<'_> {
             drop(ip);
             return Ok((ptr2, ret));
         }
-        let ptr2 = self.kernel.itable.alloc_inode(dp.dev, typ, tx);
+        let ptr2 = self.kernel().itable.alloc_inode(dp.dev, typ, tx);
         let mut ip = ptr2.lock();
         ip.deref_inner_mut().nlink = 1;
         ip.update(tx);
@@ -91,7 +91,7 @@ impl KernelCtx<'_> {
                 unsafe { FileName::from_bytes(b".") },
                 ip.inum,
                 tx,
-                &self.kernel.itable,
+                &self.kernel().itable,
             )
             // SAFETY: b".." does not contain any NUL characters.
             .and_then(|_| {
@@ -99,12 +99,12 @@ impl KernelCtx<'_> {
                     unsafe { FileName::from_bytes(b"..") },
                     dp.inum,
                     tx,
-                    &self.kernel.itable,
+                    &self.kernel().itable,
                 )
             })
             .expect("create dots");
         }
-        dp.dirlink(&name, ip.inum, tx, &self.kernel.itable)
+        dp.dirlink(&name, ip.inum, tx, &self.kernel().itable)
             .expect("create: dirlink");
         let ret = f(&mut ip);
         drop(ip);
@@ -114,8 +114,8 @@ impl KernelCtx<'_> {
     /// Create another name(newname) for the file oldname.
     /// Returns Ok(()) on success, Err(()) on error.
     fn link(&self, oldname: &CStr, newname: &CStr) -> Result<(), ()> {
-        let tx = self.kernel.file_system.begin_transaction();
-        let ptr = self.kernel.itable.namei(Path::new(oldname), self)?;
+        let tx = self.kernel().file_system.begin_transaction();
+        let ptr = self.kernel().itable.namei(Path::new(oldname), self)?;
         let mut ip = ptr.lock();
         if ip.deref_inner().typ == InodeType::Dir {
             return Err(());
@@ -124,11 +124,11 @@ impl KernelCtx<'_> {
         ip.update(&tx);
         drop(ip);
 
-        if let Ok((ptr2, name)) = self.kernel.itable.nameiparent(Path::new(newname), self) {
+        if let Ok((ptr2, name)) = self.kernel().itable.nameiparent(Path::new(newname), self) {
             let mut dp = ptr2.lock();
             if dp.dev != ptr.dev
                 || dp
-                    .dirlink(name, ptr.inum, &tx, &self.kernel.itable)
+                    .dirlink(name, ptr.inum, &tx, &self.kernel().itable)
                     .is_err()
             {
             } else {
@@ -146,13 +146,16 @@ impl KernelCtx<'_> {
     /// Returns Ok(()) on success, Err(()) on error.
     fn unlink(&self, filename: &CStr) -> Result<(), ()> {
         let de: Dirent = Default::default();
-        let tx = self.kernel.file_system.begin_transaction();
-        let (ptr, name) = self.kernel.itable.nameiparent(Path::new(filename), self)?;
+        let tx = self.kernel().file_system.begin_transaction();
+        let (ptr, name) = self
+            .kernel()
+            .itable
+            .nameiparent(Path::new(filename), self)?;
         let mut dp = ptr.lock();
 
         // Cannot unlink "." or "..".
         if !(name.as_bytes() == b"." || name.as_bytes() == b"..") {
-            if let Ok((ptr2, off)) = dp.dirlookup(&name, &self.kernel.itable) {
+            if let Ok((ptr2, off)) = dp.dirlookup(&name, &self.kernel().itable) {
                 let mut ip = ptr2.lock();
                 assert!(ip.deref_inner().nlink >= 1, "unlink: nlink < 1");
 
@@ -177,12 +180,12 @@ impl KernelCtx<'_> {
     /// Open a file; omode indicate read/write.
     /// Returns Ok(file descriptor) on success, Err(()) on error.
     fn open(&mut self, name: &Path, omode: FcntlFlags) -> Result<usize, ()> {
-        let tx = self.kernel.file_system.begin_transaction();
+        let tx = self.kernel().file_system.begin_transaction();
 
         let (ip, typ) = if omode.contains(FcntlFlags::O_CREATE) {
             self.create(name, InodeType::File, &tx, |ip| ip.deref_inner().typ)?
         } else {
-            let ptr = self.kernel.itable.namei(name, self)?;
+            let ptr = self.kernel().itable.namei(name, self)?;
             let ip = ptr.lock();
             let typ = ip.deref_inner().typ;
 
@@ -195,7 +198,7 @@ impl KernelCtx<'_> {
 
         let filetype = match typ {
             InodeType::Device { major, .. } => {
-                let major = self.kernel.devsw.get(major as usize).ok_or(())?;
+                let major = self.kernel().devsw.get(major as usize).ok_or(())?;
                 FileType::Device { ip, major }
             }
             _ => {
@@ -208,7 +211,7 @@ impl KernelCtx<'_> {
             }
         };
 
-        let f = self.kernel.ftable.alloc_file(
+        let f = self.kernel().ftable.alloc_file(
             filetype,
             !omode.intersects(FcntlFlags::O_WRONLY),
             omode.intersects(FcntlFlags::O_WRONLY | FcntlFlags::O_RDWR),
@@ -231,7 +234,7 @@ impl KernelCtx<'_> {
     /// Create a new directory.
     /// Returns Ok(()) on success, Err(()) on error.
     fn mkdir(&self, dirname: &CStr) -> Result<(), ()> {
-        let tx = self.kernel.file_system.begin_transaction();
+        let tx = self.kernel().file_system.begin_transaction();
         self.create(Path::new(dirname), InodeType::Dir, &tx, |_| ())?;
         Ok(())
     }
@@ -239,7 +242,7 @@ impl KernelCtx<'_> {
     /// Create a device file.
     /// Returns Ok(()) on success, Err(()) on error.
     fn mknod(&self, filename: &CStr, major: u16, minor: u16) -> Result<(), ()> {
-        let tx = self.kernel.file_system.begin_transaction();
+        let tx = self.kernel().file_system.begin_transaction();
         self.create(
             Path::new(filename),
             InodeType::Device { major, minor },
@@ -257,8 +260,8 @@ impl KernelCtx<'_> {
         // value, ptr, will be dropped when this method returns. Deallocation
         // of an inode may cause disk write operations, so we must begin a
         // transaction here.
-        let _tx = self.kernel.file_system.begin_transaction();
-        let ptr = self.kernel.itable.namei(Path::new(dirname), self)?;
+        let _tx = self.kernel().file_system.begin_transaction();
+        let ptr = self.kernel().itable.namei(Path::new(dirname), self)?;
         let ip = ptr.lock();
         if ip.deref_inner().typ != InodeType::Dir {
             return Err(());
@@ -271,7 +274,7 @@ impl KernelCtx<'_> {
     /// Create a pipe, put read/write file descriptors in fd0 and fd1.
     /// Returns Ok(()) on success, Err(()) on error.
     fn pipe(&mut self, fdarray: UVAddr) -> Result<(), ()> {
-        let (pipereader, pipewriter) = self.kernel.allocate_pipe()?;
+        let (pipereader, pipewriter) = self.kernel().allocate_pipe()?;
 
         let fd0 = pipereader.fdalloc(self).map_err(|_| ())?;
         let fd1 = pipewriter
@@ -424,9 +427,9 @@ impl KernelCtx<'_> {
                 break;
             }
 
-            let mut page = some_or!(self.kernel.kmem.alloc(), break);
+            let mut page = some_or!(self.kernel().kmem.alloc(), break);
             if self.proc.fetchstr(uarg.into(), &mut page[..]).is_err() {
-                self.kernel.kmem.free(page);
+                self.kernel().kmem.free(page);
                 break;
             }
             args.push(page);
@@ -439,7 +442,7 @@ impl KernelCtx<'_> {
         };
 
         for page in args.drain(..) {
-            self.kernel.kmem.free(page);
+            self.kernel().kmem.free(page);
         }
 
         ret

--- a/kernel-rs/src/syscall/mod.rs
+++ b/kernel-rs/src/syscall/mod.rs
@@ -39,8 +39,8 @@ impl KernelCtx<'_> {
             _ => {
                 println!(
                     "{} {}: unknown sys call {}",
-                    self.proc.pid(),
-                    str::from_utf8(&self.proc.deref_data().name).unwrap_or("???"),
+                    self.proc().pid(),
+                    str::from_utf8(&self.proc().deref_data().name).unwrap_or("???"),
                     num
                 );
                 Err(())

--- a/kernel-rs/src/syscall/proc.rs
+++ b/kernel-rs/src/syscall/proc.rs
@@ -4,20 +4,20 @@ impl KernelCtx<'_> {
     /// Terminate the current process; status reported to wait(). No return.
     pub fn sys_exit(&mut self) -> Result<usize, ()> {
         let n = self.proc.argint(0)?;
-        self.kernel.procs().exit_current(n, self);
+        self.kernel().procs().exit_current(n, self);
     }
 
     /// Create a process.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub fn sys_fork(&mut self) -> Result<usize, ()> {
-        Ok(self.kernel.procs().fork(self)? as _)
+        Ok(self.kernel().procs().fork(self)? as _)
     }
 
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub fn sys_wait(&mut self) -> Result<usize, ()> {
         let p = self.proc.argaddr(0)?;
-        Ok(self.kernel.procs().wait(p.into(), self)? as _)
+        Ok(self.kernel().procs().wait(p.into(), self)? as _)
     }
 
     /// Return the current process’s PID.
@@ -29,14 +29,15 @@ impl KernelCtx<'_> {
     /// Returns Ok(start of new memory) on success, Err(()) on error.
     pub fn sys_sbrk(&mut self) -> Result<usize, ()> {
         let n = self.proc.argint(0)?;
-        self.proc.memory_mut().resize(n, &self.kernel.kmem)
+        let kmem = &self.kernel().kmem;
+        self.proc.memory_mut().resize(n, kmem)
     }
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
     pub fn sys_sleep(&self) -> Result<usize, ()> {
         let n = self.proc.argint(0)?;
-        let mut ticks = self.kernel.ticks.lock();
+        let mut ticks = self.kernel().ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
             if self.proc.killed() {
@@ -51,14 +52,14 @@ impl KernelCtx<'_> {
     /// Returns Ok(0) on success, Err(()) on error.
     pub fn sys_kill(&self) -> Result<usize, ()> {
         let pid = self.proc.argint(0)?;
-        self.kernel.procs().kill(pid)?;
+        self.kernel().procs().kill(pid)?;
         Ok(0)
     }
 
     /// Return how many clock tick interrupts have occurred
     /// since start.
     pub fn sys_uptime(&self) -> Result<usize, ()> {
-        Ok(*self.kernel.ticks.lock() as usize)
+        Ok(*self.kernel().ticks.lock() as usize)
     }
 
     /// Shutdowns this machine, discarding all unsaved data. No return.

--- a/kernel-rs/src/syscall/proc.rs
+++ b/kernel-rs/src/syscall/proc.rs
@@ -3,7 +3,7 @@ use crate::{arch::poweroff, proc::KernelCtx};
 impl KernelCtx<'_> {
     /// Terminate the current process; status reported to wait(). No return.
     pub fn sys_exit(&mut self) -> Result<usize, ()> {
-        let n = self.proc.argint(0)?;
+        let n = self.proc().argint(0)?;
         self.kernel().procs().exit_current(n, self);
     }
 
@@ -16,31 +16,31 @@ impl KernelCtx<'_> {
     /// Wait for a child to exit.
     /// Returns Ok(child’s PID) on success, Err(()) on error.
     pub fn sys_wait(&mut self) -> Result<usize, ()> {
-        let p = self.proc.argaddr(0)?;
+        let p = self.proc().argaddr(0)?;
         Ok(self.kernel().procs().wait(p.into(), self)? as _)
     }
 
     /// Return the current process’s PID.
     pub fn sys_getpid(&self) -> Result<usize, ()> {
-        Ok(self.proc.pid() as _)
+        Ok(self.proc().pid() as _)
     }
 
     /// Grow process’s memory by n bytes.
     /// Returns Ok(start of new memory) on success, Err(()) on error.
     pub fn sys_sbrk(&mut self) -> Result<usize, ()> {
-        let n = self.proc.argint(0)?;
+        let n = self.proc().argint(0)?;
         let kmem = &self.kernel().kmem;
-        self.proc.memory_mut().resize(n, kmem)
+        self.proc_mut().memory_mut().resize(n, kmem)
     }
 
     /// Pause for n clock ticks.
     /// Returns Ok(0) on success, Err(()) on error.
     pub fn sys_sleep(&self) -> Result<usize, ()> {
-        let n = self.proc.argint(0)?;
+        let n = self.proc().argint(0)?;
         let mut ticks = self.kernel().ticks.lock();
         let ticks0 = *ticks;
         while ticks.wrapping_sub(ticks0) < n as u32 {
-            if self.proc.killed() {
+            if self.proc().killed() {
                 return Err(());
             }
             ticks.sleep();
@@ -51,7 +51,7 @@ impl KernelCtx<'_> {
     /// Terminate process PID.
     /// Returns Ok(0) on success, Err(()) on error.
     pub fn sys_kill(&self) -> Result<usize, ()> {
-        let pid = self.proc.argint(0)?;
+        let pid = self.proc().argint(0)?;
         self.kernel().procs().kill(pid)?;
         Ok(0)
     }
@@ -64,7 +64,7 @@ impl KernelCtx<'_> {
 
     /// Shutdowns this machine, discarding all unsaved data. No return.
     pub fn sys_poweroff(&self) -> Result<usize, ()> {
-        let exitcode = self.proc.argint(0)?;
+        let exitcode = self.proc().argint(0)?;
         poweroff::machine_poweroff(exitcode as _);
     }
 }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -72,7 +72,7 @@ impl KernelCtx<'_> {
             // system call
 
             if self.proc.killed() {
-                self.kernel.procs().exit_current(-1, &mut self);
+                self.kernel().procs().exit_current(-1, &mut self);
             }
 
             // sepc points to the ecall instruction,
@@ -85,7 +85,7 @@ impl KernelCtx<'_> {
             let syscall_no = self.proc.trap_frame_mut().a7 as i32;
             self.proc.trap_frame_mut().a0 = ok_or!(self.syscall(syscall_no), usize::MAX);
         } else {
-            which_dev = unsafe { self.kernel.dev_intr() };
+            which_dev = unsafe { self.kernel().dev_intr() };
             if which_dev == 0 {
                 println!(
                     "usertrap(): unexpected scause {:018p} pid={}",
@@ -102,7 +102,7 @@ impl KernelCtx<'_> {
         }
 
         if self.proc.killed() {
-            self.kernel.procs().exit_current(-1, &mut self);
+            self.kernel().procs().exit_current(-1, &mut self);
         }
 
         // Give up the CPU if this is a timer interrupt.

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -67,47 +67,47 @@ impl KernelCtx<'_> {
         let mut which_dev: i32 = 0;
 
         // Save user program counter.
-        self.proc.trap_frame_mut().epc = r_sepc();
+        self.proc_mut().trap_frame_mut().epc = r_sepc();
         if r_scause() == 8 {
             // system call
 
-            if self.proc.killed() {
+            if self.proc().killed() {
                 self.kernel().procs().exit_current(-1, &mut self);
             }
 
             // sepc points to the ecall instruction,
             // but we want to return to the next instruction.
-            self.proc.trap_frame_mut().epc = (self.proc.trap_frame().epc).wrapping_add(4);
+            self.proc_mut().trap_frame_mut().epc = (self.proc().trap_frame().epc).wrapping_add(4);
 
             // An interrupt will change sstatus &c registers,
             // so don't enable until done with those registers.
             unsafe { intr_on() };
-            let syscall_no = self.proc.trap_frame_mut().a7 as i32;
-            self.proc.trap_frame_mut().a0 = ok_or!(self.syscall(syscall_no), usize::MAX);
+            let syscall_no = self.proc_mut().trap_frame_mut().a7 as i32;
+            self.proc_mut().trap_frame_mut().a0 = ok_or!(self.syscall(syscall_no), usize::MAX);
         } else {
             which_dev = unsafe { self.kernel().dev_intr() };
             if which_dev == 0 {
                 println!(
                     "usertrap(): unexpected scause {:018p} pid={}",
                     r_scause() as *const u8,
-                    self.proc.pid()
+                    self.proc().pid()
                 );
                 println!(
                     "            sepc={:018p} stval={:018p}",
                     r_sepc() as *const u8,
                     r_stval() as *const u8
                 );
-                self.proc.kill();
+                self.proc().kill();
             }
         }
 
-        if self.proc.killed() {
+        if self.proc().killed() {
             self.kernel().procs().exit_current(-1, &mut self);
         }
 
         // Give up the CPU if this is a timer interrupt.
         if which_dev == 2 {
-            unsafe { self.proc.yield_cpu() };
+            unsafe { self.proc().yield_cpu() };
         }
 
         unsafe { self.user_trap_ret() };
@@ -133,14 +133,15 @@ impl KernelCtx<'_> {
         // the process next re-enters the kernel.
 
         // kernel page table
-        self.proc.trap_frame_mut().kernel_satp = r_satp();
+        self.proc_mut().trap_frame_mut().kernel_satp = r_satp();
 
         // process's kernel stack
-        self.proc.trap_frame_mut().kernel_sp = self.proc.deref_mut_data().kstack + PGSIZE;
-        self.proc.trap_frame_mut().kernel_trap = usertrap as usize;
+        self.proc_mut().trap_frame_mut().kernel_sp =
+            self.proc_mut().deref_mut_data().kstack + PGSIZE;
+        self.proc_mut().trap_frame_mut().kernel_trap = usertrap as usize;
 
         // hartid for cpuid()
-        self.proc.trap_frame_mut().kernel_hartid = r_tp();
+        self.proc_mut().trap_frame_mut().kernel_hartid = r_tp();
 
         // Set up the registers that trampoline.S's sret will use
         // to get to user space.
@@ -156,10 +157,10 @@ impl KernelCtx<'_> {
         unsafe { x.write() };
 
         // Set S Exception Program Counter to the saved user pc.
-        unsafe { w_sepc(self.proc.trap_frame().epc) };
+        unsafe { w_sepc(self.proc().trap_frame().epc) };
 
         // Tell trampoline.S the user page table to switch to.
-        let satp: usize = self.proc.memory().satp();
+        let satp: usize = self.proc().memory().satp();
 
         // Jump to trampoline.S at the top of memory, which
         // switches to the user page table, restores user registers,


### PR DESCRIPTION
참고: https://github.com/kaist-cp/rv6/pull/490#discussion_r614735246

* `KernelCtx`의 `kernel`와 `proc` field를 private field로 변환했습니다.
  ```Rust
  pub struct KernelCtx<'p> {
      kernel: &'p Kernel,
      proc: CurrentProc<'p>,
  }
  
  impl<'p> KernelCtx<'p> {
      pub fn kernel(&self) -> &'p Kernel {
          &self.kernel
      }
  
      pub fn proc(&self) -> &CurrentProc<'p> {
          &self.proc
     }
  
      pub fn proc_mut(&mut self) -> &mut CurrentProc<'p> {
          &mut self.proc
      }
  }
  ```
* 이외에는, 그저 기계적으로
  * `self.kernel` -> `self.kernel()`로
  * `self.proc` -> `self.proc()` (또는 `self.proc_mut()`)
로 변환한 것 뿐입니다.