### PR TITLE
[Closes #471] Use `where` bound to const check at compilation time

### DIFF
--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -18,6 +18,9 @@ lfs = []
 [profile.dev]
 panic = "abort"
 opt-level = 1
+# TODO: The `const_generics` and `const_evaluatable_checked` feature causes an ICE on low nightly versions
+# when trying incremental compilation. Remove this after upgrading to a higher nightly version.
+incremental = false
 
 [profile.release]
 panic = "abort"

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -48,6 +48,8 @@
 #![feature(const_mut_refs)]
 #![feature(const_precise_live_drops)]
 #![feature(const_trait_impl)]
+#![feature(const_generics)]
+#![feature(const_evaluatable_checked)]
 #![feature(generic_associated_types)]
 #![feature(maybe_uninit_extra)]
 #![feature(raw_ref_op)]

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -76,8 +76,8 @@ impl Page {
 
     pub fn as_uninit_mut<T>(&mut self) -> &mut MaybeUninit<T>
     where
-        [u8; PGSIZE - mem::size_of::<T>()]: , /* We need mem::size_of::<T>() <= PGSIZE */
-        [u8; PGSIZE % mem::align_of::<T>() + usize::MAX]: , /* We need PGSIZE % mem::align_of::<T> == 0 */
+        [(); PGSIZE - mem::size_of::<T>()]: , /* We need mem::size_of::<T>() <= PGSIZE */
+        [(); PGSIZE % mem::align_of::<T>() + usize::MAX]: , /* We need PGSIZE % mem::align_of::<T> == 0 */
     {
         // SAFETY: self.inner is an array of length PGSIZE aligned with PGSIZE bytes.
         // The above assertions show that it can contain a value of T. As it contains arbitrary

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -76,8 +76,8 @@ impl Page {
 
     pub fn as_uninit_mut<T>(&mut self) -> &mut MaybeUninit<T>
     where
-	    [u8; PGSIZE - mem::size_of::<T>()]:,                // We need mem::size_of::<T>() <= PGSIZE
-        [u8; PGSIZE % mem::align_of::<T>() + usize::MAX]:   // We need PGSIZE % mem::align_of::<T> == 0
+        [u8; PGSIZE - mem::size_of::<T>()]: , /* We need mem::size_of::<T>() <= PGSIZE */
+        [u8; PGSIZE % mem::align_of::<T>() + usize::MAX]: , /* We need PGSIZE % mem::align_of::<T> == 0 */
     {
         // SAFETY: self.inner is an array of length PGSIZE aligned with PGSIZE bytes.
         // The above assertions show that it can contain a value of T. As it contains arbitrary

--- a/kernel-rs/src/page.rs
+++ b/kernel-rs/src/page.rs
@@ -74,16 +74,11 @@ impl Page {
         }
     }
 
-    pub fn as_uninit_mut<T>(&mut self) -> &mut MaybeUninit<T> {
-        // TODO(https://github.com/kaist-cp/rv6/issues/471): Use const_assert! (or equivalent)
-        // instead. Currently, use of T inside const_assert! incurs a compile error: "can't use
-        // generic parameters from outer function". Also, there's a workaround using
-        // feature(const_generics) and feature(const_evaluatable_checked). However, using them makes
-        // the compiler panic. When the compiler becomes updated, we will fix the following lines to
-        // use static checks.
-        assert!(mem::size_of::<T>() <= PGSIZE);
-        assert_eq!(PGSIZE % mem::align_of::<T>(), 0);
-
+    pub fn as_uninit_mut<T>(&mut self) -> &mut MaybeUninit<T>
+    where
+	    [u8; PGSIZE - mem::size_of::<T>()]:,                // We need mem::size_of::<T>() <= PGSIZE
+        [u8; PGSIZE % mem::align_of::<T>() + usize::MAX]:   // We need PGSIZE % mem::align_of::<T> == 0
+    {
         // SAFETY: self.inner is an array of length PGSIZE aligned with PGSIZE bytes.
         // The above assertions show that it can contain a value of T. As it contains arbitrary
         // data, we cannot treat it as &mut T. Instead, we use &mut MaybeUninit<T>. It's ok because

--- a/kernel-rs/src/util/mod.rs
+++ b/kernel-rs/src/util/mod.rs
@@ -55,8 +55,8 @@ pub fn memmove(dst: &mut [u8], src: &[u8]) {
 /// Filling a value of `T` with a value of `S` must not break the invariant of `T`.
 pub unsafe fn memset<T, S: Copy>(dst: &mut T, v: S)
 where
-    [u8; core::mem::size_of::<T>() % core::mem::size_of::<S>() + usize::MAX]: , /* We need mem::size_of::<T>() % mem::size_of::<S>() == 0 */
-    [u8; core::mem::align_of::<T>() % core::mem::align_of::<S>() + usize::MAX]: , /* We need mem::align_of::<T>() % mem::align_of::<S>() == 0 */
+    [(); core::mem::size_of::<T>() % core::mem::size_of::<S>() + usize::MAX]: , /* We need mem::size_of::<T>() % mem::size_of::<S>() == 0 */
+    [(); core::mem::align_of::<T>() % core::mem::align_of::<S>() + usize::MAX]: , /* We need mem::align_of::<T>() % mem::align_of::<S>() == 0 */
 {
     // SAFETY: T's size/alignment is a multiple of S's size/alignment.
     let buf = unsafe {

--- a/kernel-rs/src/util/mod.rs
+++ b/kernel-rs/src/util/mod.rs
@@ -53,10 +53,11 @@ pub fn memmove(dst: &mut [u8], src: &[u8]) {
 /// # SAFETY
 ///
 /// Filling a value of `T` with a value of `S` must not break the invariant of `T`.
-pub unsafe fn memset<T, S: Copy>(dst: &mut T, v: S) {
-    // Cannot use `const_assert!` here. Compiler optimization will remove `assert!`.
-    assert!(core::mem::size_of::<T>() % core::mem::size_of::<S>() == 0);
-    assert!(core::mem::align_of::<T>() % core::mem::align_of::<S>() == 0);
+pub unsafe fn memset<T, S: Copy>(dst: &mut T, v: S)
+where
+	[u8; core::mem::size_of::<T>() % core::mem::size_of::<S>() + usize::MAX]:,  // We need mem::size_of::<T>() % mem::size_of::<S>() == 0
+    [u8; core::mem::align_of::<T>() % core::mem::align_of::<S>() + usize::MAX]:,// We need mem::align_of::<T>() % mem::align_of::<S>() == 0
+{
     // SAFETY: T's size/alignment is a multiple of S's size/alignment.
     let buf = unsafe {
         core::slice::from_raw_parts_mut(

--- a/kernel-rs/src/util/mod.rs
+++ b/kernel-rs/src/util/mod.rs
@@ -55,8 +55,8 @@ pub fn memmove(dst: &mut [u8], src: &[u8]) {
 /// Filling a value of `T` with a value of `S` must not break the invariant of `T`.
 pub unsafe fn memset<T, S: Copy>(dst: &mut T, v: S)
 where
-	[u8; core::mem::size_of::<T>() % core::mem::size_of::<S>() + usize::MAX]:,  // We need mem::size_of::<T>() % mem::size_of::<S>() == 0
-    [u8; core::mem::align_of::<T>() % core::mem::align_of::<S>() + usize::MAX]:,// We need mem::align_of::<T>() % mem::align_of::<S>() == 0
+    [u8; core::mem::size_of::<T>() % core::mem::size_of::<S>() + usize::MAX]: , /* We need mem::size_of::<T>() % mem::size_of::<S>() == 0 */
+    [u8; core::mem::align_of::<T>() % core::mem::align_of::<S>() + usize::MAX]: , /* We need mem::align_of::<T>() % mem::align_of::<S>() == 0 */
 {
     // SAFETY: T's size/alignment is a multiple of S's size/alignment.
     let buf = unsafe {


### PR DESCRIPTION
Partially resolves #471 
https://github.com/kaist-cp/rv6/issues/471#issuecomment-1024471179

[PR#489](https://github.com/kaist-cp/rv6/pull/489)와 비슷하게 여전히 error message를 띄우는 건 안되지만, 그래도 이전보다는 훨씬 깔끔한 방법을 사용해봤습니다.

```Rust
pub fn as_uninit_mut<T>(&mut self) -> &mut MaybeUninit<T>
where
	[u8; PGSIZE - mem::size_of::<T>()]:,                // We need mem::size_of::<T>() <= PGSIZE
        [u8; PGSIZE % mem::align_of::<T>() + usize::MAX]:   // We need PGSIZE % mem::align_of::<T> == 0
{
	//...
}
```

[Rust blog](https://blog.rust-lang.org/inside-rust/2021/09/06/Splitting-const-generics.html) 등을 확인해보면, 아직은 위 예처럼 array length부분 등을 이용해 검사를 해보기를 권고하는 것 같습니다.
(추후에 훨찐 직관적인 syntax를 제공하겠다고는 했으나, 아직 안 나온 것 같습니다.)