### PR TITLE
Fix ARM build bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ LM = lmbench
 
 ifeq ($(TARGET),arm)
 RUST_TARGET = aarch64-unknown-none
+RUST_BUILD_TARGET = $(RUST_TARGET)
 ARCH = aarch64
 TOOLPREFIX = aarch64-linux-gnu-
 MARCH = armv8-a
@@ -27,6 +28,7 @@ endif
 ADD_QEMUOPTS += -machine gic-version=$(GIC_VERSION)
 else
 RUST_TARGET = riscv64gc-unknown-none-elfhf
+RUST_BUILD_TARGET = kernel-rs/$(RUST_TARGET).json
 ARCH = riscv64
 TARGET = riscv
 MARCH = rv64g
@@ -170,7 +172,7 @@ $U/initcode: $(UT)/initcode.S
 # there is bug in rustc 1.56.0-nightly (30a0a9b69 2021-08-17).
 # aarch64-unknown-none.json file does not work properly.
 $(KR)/target/$(RUST_TARGET)/$(RUST_MODE)/librv6_kernel.a: $(shell find $(KR) -type f)
-	cargo build --manifest-path kernel-rs/Cargo.toml --target kernel-rs/$(RUST_TARGET).json $(CARGOFLAGS)
+	cargo build --manifest-path kernel-rs/Cargo.toml --target $(RUST_BUILD_TARGET) $(CARGOFLAGS)
 
 tags: $(OBJS) _init
 	etags *.S *.c


### PR DESCRIPTION
`TARGET=arm make qemu` 로 실행 시 shell이 제대로 실행되지 않던 버그를 해결했습니다.