### PR TITLE
Closes #400

### DIFF
--- a/kernel-rs/src/arena/array_arena.rs
+++ b/kernel-rs/src/arena/array_arena.rs
@@ -1,12 +1,16 @@
 //! Array based arena.
+use core::{ops::Deref, ptr::NonNull};
+
 use array_macro::array;
 use pin_project::pin_project;
 
-use super::{Arena, ArenaGuard, ArenaObject, ArenaRef, Entry, EntryRef, Rc};
+use super::{Arena, ArenaObject, ArenaRef, Rc};
 use crate::{
-    arena::Handle,
     lock::{Spinlock, SpinlockGuard},
-    util::branded::Branded,
+    util::{
+        branded::Branded,
+        shared_rc_cell::{BrandedRcCell, BrandedRef, RcCell, SharedGuard},
+    },
 };
 
 unsafe impl<T: Send, const CAPACITY: usize> Sync for ArrayArena<T, CAPACITY> {}
@@ -15,7 +19,7 @@ unsafe impl<T: Send, const CAPACITY: usize> Sync for ArrayArena<T, CAPACITY> {}
 #[pin_project]
 pub struct ArrayArena<T, const CAPACITY: usize> {
     #[pin]
-    entries: [Entry<T>; CAPACITY],
+    entries: [RcCell<T>; CAPACITY],
     lock: Spinlock<()>,
 }
 
