### PR TITLE
[Closes #576] Use 8B-copy instead of 1B-copy

### DIFF
--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -14,8 +14,6 @@
 use core::mem::{self, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
 
-use static_assertions::const_assert;
-
 use crate::arena::ArenaRc;
 use crate::util::strong_pin::StrongPin;
 use crate::{
@@ -23,6 +21,7 @@ use crate::{
     lock::SleepLock,
     param::{BSIZE, NBUF},
     proc::{KernelCtx, WaitChannel},
+    util::memmove,
 };
 
 pub struct BufEntry {
@@ -80,14 +79,7 @@ pub struct BufData {
 
 impl BufData {
     pub fn copy_from(&mut self, buf: &BufData) {
-        const_assert!(mem::size_of::<BufData>() % mem::size_of::<u32>() == 0);
-        const_assert!(mem::align_of::<BufData>() % mem::align_of::<u32>() == 0);
-        // SAFETY: BufData's size/alignment is a multiple of u32's size/alignment.
-        let (_, dst, _) = unsafe { self.align_to_mut::<u32>() };
-        let (_, src, _) = unsafe { buf.align_to::<u32>() };
-        for (d, s) in dst.iter_mut().zip(src) {
-            *d = *s;
-        }
+        memmove(&mut self.inner, &buf.inner);
     }
 }
 

--- a/kernel-rs/src/fs/ufs/inode.rs
+++ b/kernel-rs/src/fs/ufs/inode.rs
@@ -82,7 +82,7 @@ use crate::{
     param::NINODE,
     param::ROOTDEV,
     proc::KernelCtx,
-    util::strong_pin::StrongPin,
+    util::{memset, strong_pin::StrongPin},
 };
 
 /// Directory is a file containing a sequence of Dirent structures.
@@ -454,16 +454,8 @@ impl Itable<Ufs> {
 
             // a free inode
             if dip.typ == DInodeType::None {
-                const_assert!(mem::size_of::<Dinode>() % mem::size_of::<u32>() == 0);
-                const_assert!(mem::align_of::<Dinode>() % mem::align_of::<u32>() == 0);
-                // SAFETY: DInode's size/alignment is a multiple of u32's size/alignment.
-                let buf = unsafe {
-                    core::slice::from_raw_parts_mut(
-                        dip as *mut _ as *mut u32,
-                        mem::size_of::<Dinode>() / mem::size_of::<u32>(),
-                    )
-                };
-                buf.fill(0);
+                // SAFETY: DInode does not have any invariant.
+                unsafe { memset(dip, 0u32) };
                 match typ {
                     InodeType::None => dip.typ = DInodeType::None,
                     InodeType::Dir => dip.typ = DInodeType::Dir,

--- a/kernel-rs/src/fs/ufs/log.rs
+++ b/kernel-rs/src/fs/ufs/log.rs
@@ -86,7 +86,7 @@ impl Log {
             // Copy block to dst.
             dbuf.deref_inner_mut()
                 .data
-                .copy_from_slice(&lbuf.deref_inner().data[..]);
+                .copy_from(&lbuf.deref_inner().data);
 
             // Write dst to disk.
             hal().disk().write(&mut dbuf, ctx);
@@ -162,7 +162,7 @@ impl Log {
 
             to.deref_inner_mut()
                 .data
-                .copy_from_slice(&from.deref_inner().data[..]);
+                .copy_from(&from.deref_inner().data);
 
             // Write the log.
             hal().disk().write(&mut to, ctx);

--- a/kernel-rs/src/fs/ufs/mod.rs
+++ b/kernel-rs/src/fs/ufs/mod.rs
@@ -532,7 +532,9 @@ impl FileSystem for Ufs {
             }
             guard.nlink = dip.nlink;
             guard.size = dip.size;
-            guard.addr_direct.copy_from_slice(&dip.addr_direct);
+            for (d, s) in guard.addr_direct.iter_mut().zip(&dip.addr_direct) {
+                *d = *s;
+            }
             guard.addr_indirect = dip.addr_indirect;
             bp.free(ctx);
             guard.valid = true;

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -7,8 +7,8 @@ use core::{
 
 use static_assertions::const_assert;
 
-use crate::addr::PAddr;
 pub use crate::addr::PGSIZE;
+use crate::{addr::PAddr, util::memset};
 
 // `RawPage` must be aligned with PGSIZE.
 const_assert!(PGSIZE == 4096);
@@ -31,11 +31,8 @@ pub struct Page {
 
 impl RawPage {
     pub fn write_bytes(&mut self, v: u8) {
-        const_assert!(mem::size_of::<RawPage>() % mem::size_of::<u64>() == 0);
-        const_assert!(mem::align_of::<RawPage>() % mem::align_of::<u64>() == 0);
-        // SAFETY: RawPage's size/alignment is a multiple of u64's size/alignment.
-        let (_, buf, _) = unsafe { self.inner.align_to_mut::<u64>() };
-        buf.fill(u64::from_le_bytes([v; 8]));
+        // SAFETY: RawPage does not have any invariant.
+        unsafe { memset(self, u64::from_le_bytes([v; 8])) };
     }
 }
 

--- a/kernel-rs/src/util/mod.rs
+++ b/kernel-rs/src/util/mod.rs
@@ -34,14 +34,35 @@ pub fn memmove(dst: &mut [u8], src: &[u8]) {
         b
     }
 
+    // Try 8B-move.
     if aux::<u64>(dst, src) {
         return;
     }
+    // If 8B-move is not possible, try 4B-move.
     if aux::<u32>(dst, src) {
         return;
     }
+    // If 4B-move is not possible, try 2B-move.
     if aux::<u16>(dst, src) {
         return;
     }
+    // If 2B-move is not possible, do 1B-move.
     dst.copy_from_slice(src);
+}
+
+/// # SAFETY
+///
+/// Filling a value of `T` with a value of `S` must not break the invariant of `T`.
+pub unsafe fn memset<T, S: Copy>(dst: &mut T, v: S) {
+    // Cannot use `const_assert!` here. Compiler optimization will remove `assert!`.
+    assert!(core::mem::size_of::<T>() % core::mem::size_of::<S>() == 0);
+    assert!(core::mem::align_of::<T>() % core::mem::align_of::<S>() == 0);
+    // SAFETY: T's size/alignment is a multiple of S's size/alignment.
+    let buf = unsafe {
+        core::slice::from_raw_parts_mut(
+            dst as *mut _ as *mut S,
+            core::mem::size_of::<T>() / core::mem::size_of::<S>(),
+        )
+    };
+    buf.fill(v);
 }

--- a/kernel-rs/src/util/mod.rs
+++ b/kernel-rs/src/util/mod.rs
@@ -15,3 +15,33 @@ pub fn spin_loop() -> ! {
         ::core::hint::spin_loop();
     }
 }
+
+pub fn memmove(dst: &mut [u8], src: &[u8]) {
+    assert_eq!(dst.len(), src.len());
+
+    fn aux<T: Copy>(dst: &mut [u8], src: &[u8]) -> bool {
+        let a = core::mem::align_of::<T>();
+        let b = dst.as_ptr().align_offset(a) == src.as_ptr().align_offset(a);
+        if b {
+            let (dpre, dshort, dsuf) = unsafe { dst.align_to_mut::<T>() };
+            let (spre, sshort, ssuf) = unsafe { src.align_to::<T>() };
+            dpre.copy_from_slice(spre);
+            for (d, s) in dshort.iter_mut().zip(sshort) {
+                *d = *s;
+            }
+            dsuf.copy_from_slice(ssuf);
+        }
+        b
+    }
+
+    if aux::<u64>(dst, src) {
+        return;
+    }
+    if aux::<u32>(dst, src) {
+        return;
+    }
+    if aux::<u16>(dst, src) {
+        return;
+    }
+    dst.copy_from_slice(src);
+}

--- a/kernel-rs/src/vm.rs
+++ b/kernel-rs/src/vm.rs
@@ -1,6 +1,7 @@
 use core::{cmp, marker::PhantomData, mem, pin::Pin, slice};
 
 use bitflags::bitflags;
+use static_assertions::const_assert;
 use zerocopy::{AsBytes, FromBytes};
 
 use crate::{
@@ -14,6 +15,7 @@ use crate::{
     page::Page,
     param::NPROC,
     proc::KernelCtx,
+    util::memmove,
 };
 
 type PageTableEntry = <TargetArch as PageTableManager>::PageTableEntry;
@@ -304,7 +306,7 @@ impl UserMemory {
         if let Some(src) = src_opt {
             assert!(src.len() < PGSIZE, "new: more than a page");
             let mut page = allocator.alloc(Some(0))?;
-            (&mut page[..src.len()]).copy_from_slice(src);
+            memmove(&mut page[..src.len()], src);
             memory
                 .push_page(
                     page,
@@ -335,10 +337,20 @@ impl UserMemory {
             let pa = pte.get_pa();
             let flags = pte.get_flags();
             let mut page = allocator.alloc(None)?;
+            const_assert!(PGSIZE % mem::size_of::<u64>() == 0);
+            const_assert!(PGSIZE % mem::align_of::<u64>() == 0);
             // SAFETY: pa is an address in page_table,
             // and thus it is the address of a page by the invariant.
-            let src = unsafe { slice::from_raw_parts(pa.into_usize() as *const u8, PGSIZE) };
-            page.copy_from_slice(src);
+            let src = unsafe {
+                slice::from_raw_parts(
+                    pa.into_usize() as *const u64,
+                    PGSIZE / mem::size_of::<u64>(),
+                )
+            };
+            let (_, buf, _) = unsafe { page.align_to_mut::<u64>() };
+            for (d, s) in buf.iter_mut().zip(src.iter()) {
+                *d = *s;
+            }
             new.push_page(page, flags, allocator)
                 .map_err(|page| allocator.free(page))
                 .ok()?;
@@ -457,7 +469,7 @@ impl UserMemory {
             let poffset = dst - va;
             let page = self.get_slice(va.into()).ok_or(())?;
             let n = cmp::min(PGSIZE - poffset, len);
-            page[poffset..poffset + n].copy_from_slice(&src[offset..offset + n]);
+            memmove(&mut page[poffset..poffset + n], &src[offset..offset + n]);
             len -= n;
             offset += n;
             dst += n;
@@ -484,7 +496,7 @@ impl UserMemory {
             let poffset = src - va;
             let page = self.get_slice(va.into()).ok_or(())?;
             let n = cmp::min(PGSIZE - poffset, len);
-            dst[offset..offset + n].copy_from_slice(&page[poffset..poffset + n]);
+            memmove(&mut dst[offset..offset + n], &page[poffset..poffset + n]);
             len -= n;
             offset += n;
             src += n;
@@ -520,11 +532,11 @@ impl UserMemory {
             let from = &page[poffset..poffset + n];
             match from.iter().position(|c| *c == 0) {
                 Some(i) => {
-                    dst[offset..offset + i + 1].copy_from_slice(&from[..i + 1]);
+                    memmove(&mut dst[offset..offset + i + 1], &from[..i + 1]);
                     return Ok(());
                 }
                 None => {
-                    dst[offset..offset + n].copy_from_slice(from);
+                    memmove(&mut dst[offset..offset + n], from);
                     max -= n;
                     offset += n;
                     src += n;


### PR DESCRIPTION
Closes #576

큰 배열을 복사할 때 1B씩 복사하는 대신 8B씩 복사하도록 수정하여 성능 문제를 해결함.