### PR TITLE
Remove `kernel_ctx` in `UfsTx::drop`

### DIFF
--- a/kernel-rs/src/lock/sleeplock.rs
+++ b/kernel-rs/src/lock/sleeplock.rs
@@ -36,6 +36,7 @@ impl RawLock for RawSleeplock {
     fn release(&self) {
         let mut guard = self.inner.lock();
         *guard = -1;
+        // TODO(https://github.com/kaist-cp/rv6/issues/267): remove kernel_ref()
         unsafe { kernel_ref(|kref| guard.wakeup(kref)) };
     }
 

--- a/kernel-rs/src/proc/procs.rs
+++ b/kernel-rs/src/proc/procs.rs
@@ -427,12 +427,11 @@ impl<'id, 's> ProcsRef<'id, 's> {
         // If self.cwd is not None, the inode inside self.cwd will be dropped
         // by assigning None to self.cwd. Deallocation of an inode may cause
         // disk write operations, so we must begin a transaction here.
-        let kernel = ctx.kernel();
-        let tx = kernel.fs().begin_tx();
+        let tx = ctx.kernel().fs().begin_tx();
         // SAFETY: CurrentProc's cwd has been initialized.
         // It's ok to drop cwd as proc will not be used any longer.
         unsafe { ctx.proc_mut().deref_mut_data().cwd.assume_init_drop() };
-        drop(tx);
+        tx.end(ctx);
 
         // Give all children to init.
         let mut parent_guard = self.wait_guard();


### PR DESCRIPTION
`UfsTx::drop`의 `kernel_ctx` 호출을 없애기 위해 `UfsTx`가 드롭되면 패닉하도록 만들고 `UfsTx`와 `KernelCtx`를 받아 `end_op`를 호출하는 `UfsTx::end` 메서드를 추가했습니다.