@@ -33,15 +37,15 @@ impl<T, const CAPACITY: usize> ArrayArena<T, CAPACITY> {
     #[allow(clippy::new_ret_no_self)]
     pub const fn new<D: Default>() -> ArrayArena<D, CAPACITY> {
         ArrayArena {
-            entries: array![_ => Entry::new(Default::default()); CAPACITY],
+            entries: array![_ => RcCell::new(Default::default()); CAPACITY],
             lock: Spinlock::new("ArrayArena", ()),
         }
     }
 }
 
 impl<'id, T, const CAPACITY: usize> ArenaRef<'id, &ArrayArena<T, CAPACITY>> {
-    fn lock(&self) -> ArenaGuard<'id, '_> {
-        ArenaGuard(self.0.brand(self.lock.lock()))
+    fn lock(&self) -> SharedGuard<'id, '_> {
+        unsafe { SharedGuard::new_unchecked(self.0.brand(self.lock.lock())) }
     }
 
     fn entries(&self) -> EntryIter<'id, '_, T> {
@@ -50,13 +54,15 @@ impl<'id, T, const CAPACITY: usize> ArenaRef<'id, &ArrayArena<T, CAPACITY>> {
 }
 
 #[repr(transparent)]
-struct EntryIter<'id, 's, T>(Branded<'id, core::slice::Iter<'s, Entry<T>>>);
+struct EntryIter<'id, 's, T>(Branded<'id, core::slice::Iter<'s, RcCell<T>>>);
 
-impl<'id, 's, T> Iterator for EntryIter<'id, 's, T> {
-    type Item = EntryRef<'id, 's, T>;
+impl<'id: 's, 's, T> Iterator for EntryIter<'id, 's, T> {
+    type Item = &'s BrandedRcCell<'id, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|inner| EntryRef(self.0.brand(inner)))
+        self.0
+            .next()
+            .map(|inner| unsafe { &*(inner as *const _ as *const _) })
     }
 }
 
@@ -73,23 +79,21 @@ impl<T: 'static + ArenaObject + Unpin + Send, const CAPACITY: usize> Arena
     ) -> Option<Rc<Self>> {
         ArenaRef::new(self, |arena: ArenaRef<'_, &ArrayArena<T, CAPACITY>>| {
             let mut guard = arena.lock();
-            // If empty is Some(v), v.rc is 0.
-            let mut empty: Option<Handle<T>> = None;
-            for entry in arena.entries() {
-                let rc = entry.get_mut_rc(&mut guard);
+            let mut empty = None;
+            for cell in arena.entries() {
+                let rc = cell.get_rc_mut(&mut guard);
                 if *rc == 0 {
-                    let _ = empty.get_or_insert(entry.into_handle());
-                } else if c(&entry) {
-                    *rc += 1;
-                    return Some(Rc::new(self, entry.into_handle()));
+                    let _ = empty.get_or_insert(NonNull::from(cell));
+                } else if let Some(data) = cell.get_data(&mut guard) {
+                    if c(data) {
+                        return Some(Rc::new(self, cell.make_ref(&mut guard).into_ref()));
+                    }
                 }
             }
-            empty.map(|handle| {
-                // SAFETY: handle.rc is 0.
-                n(unsafe { &mut *handle.data_raw() });
-                let entry = EntryRef(arena.0.brand(&handle));
-                *entry.get_mut_rc(&mut guard) += 1;
-                Rc::new(self, handle)
+            empty.map(|cell| {
+                let cell = unsafe { cell.as_ref() };
+                n(unsafe { cell.get_data_mut_unchecked(&mut guard) });
+                Rc::new(self, cell.make_ref(&mut guard).into_ref())
             })
         })
     }
@@ -97,36 +101,33 @@ impl<T: 'static + ArenaObject + Unpin + Send, const CAPACITY: usize> Arena
     fn alloc<F: FnOnce() -> Self::Data>(&self, f: F) -> Option<Rc<Self>> {
         ArenaRef::new(self, |arena: ArenaRef<'_, &ArrayArena<T, CAPACITY>>| {
             let mut guard = arena.lock();
-            for entry in arena.entries() {
-                let rc = entry.get_mut_rc(&mut guard);
-                if *rc == 0 {
-                    // SAFETY: handle.rc is 0.
-                    unsafe { *entry.data_raw() = f() };
-                    *rc += 1;
-                    return Some(Rc::new(self, entry.into_handle()));
+            for cell in arena.entries() {
+                if let Some(data) = cell.get_data_mut(&mut guard) {
+                    *data = f();
+                    return Some(Rc::new(self, cell.make_ref(&mut guard).into_ref()));
                 }
             }
             None
         })
     }
 
-    fn dup<'id>(self: ArenaRef<'id, &Self>, handle: &EntryRef<'id, '_, Self::Data>) {
+    fn dup<'id>(self: ArenaRef<'id, &Self>, handle: &BrandedRef<'id, Self::Data>) -> Rc<Self> {
         let mut guard = self.lock();
-        let rc = handle.get_mut_rc(&mut guard);
-        *rc += 1;
+        Rc::new(self.deref(), handle.clone(&mut guard).into_ref())
     }
 
-    fn dealloc<'id>(self: ArenaRef<'id, &Self>, handle: EntryRef<'id, '_, Self::Data>) {
+    fn dealloc<'id>(self: ArenaRef<'id, &Self>, handle: BrandedRef<'id, Self::Data>) {
         let mut guard = self.lock();
-        let rc = handle.get_mut_rc(&mut guard);
-        if *rc == 1 {
-            // SAFETY: handle.rc will become 0.
-            unsafe { (*handle.data_raw()).finalize::<Self>(&mut guard.0) };
-        }
+        let handle = match handle.into_mut(&mut guard) {
+            Ok(mut data) => {
+                data.get_data_mut().finalize::<Self>(guard.inner_mut());
+                data.into_ref(&mut guard)
+            }
+            Err(handle) => handle,
+        };
         // To prevent `find_or_alloc` and `alloc` from mutating `handle` while finalizing `handle`,
         // `rc` should be decreased after the finalization.
-        let rc = handle.get_mut_rc(&mut guard);
-        *rc -= 1;
+        handle.free(&mut guard);
     }
 
     unsafe fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R

--- a/kernel-rs/src/arena/array_arena.rs
+++ b/kernel-rs/src/arena/array_arena.rs
@@ -1,23 +1,22 @@
 //! Array based arena.
-
-use core::convert::TryFrom;
-use core::pin::Pin;
-
 use array_macro::array;
 use pin_project::pin_project;
 
-use super::{Arena, ArenaObject, ArenaRef, Handle, HandleRef, Rc};
+use super::{Arena, ArenaGuard, ArenaObject, ArenaRef, Entry, EntryRef, Rc};
 use crate::{
+    arena::Handle,
     lock::{Spinlock, SpinlockGuard},
-    util::pinned_array::IterPinMut,
-    util::rc_cell::{RcCell, RefMut},
+    util::branded::Branded,
 };
+
+unsafe impl<T: Send, const CAPACITY: usize> Sync for ArrayArena<T, CAPACITY> {}
 
 /// A homogeneous memory allocator equipped with reference counts.
 #[pin_project]
 pub struct ArrayArena<T, const CAPACITY: usize> {
     #[pin]
-    entries: [RcCell<T>; CAPACITY],
+    entries: [Entry<T>; CAPACITY],
+    lock: Spinlock<()>,
 }
 
 impl<T, const CAPACITY: usize> ArrayArena<T, CAPACITY> {
@@ -34,83 +33,100 @@ impl<T, const CAPACITY: usize> ArrayArena<T, CAPACITY> {
     #[allow(clippy::new_ret_no_self)]
     pub const fn new<D: Default>() -> ArrayArena<D, CAPACITY> {
         ArrayArena {
-            entries: array![_ => RcCell::new(Default::default()); CAPACITY],
+            entries: array![_ => Entry::new(Default::default()); CAPACITY],
+            lock: Spinlock::new("ArrayArena", ()),
         }
     }
 }
 
+impl<'id, T, const CAPACITY: usize> ArenaRef<'id, &ArrayArena<T, CAPACITY>> {
+    fn lock(&self) -> ArenaGuard<'id, '_> {
+        ArenaGuard(self.0.brand(self.lock.lock()))
+    }
+
+    fn entries(&self) -> EntryIter<'id, '_, T> {
+        EntryIter(self.0.brand(self.entries.iter()))
+    }
+}
+
+#[repr(transparent)]
+struct EntryIter<'id, 's, T>(Branded<'id, core::slice::Iter<'s, Entry<T>>>);
+
+impl<'id, 's, T> Iterator for EntryIter<'id, 's, T> {
+    type Item = EntryRef<'id, 's, T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|inner| EntryRef(self.0.brand(inner)))
+    }
+}
+
 impl<T: 'static + ArenaObject + Unpin + Send, const CAPACITY: usize> Arena
