### PR TITLE
[WIP] Change Segment, InodeMap, LFS

### DIFF
--- a/kernel-rs/src/fs/lfs/checkpoint.rs
+++ b/kernel-rs/src/fs/lfs/checkpoint.rs
@@ -1,0 +1,55 @@
+// TODO: Every time a transaction (`Tx`) ends, should update the checkpoint to indicate what is the latest segment,
+// and up to what block it is valid.
+// TODO: What if a single transaction takes more than a single segment?
+
+use crate::param::NINODE;
+
+/// Checkpoint. 
+/// Stored at two fixed positions on disk.
+/// Stores the location of the inode map, segment usage table,
+/// and indicates the latest segment and its last valid block.
+struct Checkpoint {
+    last_segment: u32,
+    last_segment_block: u32,
+}
+
+struct InodeMapEntry {
+    seg_no: u32,
+    seg_block_no: u32,
+}
+
+/// Simple translation of inode_number -> (segment_number, segment_block_number).
+/// 
+/// # Note
+/// 
+/// The in-memory `Inode`s are stored on the `Itable`, not here.
+// TODO: Synchronization?
+pub struct InodeMap {
+    entry: [InodeMapEntry; NINODE],
+}
+
+impl InodeMap {
+    /// Load the InodeMap from the Checkpoint region.
+    pub fn new() -> InodeMap {
+        !todo()
+    }
+
+    /// For the inode with inode number `inum`,
+    /// returns the segment number and segment block number.
+    pub fn get(&self, inum: u32) -> (u32, u32) {
+        assert!(inum < NINODE, "invalid inum");
+        (entry[inum].seg_no, entry[inum].seg_block_no)
+    }
+
+    /// For the inode with inode number `inum`,
+    /// updates the mapping for its segment number and segment block number.
+    /// 
+    /// # Note
+    /// 
+    /// This should be used only by the `Segment`.
+    pub fn set(&mut self, inum: u32, seg_no: u32, seg_block_no: u32) {
+        assert!(inum < NINODE, "invalid inum");
+        entry[inum].seg_no = seg_no;
+        entry[inum].seg_block_nono = seg_block_no;
+    }
+}

--- a/kernel-rs/src/fs/lfs/inode.rs
+++ b/kernel-rs/src/fs/lfs/inode.rs
@@ -178,15 +178,13 @@ impl InodeGuard<'_, Lfs> {
         self.iter_dirents(ctx)
             .find(|(de, _)| de.inum != 0 && de.get_name() == name)
             .map(|(_de, _offf)| {
-                // TODO: replace the return type of fs() with Lfs
-                todo!()
-                // (
-                //     ctx.kernel()
-                //         .fs()
-                //         .imap()
-                //         .get_inode(self.dev, de.inum as u32),
-                //     off,
-                // )
+                (
+                    ctx.kernel()
+                        .fs()
+                        .itable()
+                        .get_inode(self.dev, de.inum as u32),
+                    off,
+                )
             })
             .ok_or(())
     }
@@ -202,6 +200,8 @@ impl InodeGuard<'_, Lfs> {
 
         const_assert!(IPB <= mem::size_of::<BufData>() / mem::size_of::<Dinode>());
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<Dinode>() == 0);
+
+        // TODO: use `Segment::push_back_inode`.
 
         // SAFETY:
         // * dip is aligned properly.

--- a/kernel-rs/src/fs/lfs/segment.rs
+++ b/kernel-rs/src/fs/lfs/segment.rs
@@ -11,16 +11,29 @@ pub enum BlockType {
     Imap,
 }
 
+pub struct SegSumEntry {
+    /// Inode number. If -1, indicates the inode map.
+    inum: u16,
+
+    /// Logical block number of the inode. If -1, indicates the inode itself.
+    logical_block_no: i32
+}
+
 // TODO: implement segment flush algorithms here
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
 #[repr(C)]
