### PR TITLE
[Closes #298] Uart & Console refactoring

### DIFF
--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -52,6 +52,7 @@
 #![feature(maybe_uninit_extra)]
 #![feature(maybe_uninit_ref)]
 #![feature(variant_count)]
+#![feature(const_mut_refs)]
 
 mod arch;
 mod arena;

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -234,7 +234,8 @@ impl KernelRef<'_, '_> {
             let irq = unsafe { plic_claim() };
 
             if irq as usize == UART0_IRQ {
-                self.uart.intr(self);
+                // SAFETY: it's unsafe only when ctrl+p is pressed.
+                unsafe { self.console.intr(self) };
             } else if irq as usize == VIRTIO0_IRQ {
                 self.file_system.log.disk.lock().intr(self);
             } else if irq != 0 {

--- a/kernel-rs/src/uart.rs
+++ b/kernel-rs/src/uart.rs
@@ -5,13 +5,6 @@
 use core::ptr;
 
 use self::UartCtrlRegs::{FCR, IER, ISR, LCR, LSR, RBR, THR};
-use crate::arch::memlayout::UART0;
-use crate::{
-    console::consoleintr,
-    kernel::{kernel_builder, kernel_ref, KernelRef},
-    lock::{pop_off, push_off, Sleepablelock, SleepablelockGuard},
-    util::spin_loop,
-};
 
 const UART_TX_BUF_SIZE: usize = 32;
 
@@ -68,191 +61,107 @@ enum UartCtrlRegs {
 
 impl UartCtrlRegs {
     /// The UART control registers are memory-mapped
-    /// at address UART0. This macro returns the
+    /// at address uart. This macro returns the
     /// address of one of the registers.
-    fn reg(self) -> *mut u8 {
+    fn addr(self, uart: usize) -> *mut u8 {
         match self {
-            THR | RBR => UART0 as *mut u8,
-            IER => (UART0 + 1) as *mut u8,
-            FCR | ISR => (UART0 + 2) as *mut u8,
-            LCR => (UART0 + 3) as *mut u8,
-            LSR => (UART0 + 5) as *mut u8,
+            THR | RBR => uart as *mut u8,
+            IER => (uart + 1) as *mut u8,
+            FCR | ISR => (uart + 2) as *mut u8,
+            LCR => (uart + 3) as *mut u8,
+            LSR => (uart + 5) as *mut u8,
         }
     }
-
-    fn read(self) -> u8 {
-        unsafe { ptr::read_volatile(self.reg()) }
-    }
-
-    fn write(self, v: u8) {
-        unsafe { ptr::write_volatile(self.reg(), v) }
-    }
 }
 
-pub struct UartTX {
-    pub buf: [u8; UART_TX_BUF_SIZE],
+struct UartTX {
+    buf: [u8; UART_TX_BUF_SIZE],
 
     /// Write next to uart_tx_buf[uart_tx_w % UART_TX_BUF_SIZE]
-    pub w: u64,
+    w: u64,
 
     /// Read next from uart_tx_buf[uar_tx_r % UART_TX_BUF_SIZE]
-    pub r: u64,
+    r: u64,
 }
 
+/// # Safety
+///
+/// uart..(uart + 5) are owned addresses.
 pub struct Uart {
-    pub tx_lock: Sleepablelock<UartTX>,
+    uart: usize,
 }
 
 impl Uart {
-    pub const fn new() -> Self {
-        Self {
-            tx_lock: Sleepablelock::new(
-                "uart",
-                UartTX {
-                    buf: [0; UART_TX_BUF_SIZE],
-                    w: 0,
-                    r: 0,
-                },
-            ),
-        }
+    /// # Safety
+    ///
+    /// uart..(uart + 5) are owned addresses.
+    pub const unsafe fn new(uart: usize) -> Self {
+        Self { uart }
     }
 
-    pub fn init() {
+    pub fn init(&self) {
         // Disable interrupts.
-        IER.write(0x00);
+        self.write(IER, 0x00);
 
         // Special mode to set baud rate.
-        LCR.write(UartRegBits::LCRBaudLatch.bits());
+        self.write(LCR, UartRegBits::LCRBaudLatch.bits());
 
         // LSB for baud rate of 38.4K.
-        RBR.write(0x03);
+        self.write(RBR, 0x03);
 
         // MSB for baud rate of 38.4K.
-        IER.write(0x00);
+        self.write(IER, 0x00);
 
         // Leave set-baud mode,
         // and set word length to 8 bits, no parity.
-        LCR.write(UartRegBits::LCREightBits.bits());
+        self.write(LCR, UartRegBits::LCREightBits.bits());
 
         // Reset and enable FIFOs.
-        FCR.write(UartRegBits::FCRFifoEnable.bits() | UartRegBits::FCRFifoClear.bits());
+        self.write(
+            FCR,
+            UartRegBits::FCRFifoEnable.bits() | UartRegBits::FCRFifoClear.bits(),
+        );
 
         // Enable transmit and receive interrupts.
-        IER.write(UartRegBits::IERTxEnable.bits() | UartRegBits::IERRxEnable.bits());
+        self.write(
+            IER,
+            UartRegBits::IERTxEnable.bits() | UartRegBits::IERRxEnable.bits(),
+        );
     }
 
-    /// Add a character to the output buffer and tell the
-    /// UART to start sending if it isn't already.
-    /// Blocks if the output buffer is full.
-    /// Since it may block, it can't be called
-    /// from interrupts; it's only suitable for use
-    /// by write().
-    pub fn putc(&self, c: i32) {
-        let mut guard = self.tx_lock.lock();
-        // TODO: remove kernel_builder()
-        if kernel_builder().is_panicked() {
-            spin_loop();
-        }
-        loop {
-            if guard.w == guard.r + UART_TX_BUF_SIZE as u64 {
-                // Buffer is full.
-                // Wait for uartstart() to open up space in the buffer.
-                guard.sleep();
-            } else {
-                let w = guard.w;
-                guard.buf[w as usize % UART_TX_BUF_SIZE] = c as u8;
-                guard.w += 1;
-                self.start(guard);
-                return;
-            }
-        }
-    }
-
-    /// Alternate version of uartputc() that doesn't
-    /// use interrupts, for use by kernel printf() and
-    /// to echo characters. It spins waiting for the uart's
-    /// output register to be empty.
-    pub fn putc_sync(c: i32) {
-        unsafe {
-            push_off();
-        }
-        // TODO: remove kernel_builder()
-        if kernel_builder().is_panicked() {
-            spin_loop();
-        }
-
-        // Wait for Transmit Holding Empty to be set in LSR.
-        while LSR.read() & UartRegBits::LSRTxIdle.bits() == 0 {}
-
-        THR.write(c as u8);
-
-        unsafe {
-            pop_off();
-        }
-    }
-
-    /// If the UART is idle, and a character is waiting
-    /// in the transmit buffer, send it.
-    /// Caller must hold uart_tx_lock.
-    /// Called from both the top- and bottom-half.
-    fn start(&self, mut guard: SleepablelockGuard<'_, UartTX>) {
-        loop {
-            if guard.w == guard.r {
-                // Transmit buffer is empty.
-                return;
-            }
-
-            if (LSR.read() & UartRegBits::LSRTxIdle.bits()) == 0 {
-                // The UART transmit holding register is full,
-                // so we cannot give it another byte.
-                // It will interrupt when it's ready for a new byte.
-                return;
-            }
-
-            let c = guard.buf[guard.r as usize % UART_TX_BUF_SIZE];
-            guard.r += 1;
-
-            // Maybe uartputc() is waiting for space in the buffer.
-            unsafe {
-                // TODO: remove kernel_ref()
-                kernel_ref(|kref| {
-                    guard.wakeup(kref);
-                })
-            };
-
-            THR.write(c);
-        }
-    }
-
-    /// Read one input character from the UART.
-    /// Return -1 if none is waiting.
-    /// TODO(https://github.com/kaist-cp/rv6/issues/361)
-    /// should get &self - need to refactor when encapsulate Uart into Console.
-    fn getc() -> i32 {
-        if LSR.read() & 0x01 != 0 {
+    /// Read one input character from the UART. Return Err(()) if none is waiting.
+    pub fn getc(&self) -> Result<i32, ()> {
+        if self.read(LSR) & 0x01 != 0 {
             // Input data is ready.
-            RBR.read() as i32
+            Ok(self.read(RBR) as i32)
         } else {
-            -1
+            Err(())
         }
     }
 
-    /// Handle a uart interrupt, raised because input has
-    /// arrived, or the uart is ready for more output, or
-    /// both. Called from trap.c.
-    pub fn intr(&self, kernel: KernelRef<'_, '_>) {
-        // Read and process incoming characters.
-        loop {
-            let c = Uart::getc();
-            if c == -1 {
-                break;
-            }
-            unsafe {
-                consoleintr(c, kernel);
-            }
-        }
+    /// Write one output character to the UART.
+    pub fn putc(&self, c: u8) {
+        self.write(THR, c);
+    }
 
-        // Send buffered characters.
-        self.start(self.tx_lock.lock());
+    /// Check whether the UART transmit holding register is full.
+    pub fn is_full(&self) -> bool {
+        (self.read(LSR) & UartRegBits::LSRTxIdle.bits()) == 0
+    }
+
+    fn read(&self, reg: UartCtrlRegs) -> u8 {
+        // SAFETY:
+        // * the address is valid because of the invariant of self.
+        // * volatile concurrent accesses are safe.
+        //   (https://github.com/kaist-cp/rv6/issues/188#issuecomment-683548362)
+        unsafe { ptr::read_volatile(reg.addr(self.uart)) }
+    }
+
+    fn write(&self, reg: UartCtrlRegs, v: u8) {
+        // SAFETY:
+        // * the address is valid because of the invariant of self.
+        // * volatile concurrent accesses are safe.
+        //   (https://github.com/kaist-cp/rv6/issues/188#issuecomment-683548362)
+        unsafe { ptr::write_volatile(reg.addr(self.uart), v) }
     }
 }


### PR DESCRIPTION
`Uart`와 `Console`을 리팩토링하는 PR입니다.

* `Uart`와 `Console`이 상호 의존적이기 때문에 어느 한쪽이 다른 하나를 소유한다고 보기 어려운 것 같아, 구조는 그대로 두고 대부분의 메서드가 `KernelRef`나 `KernelCtx`를 받도록 만들었습니다.
* `Uart`가 MMIO 레지스터를 소유하는 개념을 명확히 했습니다. 여러 `Uart`가 동시에 존재할 수 있으므로, `Uart`는 만들어질 때 MMIO 레지스터의 위치를 인자로 받습니다.