-    for Spinlock<ArrayArena<T, CAPACITY>>
+    for ArrayArena<T, CAPACITY>
 {
     type Data = T;
-    type Guard<'s> = SpinlockGuard<'s, ArrayArena<T, CAPACITY>>;
+    type Guard<'s> = SpinlockGuard<'s, ()>;
 
     fn find_or_alloc<C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
         &self,
         c: C,
         n: N,
     ) -> Option<Rc<Self>> {
-        ArenaRef::new(self, |arena| {
-            let mut guard = arena.pinned_lock_unchecked();
-            let this = guard.get_pin_mut().project();
-
-            let mut empty: Option<*mut RcCell<T>> = None;
-            for entry in IterPinMut::from(this.entries) {
-                if !entry.is_borrowed() {
-                    if empty.is_none() {
-                        empty = Some(entry.as_ref().get_ref() as *const _ as *mut _)
-                    }
-                    // Note: Do not use `break` here.
-                    // We must first search through all entries, and then alloc at empty
-                    // only if the entry we're finding for doesn't exist.
-                } else if let Some(r) = entry.try_borrow() {
-                    // The entry is not under finalization. Check its data.
-                    if c(&r) {
-                        return Some(Rc::new(arena, Handle(arena.0.brand(r))));
-                    }
+        ArenaRef::new(self, |arena: ArenaRef<'_, &ArrayArena<T, CAPACITY>>| {
+            let mut guard = arena.lock();
+            // If empty is Some(v), v.rc is 0.
+            let mut empty: Option<Handle<T>> = None;
+            for entry in arena.entries() {
+                let rc = entry.get_mut_rc(&mut guard);
+                if *rc == 0 {
+                    let _ = empty.get_or_insert(entry.into_handle());
+                } else if c(&entry) {
+                    *rc += 1;
+                    return Some(Rc::new(self, entry.into_handle()));
                 }
             }
-
-            empty.map(|cell_raw| {
-                // SAFETY: `cell` is not referenced or borrowed. Also, it is already pinned.
-                let mut cell = unsafe { Pin::new_unchecked(&mut *cell_raw) };
-                n(cell.as_mut().get_pin_mut().unwrap().get_mut());
-                let handle = Handle(arena.0.brand(cell.borrow()));
-                Rc::new(arena, handle)
+            empty.map(|handle| {
+                // SAFETY: handle.rc is 0.
+                n(unsafe { &mut *handle.data_raw() });
+                let entry = EntryRef(arena.0.brand(&handle));
+                *entry.get_mut_rc(&mut guard) += 1;
+                Rc::new(self, handle)
             })
         })
     }
 
     fn alloc<F: FnOnce() -> Self::Data>(&self, f: F) -> Option<Rc<Self>> {
-        ArenaRef::new(self, |arena| {
-            let mut guard = arena.pinned_lock_unchecked();
-            let this = guard.get_pin_mut().project();
-
-            for mut entry in IterPinMut::from(this.entries) {
-                if !entry.is_borrowed() {
-                    *(entry.as_mut().get_pin_mut().unwrap().get_mut()) = f();
-                    let handle = Handle(arena.0.brand(entry.borrow()));
-                    return Some(Rc::new(arena, handle));
+        ArenaRef::new(self, |arena: ArenaRef<'_, &ArrayArena<T, CAPACITY>>| {
+            let mut guard = arena.lock();
+            for entry in arena.entries() {
+                let rc = entry.get_mut_rc(&mut guard);
+                if *rc == 0 {
+                    // SAFETY: handle.rc is 0.
+                    unsafe { *entry.data_raw() = f() };
+                    *rc += 1;
+                    return Some(Rc::new(self, entry.into_handle()));
                 }
             }
             None
         })
     }
 
-    fn dup<'id>(
-        self: ArenaRef<'id, &Self>,
-        handle: HandleRef<'id, '_, Self::Data>,
-    ) -> Handle<'id, Self::Data> {
-        let mut _this = self.pinned_lock_unchecked();
-        Handle(self.0.brand(handle.0.into_inner().clone()))
+    fn dup<'id>(self: ArenaRef<'id, &Self>, handle: &EntryRef<'id, '_, Self::Data>) {
+        let mut guard = self.lock();
+        let rc = handle.get_mut_rc(&mut guard);
+        *rc += 1;
     }
 
-    fn dealloc<'id>(self: ArenaRef<'id, &Self>, handle: Handle<'id, Self::Data>) {
-        let mut this = self.pinned_lock_unchecked();
-
-        if let Ok(mut rm) = RefMut::<T>::try_from(handle.0.into_inner()) {
-            rm.finalize::<Self>(&mut this);
+    fn dealloc<'id>(self: ArenaRef<'id, &Self>, handle: EntryRef<'id, '_, Self::Data>) {
+        let mut guard = self.lock();
+        let rc = handle.get_mut_rc(&mut guard);
+        if *rc == 1 {
+            // SAFETY: handle.rc will become 0.
+            unsafe { (*handle.data_raw()).finalize::<Self>(&mut guard.0) };
         }
+        // To prevent `find_or_alloc` and `alloc` from mutating `handle` while finalizing `handle`,
+        // `rc` should be decreased after the finalization.
+        let rc = handle.get_mut_rc(&mut guard);
+        *rc -= 1;
     }
 
     unsafe fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R

--- a/kernel-rs/src/arena/mru_arena.rs
+++ b/kernel-rs/src/arena/mru_arena.rs
@@ -1,27 +1,28 @@
 //! List based arena.
-
-use core::convert::TryFrom;
-use core::mem;
 use core::pin::Pin;
+use core::{mem, ops::Deref};
 
 use array_macro::array;
 use pin_project::pin_project;
 
-use super::{Arena, ArenaObject, ArenaRef, Handle, HandleRef, Rc};
+use super::{Arena, ArenaGuard, ArenaObject, ArenaRef, Entry, EntryRef, Handle, Rc};
 use crate::{
     lock::{Spinlock, SpinlockGuard},
-    util::intrusive_list::{List, ListEntry, ListNode},
     util::pinned_array::IterPinMut,
-    util::rc_cell::{RcCell, RefMut},
+    util::{
+        branded::Branded,
+        intrusive_list::{Iter, List, ListEntry, ListNode},
+    },
 };
+
+unsafe impl<T: Send, const CAPACITY: usize> Sync for MruArena<T, CAPACITY> {}
 
 #[pin_project]
 #[repr(C)]
 pub struct MruEntry<T> {
     #[pin]
     list_entry: ListEntry,
-    #[pin]
-    data: RcCell<T>,
+    data: Entry<T>,
 }
 
 /// A homogeneous memory allocator equipped with reference counts.
@@ -31,10 +32,8 @@ pub struct MruArena<T, const CAPACITY: usize> {
     entries: [MruEntry<T>; CAPACITY],
     #[pin]
     list: List<MruEntry<T>>,
+    lock: Spinlock<()>,
 }
-
-// SAFETY: `MruArena` never exposes its internal lists and entries.
-unsafe impl<T: Send, const CAPACITY: usize> Send for MruArena<T, CAPACITY> {}
 
 impl<T> MruEntry<T> {
     // TODO(https://github.com/kaist-cp/rv6/issues/369)
@@ -50,8 +49,42 @@ impl<T> MruEntry<T> {
     pub const fn new(data: T) -> Self {
         Self {
             list_entry: unsafe { ListEntry::new() },
-            data: RcCell::new(data),
+            data: Entry::new(data),
         }
+    }
+}
+
+impl<'id, T, const CAPACITY: usize> ArenaRef<'id, &MruArena<T, CAPACITY>> {
+    fn lock(&self) -> ArenaGuard<'id, '_> {
+        ArenaGuard(self.0.brand(self.lock.lock()))
+    }
+
+    /// # Safety
+    ///
+    /// `self.list` must not be modified during iteration.
+    unsafe fn entries(&self) -> EntryIter<'id, '_, T> {
+        EntryIter(self.0.brand(unsafe { self.list.iter_unchecked() }))
+    }
+}
+
+#[repr(transparent)]
+struct EntryIter<'id, 's, T>(Branded<'id, Iter<'s, MruEntry<T>>>);
+
+impl<'id, 's, T: 's> Iterator for EntryIter<'id, 's, T> {
+    type Item = EntryRef<'id, 's, T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0
+            .next()
+            .map(|inner| EntryRef(self.0.brand(&inner.data)))
+    }
+}
+
+impl<'id, 's, T: 's> DoubleEndedIterator for EntryIter<'id, 's, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0
+            .next_back()
+            .map(|inner| EntryRef(self.0.brand(&inner.data)))
     }
 }
 
@@ -82,6 +115,7 @@ impl<T, const CAPACITY: usize> MruArena<T, CAPACITY> {
         MruArena {
             entries: array![_ => MruEntry::new(Default::default()); CAPACITY],
             list: unsafe { List::new() },
+            lock: Spinlock::new("MruArena", ()),
         }
     }
 
@@ -96,87 +130,82 @@ impl<T, const CAPACITY: usize> MruArena<T, CAPACITY> {
 }
 
 impl<T: 'static + ArenaObject + Unpin + Send, const CAPACITY: usize> Arena
-    for Spinlock<MruArena<T, CAPACITY>>
+    for MruArena<T, CAPACITY>
 {
     type Data = T;
-    type Guard<'s> = SpinlockGuard<'s, MruArena<T, CAPACITY>>;
+    type Guard<'s> = SpinlockGuard<'s, ()>;
 
     fn find_or_alloc<C: Fn(&Self::Data) -> bool, N: FnOnce(&mut Self::Data)>(
         &self,
         c: C,
         n: N,
     ) -> Option<Rc<Self>> {
-        ArenaRef::new(self, |arena| {
-            let mut guard = arena.pinned_lock_unchecked();
-            let this = guard.get_pin_mut().project();
-
-            let mut empty: Option<*mut RcCell<T>> = None;
-            // SAFETY: the whole `MruArena` is protected by a lock.
-            for entry in unsafe { this.list.iter_pin_mut_unchecked() } {
-                if !entry.data.is_borrowed() {
-                    empty = Some(&entry.data as *const _ as *mut _);
+        ArenaRef::new(self, |arena: ArenaRef<'_, &MruArena<T, CAPACITY>>| {
+            let mut guard = arena.lock();
+            // If empty is Some(v), v.rc is 0.
+            let mut empty: Option<Handle<T>> = None;
+            // SAFETY: `self.list` is not modified during iteration.
+            for entry in unsafe { arena.entries() } {
+                let rc = entry.get_mut_rc(&mut guard);
+                if c(&entry) {
+                    *rc += 1;
+                    return Some(Rc::new(self, entry.into_handle()));
                 }
-                if let Some(r) = entry.data.try_borrow() {
-                    if c(&r) {
-                        return Some(Rc::new(arena, Handle(arena.0.brand(r))));
-                    }
+                if *rc == 0 {
+                    empty = Some(entry.into_handle());
                 }
             }
-
-            empty.map(|cell_raw| {
-                // SAFETY: `cell` is not referenced or borrowed. Also, it is already pinned.
-                let mut cell = unsafe { Pin::new_unchecked(&mut *cell_raw) };
-                n(cell.as_mut().get_pin_mut().unwrap().get_mut());
-                let handle = Handle(arena.0.brand(cell.borrow()));
-                Rc::new(arena, handle)
+            empty.map(|handle| {
+                // SAFETY: handle.rc is 0.
+                n(unsafe { &mut *handle.data_raw() });
+                let entry = EntryRef(arena.0.brand(&handle));
+                *entry.get_mut_rc(&mut guard) += 1;
+                Rc::new(self, handle)
             })
         })
     }
 
     fn alloc<F: FnOnce() -> Self::Data>(&self, f: F) -> Option<Rc<Self>> {
-        ArenaRef::new(self, |arena| {
-            let mut guard = arena.pinned_lock_unchecked();
-            let this = guard.get_pin_mut().project();
-
-            // SAFETY: the whole `MruArena` is protected by a lock.
-            for mut entry in unsafe { this.list.iter_pin_mut_unchecked().rev() } {
-                if !entry.data.is_borrowed() {
-                    *(entry
-                        .as_mut()
-                        .project()
-                        .data
-                        .get_pin_mut()
-                        .unwrap()
-                        .get_mut()) = f();
-                    let handle = Handle(arena.0.brand(entry.data.borrow()));
-                    return Some(Rc::new(arena, handle));
+        ArenaRef::new(self, |arena: ArenaRef<'_, &MruArena<T, CAPACITY>>| {
+            let mut guard = arena.lock();
+            // SAFETY: `self.list` is not modified during iteration.
+            for entry in unsafe { arena.entries() }.rev() {
+                let rc = entry.get_mut_rc(&mut guard);
+                if *rc == 0 {
+                    // SAFETY: entry.rc is 0.
+                    unsafe { *entry.data_raw() = f() };
+                    *rc += 1;
+                    return Some(Rc::new(self, entry.into_handle()));
                 }
             }
             None
         })
     }
 
-    fn dup<'id>(
-        self: ArenaRef<'id, &Self>,
-        handle: HandleRef<'id, '_, Self::Data>,
-    ) -> Handle<'id, Self::Data> {
-        let mut _this = self.pinned_lock_unchecked();
-        Handle(self.0.brand(handle.0.into_inner().clone()))
+    fn dup<'id>(self: ArenaRef<'id, &Self>, handle: &EntryRef<'id, '_, Self::Data>) {
+        let mut guard = self.lock();
+        let rc = handle.get_mut_rc(&mut guard);
+        *rc += 1;
     }
 
-    fn dealloc<'id>(self: ArenaRef<'id, &Self>, handle: Handle<'id, Self::Data>) {
-        let mut this = self.pinned_lock_unchecked();
-
-        if let Ok(mut rm) = RefMut::<T>::try_from(handle.0.into_inner()) {
-            // Finalize the arena object.
-            rm.finalize::<Self>(&mut this);
+    fn dealloc<'id>(self: ArenaRef<'id, &Self>, handle: EntryRef<'id, '_, Self::Data>) {
+        let mut guard = self.lock();
+        let rc = handle.get_mut_rc(&mut guard);
+        if *rc == 1 {
+            // SAFETY: handle.rc will become 0.
+            unsafe { (*handle.data_raw()).finalize::<Self>(&mut guard.0) };
 
             // Move this entry to the back of the list.
-            let ptr = (rm.get_cell() as *const _ as usize - MruEntry::<T>::DATA_OFFSET)
+            let ptr = (handle.deref() as *const Entry<T> as usize - MruEntry::<T>::DATA_OFFSET)
                 as *mut MruEntry<T>;
+            // SAFETY: `handle` is an `Entry` inside an `MruEntry`.
             let entry = unsafe { &*ptr };
-            this.list.push_back(entry);
+            self.list.push_back(entry);
         }
+        // To prevent `find_or_alloc` and `alloc` from mutating `handle` while finalizing `handle`,
+        // `rc` should be decreased after the finalization.
+        let rc = handle.get_mut_rc(&mut guard);
+        *rc -= 1;
     }
 
     unsafe fn reacquire_after<'s, 'g: 's, F, R: 's>(guard: &'s mut Self::Guard<'g>, f: F) -> R

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -16,7 +16,7 @@ use core::ops::{Deref, DerefMut};
 
 use crate::{
     arena::{Arena, ArenaObject, MruArena, Rc},
-    lock::{Sleeplock, Spinlock},
+    lock::Sleeplock,
     param::{BSIZE, NBUF},
     proc::WaitChannel,
 };
@@ -95,7 +95,7 @@ impl BufInner {
     }
 }
 
-pub type Bcache = Spinlock<MruArena<BufEntry, NBUF>>;
+pub type Bcache = MruArena<BufEntry, NBUF>;
 
 /// A reference counted smart pointer to a `BufEntry`.
 pub type BufUnlocked = Rc<Bcache>;
@@ -153,7 +153,7 @@ impl Bcache {
     ///
     /// The caller should make sure that `Bcache` never gets moved.
     pub const unsafe fn zero() -> Self {
-        Spinlock::new("BCACHE", MruArena::<BufEntry, NBUF>::new())
+        MruArena::<BufEntry, NBUF>::new()
     }
 
     /// Return a unlocked buf with the contents of the indicated block.

--- a/kernel-rs/src/file.rs
+++ b/kernel-rs/src/file.rs
@@ -7,7 +7,6 @@ use crate::{
     arena::{Arena, ArenaObject, ArrayArena, Rc},
     fs::{FileSystem, InodeGuard, RcInode, Ufs},
     hal::allocator,
-    lock::Spinlock,
     param::{BSIZE, MAXOPBLOCKS, NFILE},
     pipe::AllocatedPipe,
     proc::{kernel_ctx, KernelCtx},
@@ -52,7 +51,7 @@ pub struct File {
     writable: bool,
 }
 
-pub type FileTable = Spinlock<ArrayArena<File, NFILE>>;
+pub type FileTable = ArrayArena<File, NFILE>;
 
 /// map major device number to device functions.
 #[derive(Copy, Clone)]
@@ -250,7 +249,7 @@ impl ArenaObject for File {
 
 impl FileTable {
     pub const fn zero() -> Self {
-        Spinlock::new("FTABLE", ArrayArena::<File, NFILE>::new())
+        ArrayArena::<File, NFILE>::new()
     }
 
     /// Allocate a file structure.

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 
 use crate::{
     arena::{ArenaObject, ArrayArena, Rc},
-    lock::{Sleeplock, Spinlock},
+    lock::Sleeplock,
     param::NINODE,
     proc::KernelCtx,
 };
@@ -93,7 +93,7 @@ pub struct Inode<I> {
     pub inner: Sleeplock<I>,
 }
 
-pub type Itable<I> = Spinlock<ArrayArena<Inode<I>, NINODE>>;
+pub type Itable<I> = ArrayArena<Inode<I>, NINODE>;
 
 /// A reference counted smart pointer to an `Inode`.
 pub type RcInode<I> = Rc<Itable<I>>;

--- a/kernel-rs/src/fs/ufs/inode.rs
+++ b/kernel-rs/src/fs/ufs/inode.rs
@@ -84,7 +84,7 @@ use crate::{
     bio::BufData,
     fs::{Inode, InodeGuard, InodeType, Itable, RcInode},
     hal::hal,
-    lock::{Sleeplock, Spinlock},
+    lock::Sleeplock,
     param::ROOTDEV,
     param::{BSIZE, NINODE},
     proc::{kernel_ctx, KernelCtx},
@@ -799,7 +799,7 @@ impl Inode<InodeInner> {
 
 impl Itable<InodeInner> {
     pub const fn new_itable() -> Self {
-        Spinlock::new("ITABLE", ArrayArena::<Inode<InodeInner>, NINODE>::new())
+        ArrayArena::<Inode<InodeInner>, NINODE>::new()
     }
 
     /// Find the inode with number inum on device dev

--- a/kernel-rs/src/kernel.rs
+++ b/kernel-rs/src/kernel.rs
@@ -213,7 +213,7 @@ impl KernelBuilder {
         unsafe { plicinithart() };
 
         // Buffer cache.
-        this.bcache.get_pin_mut().init();
+        this.bcache.init();
 
         // First user process.
         this.procs

--- a/kernel-rs/src/lock/mod.rs
+++ b/kernel-rs/src/lock/mod.rs
@@ -95,16 +95,6 @@ impl<R: RawLock, T> Lock<R, T> {
         }
     }
 
-    // Will be removed.
-    pub fn pinned_lock_unchecked(&self) -> Guard<'_, R, T> {
-        self.lock.acquire();
-
-        Guard {
-            lock: self,
-            _marker: PhantomData,
-        }
-    }
-
     /// Returns a raw pointer to the inner data.
     /// The returned pointer is valid until this lock is moved or dropped.
     /// The caller must ensure that accessing the pointer does not incur race.

--- a/kernel-rs/src/lock/remotelock.rs
+++ b/kernel-rs/src/lock/remotelock.rs
@@ -42,6 +42,7 @@ impl<R: RawLock, U, T> RemoteLock<R, U, T> {
     ///
     /// The provided `guard` must be from the `Lock` that this `RemoteLock` borrowed from.
     /// You may want to wrap this function with a safe function that uses branded types.
+    #[inline]
     pub unsafe fn get_pin_mut_unchecked<'t>(
         &'t self,
         _guard: &'t mut Guard<'_, R, U>,
@@ -57,6 +58,7 @@ impl<'s, R: RawLock, U, T: Unpin> RemoteLock<R, U, T> {
     ///
     /// The provided `guard` must be from the `Lock` that this `RemoteLock` borrowed from.
     /// You may want to wrap this function with a safe function that uses branded types.
+    #[inline]
     pub unsafe fn get_mut_unchecked<'t>(&'t self, guard: &'t mut Guard<'_, R, U>) -> &'t mut T {
         unsafe { self.get_pin_mut_unchecked(guard) }.get_mut()
     }

--- a/kernel-rs/src/util/branded.rs
+++ b/kernel-rs/src/util/branded.rs
@@ -222,6 +222,7 @@ type Id<'id> = PhantomData<Cell<&'id mut ()>>;
 /// * `Branded::brand` returns a `Branded` that has the same `'id` with the provided `Branded`.
 ///   This is the only way to make a new `Branded` that has the same `'id` with another `Branded`.
 #[derive(Clone, Copy)]
+#[repr(transparent)]
 pub struct Branded<'id, T> {
     _id: Id<'id>,
     inner: T,

--- a/kernel-rs/src/util/mod.rs
+++ b/kernel-rs/src/util/mod.rs
@@ -9,6 +9,7 @@ pub mod intrusive_list;
 pub mod list;
 pub mod pinned_array;
 pub mod rc_cell;
+pub mod shared_rc_cell;
 
 pub fn spin_loop() -> ! {
     loop {

--- a/kernel-rs/src/util/shared_rc_cell.rs
+++ b/kernel-rs/src/util/shared_rc_cell.rs
@@ -1,0 +1,192 @@
+use core::{cell::UnsafeCell, ops::Deref, ptr::NonNull};
+
+use super::branded::Branded;
+use crate::lock::{RawSpinlock, RemoteLock, SpinlockGuard};
+
+const BORROWED_MUT: usize = usize::MAX;
+
+pub struct RcCell<T> {
+    data: UnsafeCell<T>,
+    rc: RemoteLock<RawSpinlock, (), usize>,
+}
+
+#[repr(transparent)]
+pub struct BrandedRcCell<'id, T>(Branded<'id, RcCell<T>>);
+
+#[repr(transparent)]
+pub struct SharedGuard<'id, 's>(Branded<'id, SpinlockGuard<'s, ()>>);
+
+#[repr(transparent)]
+pub struct Ref<T>(NonNull<RcCell<T>>);
+
+#[repr(transparent)]
+pub struct BrandedRef<'id, T>(Branded<'id, Ref<T>>);
+
+#[repr(transparent)]
+pub struct RefMut<T>(NonNull<RcCell<T>>);
+
+#[repr(transparent)]
+pub struct BrandedRefMut<'id, T>(Branded<'id, RefMut<T>>);
+
+impl<T> RcCell<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            data: UnsafeCell::new(data),
+            rc: RemoteLock::new(0),
+        }
+    }
+}
+
+impl<'id, T> BrandedRcCell<'id, T> {
+    pub fn get_rc_mut<'a: 'b, 'b>(&'a self, guard: &'b mut SharedGuard<'id, '_>) -> &'b mut usize {
+        unsafe { self.0.rc.get_mut_unchecked(&mut guard.0) }
+    }
+
+    pub fn get_data<'a: 'b, 'b>(&'a self, guard: &'b mut SharedGuard<'id, '_>) -> Option<&'b T> {
+        let rc = self.get_rc_mut(guard);
+        if *rc != BORROWED_MUT {
+            Some(unsafe { &*self.0.data.get() })
+        } else {
+            None
+        }
+    }
+
+    pub fn get_data_mut<'a: 'b, 'b>(
+        &'a self,
+        guard: &'b mut SharedGuard<'id, '_>,
+    ) -> Option<&'b mut T> {
+        let rc = self.get_rc_mut(guard);
+        if *rc == 0 {
+            Some(unsafe { self.get_data_mut_unchecked(guard) })
+        } else {
+            None
+        }
+    }
+
+    pub unsafe fn get_data_mut_unchecked<'a: 'b, 'b>(
+        &'a self,
+        _: &'b mut SharedGuard<'id, '_>,
+    ) -> &'b mut T {
+        unsafe { &mut *self.0.data.get() }
+    }
+
+    pub fn make_ref(&self, guard: &mut SharedGuard<'id, '_>) -> BrandedRef<'id, T> {
+        let rc = self.get_rc_mut(guard);
+        assert!(*rc < usize::MAX - 1);
+        *rc += 1;
+        BrandedRef(self.0.brand(Ref(NonNull::from(self.0.deref()))))
+    }
+}
+
+impl<'id, 's> SharedGuard<'id, 's> {
+    pub unsafe fn new_unchecked(guard: Branded<'id, SpinlockGuard<'s, ()>>) -> Self {
+        Self(guard)
+    }
+
+    pub fn inner_mut(&mut self) -> &mut SpinlockGuard<'s, ()> {
+        &mut self.0
+    }
+}
+
+impl<T> Ref<T> {
+    fn get_cell(&self) -> &RcCell<T> {
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T> Deref for Ref<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.get_cell().data.get() }
+    }
+}
+
+impl<T> Drop for Ref<T> {
+    fn drop(&mut self) {
+        panic!();
+    }
+}
+
+impl<'id, T> BrandedRef<'id, T> {
+    pub unsafe fn new_unchecked(r: Branded<'id, Ref<T>>) -> Self {
+        Self(r)
+    }
+
+    pub fn clone(&self, guard: &mut SharedGuard<'id, '_>) -> Self {
+        let rc = self.get_cell().get_rc_mut(guard);
+        assert!(*rc < usize::MAX - 1);
+        *rc += 1;
+        BrandedRef(self.0.brand(Ref(self.0 .0)))
+    }
+
+    pub fn free(self, guard: &mut SharedGuard<'id, '_>) {
+        let rc = self.get_cell().get_rc_mut(guard);
+        *rc -= 1;
+        core::mem::forget(self);
+    }
+
+    pub fn into_mut(self, guard: &mut SharedGuard<'id, '_>) -> Result<BrandedRefMut<'id, T>, Self> {
+        let rc = self.get_cell().get_rc_mut(guard);
+        if *rc == 1 {
+            *rc = BORROWED_MUT;
+            let r = Ok(BrandedRefMut(self.0.brand(RefMut(self.0 .0))));
+            core::mem::forget(self);
+            r
+        } else {
+            Err(self)
+        }
+    }
+
+    pub fn get_cell(&self) -> &BrandedRcCell<'id, T> {
+        unsafe { &*(self.0.get_cell() as *const _ as *const _) }
+    }
+
+    pub fn into_ref(self) -> Ref<T> {
+        let r = Ref(self.0 .0);
+        core::mem::forget(self);
+        r
+    }
+}
+
+impl<T> Drop for BrandedRef<'_, T> {
+    fn drop(&mut self) {
+        panic!();
+    }
+}
+
+impl<T> RefMut<T> {
+    fn get_cell(&self) -> &RcCell<T> {
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T> Drop for RefMut<T> {
+    fn drop(&mut self) {
+        panic!();
+    }
+}
+
+impl<'id, T> BrandedRefMut<'id, T> {
+    pub fn get_data_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.0.get_cell().data.get() }
+    }
+
+    pub fn into_ref(self, guard: &mut SharedGuard<'id, '_>) -> BrandedRef<'id, T> {
+        let rc = self.get_cell().get_rc_mut(guard);
+        *rc = 1;
+        let r = BrandedRef(self.0.brand(Ref(self.0 .0)));
+        core::mem::forget(self);
+        r
+    }
+
+    pub fn get_cell(&self) -> &BrandedRcCell<'id, T> {
+        unsafe { &*(self.0.get_cell() as *const _ as *const _) }
+    }
+}
+
+impl<T> Drop for BrandedRefMut<'_, T> {
+    fn drop(&mut self) {
+        panic!();
+    }
+}


### PR DESCRIPTION
Closes #400

`Arena`의 각 엔트리에서 reference counter는 `Arena`의 락으로 보호되어야 하지만 data는 락으로 보호될 필요가 없음. 따라서 기존처럼 `ArrayArena`나 `MruArena` 전체를 락으로 감싸는 것은 올바르지 않음.