### PR TITLE
usertrapret never returns

### DIFF
--- a/kernel-rs/Cargo.lock
+++ b/kernel-rs/Cargo.lock
@@ -104,18 +104,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1.2.1"
 cstr_core = { version = "0.2.3", default-features = false }
 itertools = { version = "0.10.0", default-features = false }
 num-iter = { version = "0.1.42", default-features = false }
-pin-project = "1.0.6"
+pin-project = "1.0.7"
 scopeguard = { version = "1.1.0", default-features = false }
 spin = "0.9.0"
 static_assertions = "1.1.0"

--- a/kernel-rs/src/lock/spinlock.rs
+++ b/kernel-rs/src/lock/spinlock.rs
@@ -1,6 +1,5 @@
 //! Spin locks
 use core::cell::UnsafeCell;
-use core::hint::spin_loop;
 use core::ptr;
 use core::sync::atomic::{AtomicPtr, Ordering};
 
@@ -81,7 +80,7 @@ impl RawLock for RawSpinlock {
             )
             .is_err()
         {
-            spin_loop();
+            ::core::hint::spin_loop();
         }
     }
 

--- a/kernel-rs/src/proc.rs
+++ b/kernel-rs/src/proc.rs
@@ -626,7 +626,7 @@ impl Context {
 }
 
 impl Procstate {
-    fn to_str(&self) -> &'static str {
+    fn as_str(&self) -> &'static str {
         match self {
             Procstate::USED => "used",
             Procstate::UNUSED => "unused",
@@ -1168,7 +1168,7 @@ impl Procs {
                 println!(
                     "{} {} {}",
                     unsafe { (*info).pid },
-                    Procstate::to_str(state),
+                    Procstate::as_str(state),
                     str::from_utf8(&name[0..length]).unwrap_or("???")
                 );
             }
@@ -1261,7 +1261,7 @@ impl<'id, 's> KernelRef<'id, 's> {
 }
 
 /// A fork child's very first scheduling by scheduler() will swtch to forkret.
-unsafe fn forkret() {
+unsafe fn forkret() -> ! {
     unsafe {
         kernel_ctx(|ctx| {
             // Still holding p->lock from scheduler.
@@ -1270,7 +1270,7 @@ unsafe fn forkret() {
             // regular process (e.g., because it calls sleep), and thus cannot
             // be run from main().
             ctx.kernel.file_system.init(ROOTDEV, &ctx);
-            ctx.user_trap_ret();
+            ctx.user_trap_ret()
         })
     }
 }

--- a/kernel-rs/src/start.rs
+++ b/kernel-rs/src/start.rs
@@ -4,7 +4,7 @@ use crate::{
         r_mhartid, w_medeleg, w_mepc, w_mideleg, w_mscratch, w_mtvec, w_satp, w_tp, Mstatus, MIE,
         SIE,
     },
-    kernel::kernel_main,
+    kernel::main,
     param::NCPU,
 };
 
@@ -39,7 +39,7 @@ pub unsafe fn start() {
     unsafe { x.write() };
 
     // set M Exception Program Counter to main, for mret.  requires gcc -mcmodel=medany
-    unsafe { w_mepc(kernel_main as usize) };
+    unsafe { w_mepc(main as usize) };
 
     // disable paging for now.
     unsafe { w_satp(0) };


### PR DESCRIPTION
Closes #440 

- `usertrapret() -> !`이 절대 return하지 않음을 표현함으로써 #440 을 해결하였습니다.
- usertrap/forkret/usertrapret의 관계를 더 깊이 표현하려면 (1) `UserTrapRet` 타입을 `!`을 감싸서 새로 만들고, (2) 앞 3개 함수들이 모두 `UserTrapRet`을 리턴하도록 하는 수도 있겠습니다.... 만 여기까지는 안하는게 더 readability가 높을 것 같습니다.