### PR TITLE
[Closes #596] Fix `List` (Remove unsoundness, interior mutability)

### DIFF
--- a/kernel-rs/src/arena/mru_arena.rs
+++ b/kernel-rs/src/arena/mru_arena.rs
@@ -134,7 +134,8 @@ impl<T: 'static + ArenaObject + Unpin + Send, const CAPACITY: usize> Arena
         let this = guard.get_strong_pinned_mut();
 
         let mut empty: Option<NonNull<StaticArc<T>>> = None;
-        for entry in this.list().iter_shared_mut() {
+        // SAFETY: the whole `MruArena` is protected by a lock.
+        for entry in unsafe { this.list().iter_strong_pin_mut_unchecked() } {
             let mut entry = entry.data();
 
             if let Some(entry) = entry.as_mut().try_borrow() {
@@ -161,7 +162,8 @@ impl<T: 'static + ArenaObject + Unpin + Send, const CAPACITY: usize> Arena
         let mut guard = self.inner().strong_pinned_lock();
         let this = guard.get_strong_pinned_mut();
 
-        for entry in this.list().iter_shared_mut().rev() {
+        // SAFETY: the whole `MruArena` is protected by a lock.
+        for entry in unsafe { this.list().iter_strong_pin_mut_unchecked().rev() } {
             let mut entry = entry.data();
             if let Some(data) = entry.as_mut().get_mut() {
                 *data = f();

--- a/kernel-rs/src/util/intrusive_list.rs
+++ b/kernel-rs/src/util/intrusive_list.rs
@@ -244,7 +244,9 @@ impl<T: ListNode> List<T> {
     }
 
     #[allow(clippy::needless_lifetimes)]
-    pub fn iter_shared_mut<'s>(self: StrongPinMut<'s, Self>) -> IterStrongPinMut<'s, T> {
+    pub unsafe fn iter_strong_pin_mut_unchecked<'s>(
+        self: StrongPinMut<'s, Self>,
+    ) -> IterStrongPinMut<'s, T> {
         let last = unsafe { &(*self.ptr().as_ptr()).head };
         let curr = unsafe { &*Pin::new_unchecked(last).next() };
         IterStrongPinMut {


### PR DESCRIPTION
Closes #596 
* Changed `fn iter_shared_mut` -> `unsafe fn iter_strong_pin_mut_unchecked`
* Removed interior mutability in `ListEntry`

`List`는 `RefCell`이나 tock의 list등과 달리, interior mutability를 꼭 사용해야하는 이유가 없는 것 같아 이를 제거했습니다.