### PR TITLE
Closes #483

### DIFF
--- a/kernel-rs/src/arch/riscv.rs
+++ b/kernel-rs/src/arch/riscv.rs
@@ -354,9 +354,10 @@ pub unsafe fn intr_on() {
 
 /// Disable device interrupts.
 #[inline]
-pub unsafe fn intr_off() {
+pub fn intr_off() {
     let mut x = Sstatus::read();
     x.remove(Sstatus::SIE);
+    // SAFETY: turning interrupt off is safe.
     unsafe { x.write() };
 }
 

--- a/kernel-rs/src/console.rs
+++ b/kernel-rs/src/console.rs
@@ -88,9 +88,7 @@ impl Console {
     /// Doesn't use interrupts, for use by kernel println() and to echo characters.
     /// It spins waiting for the uart's output register to be empty.
     fn putc_spin(&self, c: u8, kernel: &KernelBuilder) {
-        unsafe {
-            hal().cpus.push_off();
-        }
+        let intr = hal().cpus.push_off();
         if kernel.is_panicked() {
             spin_loop();
         }
@@ -100,9 +98,7 @@ impl Console {
 
         self.uart.putc(c);
 
-        unsafe {
-            hal().cpus.pop_off();
-        }
+        unsafe { hal().cpus.pop_off(intr) };
     }
 
     fn put_backspace_spin(&self, kernel: &KernelBuilder) {

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -50,6 +50,7 @@
 #![feature(maybe_uninit_ref)]
 #![feature(variant_count)]
 #![feature(const_mut_refs)]
+#![feature(raw_ref_op)]
 
 mod arch;
 mod arena;

--- a/kernel-rs/src/proc/kernel_ctx.rs
+++ b/kernel-rs/src/proc/kernel_ctx.rs
@@ -143,10 +143,10 @@ impl<'id, 's> KernelRef<'id, 's> {
     /// Returns pointer to the current proc.
     pub fn current_proc(&self) -> *const Proc {
         let cpus = &hal().cpus;
-        unsafe { cpus.push_off() };
-        let cpu = cpus.current();
-        let proc = unsafe { (*cpu).proc };
-        unsafe { cpus.pop_off() };
+        let intr = cpus.push_off();
+        let cpu = cpus.current(&intr);
+        let proc = cpu.get_proc();
+        unsafe { cpus.pop_off(intr) };
         proc
     }
 

--- a/kernel-rs/src/trap.rs
+++ b/kernel-rs/src/trap.rs
@@ -119,7 +119,7 @@ impl KernelCtx<'_, '_> {
         // We're about to switch the destination of traps from
         // kerneltrap() to usertrap(), so turn off interrupts until
         // we're back in user space, where usertrap() is correct.
-        unsafe { intr_off() };
+        intr_off();
 
         // Send syscalls, interrupts, and exceptions to trampoline.S.
         unsafe {


### PR DESCRIPTION
## `HeldInterrupts` 추가
* `push_off`를 하면 `HeldInterrupts`가 나옴.
* `pop_off`는 `HeldInterrupts`를 소모.
* `HeldInterrupts`의 존재가 인터럽트가 꺼져 있음을 보장.

## `CpuMut` 추가
* `NonNull<Cpu>`를 가지고 있음.
* 현재 스레드가 실행 중인 CPU에 대한 shared mutable access를 제공.
* `&Cell<Cpu>`와 유사.
* `Cpu`에 대한 참조가 유일함을 보장할 수 없기 때문에 `&mut Cpu` 대신 `CpuMut` 사용

## `Cpus::current*`
* `current_raw`: raw pointer 제공. CPU에 접근하지 않고 주소 값만 필요할 때 사용됨.
* `current_unchecked`: `CpuMut` 제공. 인터럽트가 꺼져 있으나 `HeldInterrupts`가 없을 때 사용됨.
  * `scheduler`에서 사용: `scheduler`는 CPU에 종속되어 있어 다른 CPU로 이동하지 않음.
  * `sched`에서 사용: `Spinlock<ProcInfo>`에 `HeldInterrupts`가 들어 있기는 하지만, `Cell`로부터 참조를 얻을 수 없음. `RefCell`을 사용하면 런타임 비용이 발생하고, `HeldInterrupts`를 `acquire`가 내놓게 하면, `SpinlockGuard`를 자동으로 드롭할 수 없게 됨.
* `current`: `CpuMut` 제공. `&HeldInterrupts`가 필요.

## `Spinlock`
* `intr: Cell<MaybeUninit<HeldInterrupts>>` 필드가 추가됨. 크기가 0이므로 런타임 비용 없음.