### PR TITLE
Closes #539

### DIFF
--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -72,13 +72,20 @@ impl<I> InodeGuard<'_, I> {
         // SAFETY: self.inner is locked and &mut self is exclusive.
         unsafe { &mut *self.inner.get_mut_raw() }
     }
+
+    pub fn free(self, ctx: &KernelCtx<'_, '_>) {
+        // SAFETY: self will be dropped.
+        unsafe { self.inner.unlock(ctx) };
+        core::mem::forget(self);
+    }
 }
 
 /// Unlock and put the given inode.
 impl<I> Drop for InodeGuard<'_, I> {
     fn drop(&mut self) {
-        // SAFETY: self will be dropped.
-        unsafe { self.inner.unlock() };
+        // HACK(@efenniht): we really need linear type here:
+        // https://github.com/rust-lang/rfcs/issues/814
+        panic!("InodeGuard must never drop.");
     }
 }
 

--- a/kernel-rs/src/lock/sleeplock.rs
+++ b/kernel-rs/src/lock/sleeplock.rs
@@ -1,8 +1,12 @@
 //! Sleeping locks
-use core::cell::UnsafeCell;
+use core::{
+    cell::UnsafeCell,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
-use super::{Guard, Lock, RawLock, Sleepablelock};
-use crate::{kernel::kernel_ref, proc::kernel_ctx};
+use super::Sleepablelock;
+use crate::proc::KernelCtx;
 
 /// Long-term locks for processes
 pub struct RawSleeplock {
@@ -11,9 +15,20 @@ pub struct RawSleeplock {
 }
 
 /// Locks that sleep instead of busy wait.
-pub type Sleeplock<T> = Lock<RawSleeplock, T>;
+pub struct Sleeplock<T> {
+    lock: RawSleeplock,
+    data: UnsafeCell<T>,
+}
+
+unsafe impl<T: Send> Sync for Sleeplock<T> {}
+
 /// Guards of `Sleeplock<T>`.
-pub type SleeplockGuard<'s, T> = Guard<'s, RawSleeplock, T>;
+pub struct SleeplockGuard<'s, T> {
+    lock: &'s Sleeplock<T>,
+    _marker: PhantomData<*const ()>,
+}
+
+unsafe impl<'s, T: Sync> Sync for SleeplockGuard<'s, T> {}
 
 impl RawSleeplock {
     const fn new(name: &'static str) -> Self {
@@ -21,24 +36,19 @@ impl RawSleeplock {
             inner: Sleepablelock::new(name, -1),
         }
     }
-}
 
-impl RawLock for RawSleeplock {
-    fn acquire(&self) {
+    fn acquire(&self, ctx: &KernelCtx<'_, '_>) {
         let mut guard = self.inner.lock();
         while *guard != -1 {
-            // TODO(https://github.com/kaist-cp/rv6/issues/539): remove kernel_ctx()
-            unsafe { kernel_ctx(|ctx| guard.sleep(&ctx)) };
+            guard.sleep(ctx);
         }
-        // TODO(https://github.com/kaist-cp/rv6/issues/539): remove kernel_ctx()
-        *guard = unsafe { kernel_ctx(|ctx| ctx.proc().pid()) };
+        *guard = ctx.proc().pid();
     }
 
-    fn release(&self) {
+    fn release(&self, ctx: &KernelCtx<'_, '_>) {
         let mut guard = self.inner.lock();
         *guard = -1;
-        // TODO(https://github.com/kaist-cp/rv6/issues/539): remove kernel_ref()
-        unsafe { kernel_ref(|kref| guard.wakeup(kref)) };
+        guard.wakeup(ctx.kernel());
     }
 }
 
@@ -49,5 +59,69 @@ impl<T> Sleeplock<T> {
             lock: RawSleeplock::new(name),
             data: UnsafeCell::new(data),
         }
+    }
+
+    /// Acquires the lock and returns the lock guard.
+    pub fn lock(&self, ctx: &KernelCtx<'_, '_>) -> SleeplockGuard<'_, T> {
+        self.lock.acquire(ctx);
+
+        SleeplockGuard {
+            lock: self,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns a raw pointer to the inner data.
+    pub fn get_mut_raw(&self) -> *mut T {
+        self.data.get()
+    }
+
+    /// Returns a mutable reference to the inner data.
+    pub fn get_mut(&mut self) -> &mut T
+    where
+        T: Unpin,
+    {
+        // SAFETY: we have a mutable reference of the lock.
+        unsafe { &mut *self.get_mut_raw() }
+    }
+
+    /// Unlock the lock.
+    ///
+    /// # Safety
+    ///
+    /// Use this only when we acquired the lock but did `mem::forget()` to the guard.
+    pub unsafe fn unlock(&self, ctx: &KernelCtx<'_, '_>) {
+        self.lock.release(ctx);
+    }
+}
+
+impl<T> SleeplockGuard<'_, T> {
+    pub fn free(self, ctx: &KernelCtx<'_, '_>) {
+        self.lock.lock.release(ctx);
+        core::mem::forget(self);
+    }
+}
+
+impl<T> Drop for SleeplockGuard<'_, T> {
+    fn drop(&mut self) {
+        // HACK(@efenniht): we really need linear type here:
+        // https://github.com/rust-lang/rfcs/issues/814
+        panic!("SleeplockGuard must never drop.");
+    }
+}
+
+impl<T> Deref for SleeplockGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+// We can mutably dereference the guard only when `T: Unpin`.
+// If `T: !Unpin`, use `Guard::get_pin_mut()` instead.
+impl<T: Unpin> DerefMut for SleeplockGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.lock.data.get() }
     }
 }

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -179,7 +179,7 @@ impl Sleepablelock<VirtioDisk> {
     pub fn read(&self, dev: u32, blockno: u32, ctx: &KernelCtx<'_, '_>) -> Buf {
         let mut buf = unsafe { ctx.kernel().get_bcache() }
             .get_buf(dev, blockno)
-            .lock();
+            .lock(ctx);
         if !buf.deref_inner().valid {
             VirtioDisk::rw(&mut self.lock(), &mut buf, false, ctx);
             buf.deref_inner_mut().valid = true;


### PR DESCRIPTION
Closes #539

`RawSleeplock`이 `acquire`와 `release`할 때 `KernelCtx`를 인자로 받습니다. 이제 `RawSleeplock`이 `RawLock`을 구현하지 않습니다. 이렇게 해도 코드 중복이 많아 보이지는 않습니다.