### PR TITLE
Remove println! macro

### DIFF
--- a/kernel-rs/src/hal.rs
+++ b/kernel-rs/src/hal.rs
@@ -8,7 +8,6 @@ use crate::{
     cpu::Cpus,
     kalloc::Kmem,
     lock::Spinlock,
-    println,
 };
 
 static mut HAL: Hal = Hal::new();
@@ -40,7 +39,7 @@ pub struct Hal {
     /// Sleeps waiting for there are some input in console buffer.
     pub console: Console,
 
-    pub printer: Spinlock<Printer>,
+    pub printer: Printer,
 
     #[pin]
     pub kmem: Spinlock<Kmem>,
@@ -52,7 +51,7 @@ impl Hal {
     const fn new() -> Self {
         Self {
             console: unsafe { Console::new(UART0) },
-            printer: Spinlock::new("PRINTLN", Printer::new()),
+            printer: Printer::new(),
             kmem: Spinlock::new("KMEM", unsafe { Kmem::new() }),
             cpus: Cpus::new(),
         }
@@ -68,10 +67,6 @@ impl Hal {
 
         // Console.
         this.console.init();
-
-        println!();
-        println!("rv6 kernel is booting");
-        println!();
 
         // Physical page allocator.
         unsafe { this.kmem.as_mut().get_pin_mut().init() };

--- a/kernel-rs/src/syscall.rs
+++ b/kernel-rs/src/syscall.rs
@@ -20,7 +20,6 @@ use crate::{
     ok_or,
     page::Page,
     param::{MAXARG, MAXPATH},
-    println,
     proc::{CurrentProc, KernelCtx},
     some_or,
 };
@@ -123,12 +122,12 @@ impl KernelCtx<'_, '_> {
             21 => self.sys_close(),
             22 => self.sys_poweroff(),
             _ => {
-                println!(
+                self.kernel().write_fmt(format_args!(
                     "{} {}: unknown sys call {}",
                     self.proc().pid(),
                     str::from_utf8(&self.proc().deref_data().name).unwrap_or("???"),
                     num
-                );
+                ));
                 Err(())
             }
         }

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -12,7 +12,7 @@ use crate::{
     fs::FileSystem,
     hal::hal,
     kernel::{kernel_ref, KernelRef},
-    ok_or, println,
+    ok_or,
     proc::{kernel_ctx, KernelCtx, Procstate},
 };
 
@@ -88,16 +88,16 @@ impl KernelCtx<'_, '_> {
         } else {
             which_dev = unsafe { self.kernel().dev_intr() };
             if which_dev == 0 {
-                println!(
-                    "usertrap(): unexpected scause {:018p} pid={}",
+                self.kernel().write_fmt(format_args!(
+                    "usertrap(): unexpected scause {:018p} pid={}\n",
                     r_scause() as *const u8,
                     self.proc().pid()
-                );
-                println!(
-                    "            sepc={:018p} stval={:018p}",
+                ));
+                self.kernel().write_fmt(format_args!(
+                    "            sepc={:018p} stval={:018p}\n",
                     r_sepc() as *const u8,
                     r_stval() as *const u8
-                );
+                ));
                 self.proc().kill();
             }
         }
@@ -188,12 +188,12 @@ impl KernelRef<'_, '_> {
 
         let which_dev = unsafe { self.dev_intr() };
         if which_dev == 0 {
-            println!("scause {:018p}", scause as *const u8);
-            println!(
-                "sepc={:018p} stval={:018p}",
+            self.write_fmt(format_args!("scause {:018p}\n", scause as *const u8));
+            self.write_fmt(format_args!(
+                "sepc={:018p} stval={:018p}\n",
                 r_sepc() as *const u8,
                 r_stval() as *const u8
-            );
+            ));
             panic!("kerneltrap");
         }
 


### PR DESCRIPTION
커널이 콘솔에 출력할 때는 `&KernelBuilder`가 필요합니다. 이를 명시적으로 드러낼 수 있도록 `println!` 매크로를 없애고 `KernelBuilder::write_fmt` 메서드를 사용하게 바꾸었습니다.