### PR TITLE
[Closes #478] Separate Cpu from Kernel

### DIFF
--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -11,9 +11,10 @@ use core::fmt;
 
 use crate::{
     arch::addr::UVAddr,
+    cpu::CPUS,
     file::Devsw,
     kernel::{kernel_builder, KernelBuilder, KernelRef},
-    lock::{pop_off, push_off, Sleepablelock, SleepablelockGuard},
+    lock::{Sleepablelock, SleepablelockGuard},
     param::NDEV,
     proc::KernelCtx,
     uart::Uart,
@@ -96,7 +97,7 @@ impl Console {
     /// It spins waiting for the uart's output register to be empty.
     fn putc_spin(&self, c: u8, kernel: &KernelBuilder) {
         unsafe {
-            push_off();
+            CPUS.push_off();
         }
         if kernel.is_panicked() {
             spin_loop();
@@ -108,7 +109,7 @@ impl Console {
         self.uart.putc(c);
 
         unsafe {
-            pop_off();
+            CPUS.pop_off();
         }
     }
 

--- a/kernel-rs/src/cpu.rs
+++ b/kernel-rs/src/cpu.rs
@@ -1,0 +1,114 @@
+use core::{cell::UnsafeCell, ptr};
+
+use array_macro::array;
+
+use crate::{
+    arch::riscv::r_tp,
+    arch::riscv::{intr_get, intr_off, intr_on},
+    param::NCPU,
+    proc::{Context, Proc},
+};
+
+pub static CPUS: Cpus = Cpus::new();
+
+// The `Cpu` struct of the current cpu can be mutated. To do so, we need to
+// obtain mutable pointers to `Cpu`s from a shared reference of a `Cpus`.
+// It requires interior mutability, so we use `UnsafeCell`.
+pub struct Cpus([UnsafeCell<Cpu>; NCPU]);
+
+// SAFETY: each thread access the cpu struct of the cpu on which it's running.
+unsafe impl Sync for Cpus {}
+
+impl Cpus {
+    const fn new() -> Self {
+        Self(array![_ => UnsafeCell::new(Cpu::new()); NCPU])
+    }
+}
+
+impl Cpus {
+    /// Return this CPU's cpu struct.
+    ///
+    /// It is safe to call this function with interrupts enabled, but returned address may not be the
+    /// current CPU since the scheduler can move the process to another CPU on time interrupt.
+    pub fn current(&self) -> *mut Cpu {
+        let id: usize = cpuid();
+        self.0[id].get()
+    }
+
+    /// push_off/pop_off are like intr_off()/intr_on() except that they are matched:
+    /// it takes two pop_off()s to undo two push_off()s. Also, if interrupts
+    /// are initially off, then push_off, pop_off leaves them off.
+    pub unsafe fn push_off(&self) {
+        let old = intr_get();
+        unsafe { intr_off() };
+        unsafe { (*self.current()).push_off(old) };
+    }
+
+    /// pop_off() should be paired with push_off().
+    /// See push_off() for more details.
+    pub unsafe fn pop_off(&self) {
+        assert!(!intr_get(), "pop_off - interruptible");
+        unsafe { (*self.current()).pop_off() };
+    }
+}
+
+/// Per-CPU-state.
+pub struct Cpu {
+    /// The process running on this cpu, or null.
+    pub proc: *const Proc,
+
+    /// swtch() here to enter scheduler().
+    pub context: Context,
+
+    /// Depth of push_off() nesting.
+    noff: i32,
+
+    /// Were interrupts enabled before push_off()?
+    interrupt_enabled: bool,
+}
+
+impl Cpu {
+    const fn new() -> Self {
+        Self {
+            proc: ptr::null_mut(),
+            context: Context::new(),
+            noff: 0,
+            interrupt_enabled: false,
+        }
+    }
+
+    unsafe fn push_off(&mut self, old: bool) {
+        if self.noff == 0 {
+            self.interrupt_enabled = old;
+        }
+        self.noff += 1;
+    }
+
+    unsafe fn pop_off(&mut self) {
+        assert!(self.noff >= 1, "pop_off");
+        self.noff -= 1;
+        if self.noff == 0 && self.interrupt_enabled {
+            unsafe { intr_on() };
+        }
+    }
+
+    pub fn noff(&self) -> i32 {
+        self.noff
+    }
+
+    pub fn get_interrupt(&self) -> bool {
+        self.interrupt_enabled
+    }
+
+    pub fn set_interrupt(&mut self, interrupt: bool) {
+        self.interrupt_enabled = interrupt;
+    }
+}
+
+/// Return this CPU's ID.
+///
+/// It is safe to call this function with interrupts enabled, but the returned id may not be the
+/// current CPU since the scheduler can move the process to another CPU on time interrupt.
+pub fn cpuid() -> usize {
+    r_tp()
+}

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -58,6 +58,7 @@ mod arch;
 mod arena;
 mod bio;
 mod console;
+mod cpu;
 mod exec;
 mod file;
 mod fs;

--- a/kernel-rs/src/lock/mod.rs
+++ b/kernel-rs/src/lock/mod.rs
@@ -46,7 +46,7 @@ mod spinlock;
 pub use remotelock::RemoteLock;
 pub use sleepablelock::{Sleepablelock, SleepablelockGuard};
 pub use sleeplock::{Sleeplock, SleeplockGuard};
-pub use spinlock::{pop_off, push_off, RawSpinlock, Spinlock, SpinlockGuard};
+pub use spinlock::{RawSpinlock, Spinlock, SpinlockGuard};
 
 pub trait RawLock {
     /// Acquires the lock.

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -8,9 +8,10 @@ use crate::{
         intr_get, intr_off, intr_on, r_satp, r_scause, r_sepc, r_sip, r_stval, r_tp, w_sepc, w_sip,
         w_stvec, Sstatus,
     },
+    cpu::cpuid,
     kernel::{kernel_ref, KernelRef},
     ok_or, println,
-    proc::{cpuid, kernel_ctx, KernelCtx, Procstate},
+    proc::{kernel_ctx, KernelCtx, Procstate},
 };
 
 extern "C" {


### PR DESCRIPTION
* `cpu` 모듈을 추가했습니다.
* `Cpu`의 정의를 `proc` 모듈에서 `cpu` 모듈로 옮겼습니다.
* `cpu` 모듈에 `Cpus` 타입과 `CPUS` static variable을 추가하고 `Kernel`의  `cpus` 필드는 없앴습니다.

`HeldInterrupts` 등을 추가해 interrrupt를 다루는 것은 이 PR에서 하지 않고, 추후에 하겠습니다.