+/// Segment type. The unit of disk writes.
+/// Note that we only hold the segment summary in memory.
+/// When we flush the segment, we write the segment summary and its corresponding blocks to the disk altogether.
 pub struct Segment {
-    /// Current offset of the block_buffer
-    pub offset: u32,
+    segment_no: u32,
 
-    /// Buffer that holds updated blocks
-    pub block_buffer: [BlockType; SEGSIZE],
+    /// Segment summary. Indicates info for each entry of the block_buffer.
+    segment_summary: [SegSumEntry; SEGSIZE],
+
+    /// Current offset of the block_buffer
+    offset: u32,
 }
 
 impl Segment {
@@ -38,4 +51,55 @@ impl Segment {
             offset,
         }
     }
+
+    /// Appends the updated `Inode` info at the back of the `Segment` and updates the `InodeMap`.
+    /// Flushes the Segment to the disk if needed.
+    // TODO: Change to push_back_or_update_inode
+    pub fn push_back_inode(&mut self, inode: &Inode, ctx: &KernelCtx<'_, '_>) {
+        // Update Segment
+        self.segment_summary[self.offset].inum = inode.inum;
+        self.segment_summary[self.offset].logical_block_no = -1;
+        // Update Inode Map
+        ctx.imap().set(inode.inum, self.segment_no, self.offset);
+
+        self.offset += 1;
+        if self.offset == SEGSIZE {
+            self.flush();
+        }
+    }
+
+    /// Appends the `Inode`'s updated logical block at the back of the `Segment`.
+    /// 
+    /// # Note
+    /// 
+    /// You may need to call `Segment::push_back_inode` after calling this.
+    pub fn push_back_data_block(&mut self, inode_guard: &mut InodeGuard<'_, LFS>, logical_block_no: u32) {
+        // Update Segment
+        self.segment_summary[self.offset].inum = inode_guard.inum;
+        self.segment_summary[self.offset].logical_block_no = logical_block_no;
+        // TODO: Update Inode's data block tree
+
+        self.offset += 1;
+        if self.offset == SEGSIZE {
+            self.flush();
+        }
+    }
+
+    pub fn push_back_inode_map(&mut self) {
+        // Update Segment
+        self.segment_summary[self.offset].inum = -1;
+        self.segment_summary[self.offset].logical_block_no = -1;
+
+        self.offset += 1;
+        if self.offset == SEGSIZE {
+            self.flush();
+        }
+    }
+
+    fn flush(&mut self) {
+        // TODO: write to disk
+        // TODO: update segment_no
+        self.offset = 0;
+    }
+
 }

--- a/kernel-rs/src/fs/lfs/superblock.rs
+++ b/kernel-rs/src/fs/lfs/superblock.rs
@@ -33,9 +33,11 @@ pub struct Superblock {
     /// Number of free blocks
     pub nfree_blocks: u32,
 
+    // TODO: Okay to move to `Segment::segment_no`?
     /// Current segment
-    pub cur_segment: u32,
+    // pub cur_segment: u32,
 
+    // TODO: Unnecessary if use current time (or something similar)?
     /// Checkpoint region
     pub checkpoint_region: u32,
 }


### PR DESCRIPTION
* Suggestion for the in-memory cache of disk data
  * inode : on `LFS::itable`
  * inode data (direct/indirect...) : on `Buf` (VirtioDisk does this automatically)
  * inode map : on `LFS::imap` or somewhere else...
* Types
  * Superblock: Only hold constants
  * Checkpoint : Stores the last segment and the last segment block of it that is valid.
  * `Tx` : Update `Checkpoint` only after all locks on the `Tx` is released.
-----
Q. Change inode to store seg_no and seg_block_no instead of just block_no?
  * I think this is right.
  * However, it may be unnecessary. (Simple translation : seg_no = block_no / SEGSIZE, seg_block_no = block_no % SEGSIZE)

Q. Synchronization?
  * We may need to add a lock to the `Segment`. (seems we need interior mutability anyway)
  * Inode map : Share lock with `Segment`? (Only use inode map when have the Segment guard)

Q. TODO: delete bmap?
  * What about revoking `InodeGuard::{update, bmap_or_alloc, bmap, bmap_internal}` from ufs and just tweaking them a little bit.

Q. When to actually write the checkpoint to the disk?
  * Maybe every time we actually write the segment to the disk.

Q. Abstraction layer?
  * Directory
  * Inode (+Itable)
  * Segment (+Inode Map)
  * Disk