### PR TITLE
[Closes #494] Make `RemoteLock` zero cost

### DIFF
--- a/kernel-rs/src/lock/remotelock.rs
+++ b/kernel-rs/src/lock/remotelock.rs
@@ -1,19 +1,23 @@
-use core::{cell::UnsafeCell, pin::Pin, ptr};
+use core::{cell::UnsafeCell, marker::PhantomData, pin::Pin};
 
 use super::{Guard, Lock, RawLock};
 
 /// `RemoteLock<'s, R, U, T>`, such as `RemoteLock<'s, RawSpinlock, U, T>`.
+///
 /// Similar to `Lock<R, T>`, but uses a shared raw lock.
-/// At creation, a `RemoteLock` borrows a raw lock from a `Lock` and uses it to protect its data.
+/// * At creation, a `RemoteLock` borrows a raw lock from a `Lock`.
+/// * To access its inner data, you must use that `Lock`'s guard.
+///
 /// In this way, we can make a single raw lock be shared by a `Lock` and multiple `RemoteLock`s.
 /// * See the [lock](`super`) module documentation for details.
 ///
 /// # Note
 ///
-/// To dereference the inner data, you must use `RemoteLock::get_mut`.
+/// To dereference the inner data, you must use `RemoteLock::get_pin_mut_unchecked`
+/// or `RemoteLock::get_mut_unchecked`.
 pub struct RemoteLock<'s, R: RawLock, U, T> {
-    lock: &'s Lock<R, U>,
     data: UnsafeCell<T>,
+    _marker: PhantomData<&'s Lock<R, U>>,
 }
 
 unsafe impl<'s, R: RawLock, U: Send, T: Send> Sync for RemoteLock<'s, R, U, T> {}
@@ -28,23 +32,11 @@ impl<'s, R: RawLock, U, T> RemoteLock<'s, R, U, T> {
     /// let spinlock: Spinlock<usize> = Spinlock::new("spinlock", 10);
     /// let spinlock_remote: RemoteLock<'_, RawSpinlock, usize, isize> = RemoteLock::new(&spinlock, -20);
     /// ```
-    pub const fn new(lock: &'s Lock<R, U>, data: T) -> Self {
+    pub const fn new(_lock: &'s Lock<R, U>, data: T) -> Self {
         Self {
-            lock,
             data: UnsafeCell::new(data),
+            _marker: PhantomData,
         }
-    }
-
-    /// Acquires the lock and returns the `Guard`.
-    /// * To access `self`'s inner data, use `RemoteLock::get_pin_mut` with the returned guard.
-    /// * To access the borrowed `Lock`'s data, just dereference the returned guard.
-    pub fn lock(&self) -> Guard<'_, R, U> {
-        self.lock.lock()
-    }
-
-    /// Returns a reference to the `Lock` that `self` borrowed from.
-    pub fn get_lock(&self) -> &'s Lock<R, U> {
-        self.lock
     }
 
     /// Returns a raw pointer to the inner data.
@@ -55,29 +47,31 @@ impl<'s, R: RawLock, U, T> RemoteLock<'s, R, U, T> {
         self.data.get()
     }
 
-    /// Returns a pinned mutable reference to the inner data, provided that the given
-    /// `guard` was obtained by `lock()`ing `self` or `self`'s corresponding `Lock`.
-    /// Otherwise, panics.
+    /// Returns a pinned mutable reference to the inner data.
     ///
-    /// # Note
+    /// # Safety
     ///
