### PR TITLE
Remove global function calls (`kernel` variants)

### DIFF
--- a/kernel-rs/src/fs/log.rs
+++ b/kernel-rs/src/fs/log.rs
@@ -32,6 +32,7 @@ use crate::{
     bio::{Buf, BufData, BufUnlocked},
     lock::{Sleepablelock, SleepablelockGuard},
     param::{BSIZE, LOGSIZE, MAXOPBLOCKS},
+    proc::KernelCtx,
     virtio::Disk,
 };
 
@@ -89,7 +90,7 @@ impl Log {
         }
     }
 
-    pub fn init(&self, dev: u32, start: i32, size: i32) {
+    pub fn init(&self, dev: u32, start: i32, size: i32, ctx: &KernelCtx<'_, '_>) {
         let mut inner = LogInner {
             dev,
             start,
@@ -98,7 +99,7 @@ impl Log {
             committing: false,
             bufs: ArrayVec::new(),
         };
-        LogLocked::new(LogLockedInner::Ref(&mut inner), &self.disk).recover_from_log();
+        LogLocked::new(LogLockedInner::Ref(&mut inner), &self.disk).recover_from_log(ctx);
         let _ = self.inner.call_once(|| Sleepablelock::new("LOG", inner));
     }
 
@@ -138,7 +139,7 @@ impl Log {
 
     /// Called at the end of each FS system call.
     /// Commits if this was the last outstanding operation.
-    pub fn end_op(&self) {
+    pub fn end_op(&self, ctx: &KernelCtx<'_, '_>) {
         let mut guard = self.inner().lock();
         guard.outstanding -= 1;
         assert!(!guard.committing, "guard.committing");
@@ -152,7 +153,7 @@ impl Log {
             // Call commit w/o holding locks, since not allowed to sleep with locks.
             guard.reacquire_after(||
                 // SAFETY: there is no another transaction, so `inner` cannot be read or written.
-                unsafe { self.lock_unchecked() }.commit());
+                unsafe { self.lock_unchecked() }.commit(ctx));
 
             guard.committing = false;
         }
@@ -171,13 +172,13 @@ impl<'a> LogLocked<'a> {
 
 impl LogLocked<'_> {
     /// Copy committed blocks from log to their home location.
-    fn install_trans(&mut self) {
+    fn install_trans(&mut self, ctx: &KernelCtx<'_, '_>) {
         let dev = self.inner.dev;
         let start = self.inner.start;
 
         for (tail, dbuf) in self.inner.bufs.drain(..).enumerate() {
             // Read log block.
-            let lbuf = self.disk.read(dev, (start + tail as i32 + 1) as u32);
+            let lbuf = self.disk.read(dev, (start + tail as i32 + 1) as u32, ctx);
 
             // Read dst.
             let mut dbuf = dbuf.lock();
@@ -188,13 +189,13 @@ impl LogLocked<'_> {
                 .copy_from_slice(&lbuf.deref_inner().data[..]);
 
             // Write dst to disk.
-            self.disk.write(&mut dbuf);
+            self.disk.write(&mut dbuf, ctx);
         }
     }
 
     /// Read the log header from disk into the in-memory log header.
-    fn read_head(&mut self) {
-        let mut buf = self.disk.read(self.dev, self.start as u32);
+    fn read_head(&mut self, ctx: &KernelCtx<'_, '_>) {
+        let mut buf = self.disk.read(self.dev, self.start as u32, ctx);
 
         const_assert!(mem::size_of::<LogHeader>() <= BSIZE);
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<LogHeader>() == 0);
@@ -206,7 +207,7 @@ impl LogLocked<'_> {
         let lh = unsafe { &mut *(buf.deref_inner_mut().data.as_mut_ptr() as *mut LogHeader) };
 
         for b in &lh.block[0..lh.n as usize] {
-            let buf = self.disk.read(self.dev, *b).unlock();
+            let buf = self.disk.read(self.dev, *b, ctx).unlock();
             self.bufs.push(buf);
         }
     }
@@ -214,8 +215,8 @@ impl LogLocked<'_> {
     /// Write in-memory log header to disk.
     /// This is the true point at which the
     /// current transaction commits.
-    fn write_head(&mut self) {
-        let mut buf = self.disk.read(self.dev, self.start as u32);
+    fn write_head(&mut self, ctx: &KernelCtx<'_, '_>) {
+        let mut buf = self.disk.read(self.dev, self.start as u32, ctx);
 
         const_assert!(mem::size_of::<LogHeader>() <= BSIZE);
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<LogHeader>() == 0);
@@ -230,52 +231,52 @@ impl LogLocked<'_> {
         for (db, b) in izip!(&mut lh.block, &self.bufs) {
             *db = b.blockno;
         }
-        self.disk.write(&mut buf)
+        self.disk.write(&mut buf, ctx)
     }
 
-    fn recover_from_log(&mut self) {
-        self.read_head();
+    fn recover_from_log(&mut self, ctx: &KernelCtx<'_, '_>) {
+        self.read_head(ctx);
 
         // If committed, copy from log to disk.
-        self.install_trans();
+        self.install_trans(ctx);
 
         // Clear the log.
-        self.write_head();
+        self.write_head(ctx);
     }
 
     /// Copy modified blocks from cache to self.
-    fn write_log(&mut self) {
+    fn write_log(&mut self, ctx: &KernelCtx<'_, '_>) {
         for (tail, from) in self.bufs.iter().enumerate() {
             // Log block.
             let mut to = self
                 .disk
-                .read(self.dev, (self.start + tail as i32 + 1) as u32);
+                .read(self.dev, (self.start + tail as i32 + 1) as u32, ctx);
 
             // Cache block.
-            let from = self.disk.read(self.dev, from.blockno);
+            let from = self.disk.read(self.dev, from.blockno, ctx);
 
             to.deref_inner_mut()
                 .data
                 .copy_from_slice(&from.deref_inner().data[..]);
 
             // Write the log.
-            self.disk.write(&mut to);
+            self.disk.write(&mut to, ctx);
         }
     }
 
-    fn commit(&mut self) {
+    fn commit(&mut self, ctx: &KernelCtx<'_, '_>) {
         if !self.bufs.is_empty() {
             // Write modified blocks from cache to self.
-            self.write_log();
+            self.write_log(ctx);
 
             // Write header to disk -- the real commit.
-            self.write_head();
+            self.write_head(ctx);
 
             // Now install writes to home locations.
-            self.install_trans();
+            self.install_trans(ctx);
 
             // Erase the transaction from the self.
-            self.write_head();
+            self.write_head(ctx);
         };
     }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -1222,7 +1222,7 @@ unsafe fn forkret() {
             // File system initialization must be run in the context of a
             // regular process (e.g., because it calls sleep), and thus cannot
             // be run from main().
-            ctx.kernel.file_system.init(ROOTDEV);
+            ctx.kernel.file_system.init(ROOTDEV, &ctx);
             ctx.user_trap_ret();
         })
     }


### PR DESCRIPTION
`kernel` (또는 그 variant들) 전역 함수 호출을 일부 없애는 PR입니다.

## 수정 내용

* `Disk`의 메서드들이 `&Bcache`나 `CurrentProc`을 필요로 하므로 `&KernelCtx`를 인자로 받도록 했습니다.
* `FsTransaction`, `Log`의 메서드들이 `Disk::read,write`을 호출하거나 `&Bcache`를 필요로 하므로 `&KernelCtx`를 인자로 받도록 했습니다.
* `inode.rs`의 메서드들이 `Disk`/`FsTransaction`의 메서드를 호출하거나 `&Itable`/`&FileSystem`을 필요로 하므로 `&KernelCtx`를 인자로 받도록 했습니다.

## 논의할 만한 내용

* 일부 메서드는 `KernelCtx`의 메서드가 되어야 할 수도 있는데, 일단 그런 고민은 하지 않고 `&KernelCtx`를 인자로 받도록 일괄적으로 수정했습니다.
* `InodeGuard`의 `read_internal`이 없어지고 `read_kernel`과 `read_user`에 코드 중복이 다소 생겼습니다. `read_kernel`은 유저 메모리에 접근하지 않으므로 `&KernelCtx`로 충분하지만, `read_user`는 유저 메모리에 접근하기 때문에 `&mut CurrentProc`이 필요하므로 `&mut KernelCtx`가 필요합니다. 이전처럼 공통 부분을 `read_internal`로 정의하려면 `read_internal`이 `&mut KernelCtx`를 받아야 하고, 그러면 `read_kernel`에서도 `&mut KernelCtx`를 요구하게 되며, `read_kernel`을 호출하는 모든 메서드가 `&mut KernelCtx`를 요구하게 됩니다. 이를 막고자 약간의 코드 중복을 감수하고 `read_internal`을 없앴습니다. 비슷하게, `write_internal`이 없어지고 `write_kernel`과 `write_user`에 코드 중복이 생겼습니다.