### PR TITLE
Change MAIR_EL1's mem attribute to speed up kvm

### DIFF
--- a/kernel-rs/src/arch/arm/start.rs
+++ b/kernel-rs/src/arch/arm/start.rs
@@ -78,13 +78,14 @@ pub unsafe fn start() {
     unsafe { w_mdscr_el1(0) };
 
     // set_up_mair
-    // TODO: This setting might be problematic.
+    // TODO: If device memory is needed for some attribute,
+    // use MEM_ATTR_IDX_N on arch/arm/vm.rs for set_entry function
     MAIR_EL1.write(
-        // Attribute 1 - Cacheable normal DRAM.
-        MAIR_EL1::Attr1_Normal_Outer::WriteBack_NonTransient_ReadWriteAlloc +
-            MAIR_EL1::Attr1_Normal_Inner::WriteBack_NonTransient_ReadWriteAlloc +
-            // Attribute 0 - Device.
-            MAIR_EL1::Attr0_Device::nonGathering_nonReordering_EarlyWriteAck,
+        // Attribute 0, 1 - Cacheable normal DRAM.
+        MAIR_EL1::Attr0_Normal_Outer::WriteBack_NonTransient_ReadWriteAlloc
+            + MAIR_EL1::Attr0_Normal_Inner::WriteBack_NonTransient_ReadWriteAlloc
+            + MAIR_EL1::Attr1_Normal_Outer::WriteBack_NonTransient_ReadWriteAlloc
+            + MAIR_EL1::Attr1_Normal_Inner::WriteBack_NonTransient_ReadWriteAlloc,
     );
 
     // set translation control register

--- a/kernel-rs/src/arch/arm/vm.rs
+++ b/kernel-rs/src/arch/arm/vm.rs
@@ -37,7 +37,7 @@ bitflags! {
         /// Privileged execute-never, stage 1 only
         const PXN = 1 << 53;
 
-        // TODO: are these necessary?
+        // Could be used for set_entry function and MAIR_EL1 register
         const MEM_ATTR_IDX_0 = (0 << 2);
         const MEM_ATTR_IDX_1 = (1 << 2);
         const MEM_ATTR_IDX_2 = (2 << 2);


### PR DESCRIPTION
Context is on [commit message](https://github.com/kaist-cp/rv6/commit/eb527afb14f20eef7ccbc78335d6ba322d263852).

Completed to run usertests to check consistency for code.