-    /// In order to prevent references from leaking, the returned reference
-    /// cannot outlive the given `guard`.
-    ///
-    /// This method adds some small runtime cost, since we need to check that the given
-    /// `Guard` was truely obtained by `lock()`ing `self` or `self`'s corresponding `Lock`.
-    /// TODO(https://github.com/kaist-cp/rv6/issues/375)
-    /// This runtime cost can be removed by using a trait, such as `pub trait LockID {}`.
-    pub fn get_pin_mut<'a: 'b, 'b>(&'a self, guard: &'b mut Guard<'_, R, U>) -> Pin<&'b mut T> {
-        assert!(ptr::eq(self.lock, guard.lock));
+    /// The provided `guard` must be from the `Lock` that this `RemoteLock` borrowed from.
+    /// You may want to wrap this function with a safe function that uses branded types.
+    pub unsafe fn get_pin_mut_unchecked<'a: 'b, 'b>(
+        &'a self,
+        _guard: &'b mut Guard<'_, R, U>,
+    ) -> Pin<&'b mut T> {
         unsafe { Pin::new_unchecked(&mut *self.data.get()) }
     }
 }
 
 impl<'s, R: RawLock, U, T: Unpin> RemoteLock<'s, R, U, T> {
     /// Returns a mutable reference to the inner data.
-    /// See `RemoteLock::get_pin_mut()` for details.
-    pub fn get_mut<'a: 'b, 'b>(&'a self, guard: &'b mut Guard<'_, R, U>) -> &'b mut T {
-        self.get_pin_mut(guard).get_mut()
+    ///
+    /// # Safety
+    ///
+    /// The provided `guard` must be from the `Lock` that this `RemoteLock` borrowed from.
+    /// You may want to wrap this function with a safe function that uses branded types.
+    pub unsafe fn get_mut_unchecked<'a: 'b, 'b>(
+        &'a self,
+        guard: &'b mut Guard<'_, R, U>,
+    ) -> &'b mut T {
+        unsafe { self.get_pin_mut_unchecked(guard) }.get_mut()
     }
 }

--- a/kernel-rs/src/lock/remotelock.rs
+++ b/kernel-rs/src/lock/remotelock.rs
@@ -53,10 +53,10 @@ impl<'s, R: RawLock, U, T> RemoteLock<'s, R, U, T> {
     ///
     /// The provided `guard` must be from the `Lock` that this `RemoteLock` borrowed from.
     /// You may want to wrap this function with a safe function that uses branded types.
-    pub unsafe fn get_pin_mut_unchecked<'a: 'b, 'b>(
-        &'a self,
-        _guard: &'b mut Guard<'_, R, U>,
-    ) -> Pin<&'b mut T> {
+    pub unsafe fn get_pin_mut_unchecked<'t>(
+        &'t self,
+        _guard: &'t mut Guard<'_, R, U>,
+    ) -> Pin<&'t mut T> {
         unsafe { Pin::new_unchecked(&mut *self.data.get()) }
     }
 }
@@ -68,10 +68,7 @@ impl<'s, R: RawLock, U, T: Unpin> RemoteLock<'s, R, U, T> {
     ///
     /// The provided `guard` must be from the `Lock` that this `RemoteLock` borrowed from.
     /// You may want to wrap this function with a safe function that uses branded types.
-    pub unsafe fn get_mut_unchecked<'a: 'b, 'b>(
-        &'a self,
-        guard: &'b mut Guard<'_, R, U>,
-    ) -> &'b mut T {
+    pub unsafe fn get_mut_unchecked<'t>(&'t self, guard: &'t mut Guard<'_, R, U>) -> &'t mut T {
         unsafe { self.get_pin_mut_unchecked(guard) }.get_mut()
     }
 }


### PR DESCRIPTION
Closes #494 

`RemoteLock`에는 다음과 같은 runtime cost가 있습니다.
* `&Lock`을 저장하기 위해, 추가적인 memory를 차지합니다.
* `RemoteLock::get_pin_mut`을 할때 `assert!`을 사용합니다.

`Branded`를 활용해서, 이러한 runtime cost를 safe하게 없애야합니다.

# Changes
* `RemoteLock`의 runtime cost를 모두 없앴습니다.
* 새로운 `RemoteLock`을 "src/proc.rs"에 적용하기 위해, "src/proc.rs"`를 다음과 같이 변경했습니다.
  * `ProcsRef::wait_guard`를 사용하면, `WaitGuard<'id, 's>`를 얻습니다. (`wait_lock`의 guard)
  * `ProcRef::get_mut_parent`에 `WaitGuard`를 넣으면, `Proc::parent` field를 mutably dereference할 수 있습니다.
    * 단, 당연하지만 `ProcRef`와 `WaitGuard`의 `'id`가 동일해야합니다.
  * 추가로, 다음과 같이 바꾸었습니다.
    * `ProcGuard<'s>` -> `ProcGuard<'id, 's>`
    * `ProcIter<'s>` -> `ProcIter<'id, 's>`
    * `&Procs` 대신 `ProcsRef`를 사용하도록 상당 부분을 변경했습니다.
    * `&Proc` 대신 `ProcRef`를 사용하도록 상당 부분을 변경했습니다.
    * `ProcsMut`를 추가했습니다. 실제로 사용되는 곳은 `ProcsMut::user_proc_init` 한곳 뿐입니다.
