### PR TITLE
Fix Lfs to pass usertests

### DIFF
--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -160,6 +160,13 @@ impl Buf {
         unsafe { &mut *entry.inner.get_mut_raw() }
     }
 
+    /// Returns a `BufUnlocked` without releasing the lock or consuming `self`.
+    #[allow(dead_code)]
+    pub fn create_unlocked(&self) -> BufUnlocked {
+        unsafe { ManuallyDrop::take(&mut self.inner.clone()) }
+    }
+
+    /// Returns a `BufUnlocked` after releasing the lock and consuming `self`.
     pub fn unlock(mut self, ctx: &KernelCtx<'_, '_>) -> BufUnlocked {
         // SAFETY: this method consumes self and self.inner will not be used again.
         let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
@@ -169,6 +176,7 @@ impl Buf {
         inner
     }
 
+    /// Releases the lock and consumes `self`.
     pub fn free(self, ctx: &KernelCtx<'_, '_>) {
         let _ = self.unlock(ctx);
     }

--- a/kernel-rs/src/fs/lfs/imap.rs
+++ b/kernel-rs/src/fs/lfs/imap.rs
@@ -110,7 +110,7 @@ impl Imap {
         );
         let (block_no, offset) = self.get_imap_block_no(inum);
 
-        if let Some((mut buf, addr)) = segment.get_or_add_imap_block(block_no as u32, ctx) {
+        if let Some((mut buf, addr)) = segment.get_or_add_updated_imap_block(block_no as u32, ctx) {
             if addr != self.addr[block_no] {
                 // Copy the imap block content from old imap block.
                 let old_buf = self.get_imap_block(block_no, ctx);

--- a/kernel-rs/src/fs/lfs/imap.rs
+++ b/kernel-rs/src/fs/lfs/imap.rs
@@ -1,6 +1,10 @@
+use core::mem;
+
+use static_assertions::const_assert;
+
 use super::Segment;
 use crate::{
-    bio::Buf,
+    bio::{Buf, BufData},
     hal::hal,
     param::{BSIZE, IMAPSIZE},
     proc::KernelCtx,
@@ -82,6 +86,8 @@ impl Imap {
         let (block_no, offset) = self.get_imap_block_no(inum);
         let buf = self.get_imap_block(block_no, ctx);
 
+        const_assert!(mem::size_of::<DImapBlock>() <= mem::size_of::<BufData>());
+        const_assert!(mem::align_of::<BufData>() % mem::align_of::<DImapBlock>() == 0);
         let imap_block = unsafe { &*(buf.deref_inner().data.as_ptr() as *const DImapBlock) };
         let res = imap_block.entry[offset];
         buf.free(ctx);
@@ -105,20 +111,21 @@ impl Imap {
         let (block_no, offset) = self.get_imap_block_no(inum);
 
         if let Some((mut buf, addr)) = segment.get_or_add_imap_block(block_no as u32, ctx) {
-            let imap_block =
-                unsafe { &mut *(buf.deref_inner_mut().data.as_mut_ptr() as *mut DImapBlock) };
             if addr != self.addr[block_no] {
                 // Copy the imap block content from old imap block.
-                let mut old_buf = self.get_imap_block(block_no, ctx);
-                let old_imap_block = unsafe {
-                    &mut *(old_buf.deref_inner_mut().data.as_mut_ptr() as *mut DImapBlock)
-                };
-                *imap_block = old_imap_block.clone();
+                let old_buf = self.get_imap_block(block_no, ctx);
+                buf.deref_inner_mut()
+                    .data
+                    .copy_from(&old_buf.deref_inner().data);
                 // Update imap mapping.
                 self.addr[block_no] = addr;
                 old_buf.free(ctx);
             }
             // Update entry.
+            const_assert!(mem::size_of::<DImapBlock>() <= mem::size_of::<BufData>());
+            const_assert!(mem::align_of::<BufData>() % mem::align_of::<DImapBlock>() == 0);
+            let imap_block =
+                unsafe { &mut *(buf.deref_inner_mut().data.as_mut_ptr() as *mut DImapBlock) };
             imap_block.entry[offset] = disk_block_no;
             buf.free(ctx);
             true

--- a/kernel-rs/src/fs/lfs/inode.rs
+++ b/kernel-rs/src/fs/lfs/inode.rs
@@ -363,7 +363,7 @@ impl InodeGuard<'_, Lfs> {
                 .unwrap()
         } else {
             let (mut buf, new_addr) = segment
-                .get_or_add_data_block(self.inum, bn as u32, ctx)
+                .get_or_add_updated_data_block(self.inum, bn as u32, ctx)
                 .unwrap();
             if new_addr != addr {
                 // Copy from old block to new block.
@@ -395,7 +395,9 @@ impl InodeGuard<'_, Lfs> {
             self.deref_inner_mut().addr_indirect = new_indirect;
             bp
         } else {
-            let (mut bp, new_indirect) = segment.get_or_add_indirect_block(self.inum, ctx).unwrap();
+            let (mut bp, new_indirect) = segment
+                .get_or_add_updated_indirect_block(self.inum, ctx)
+                .unwrap();
             if indirect != new_indirect {
                 // Copy from old block to new block.
                 let old_bp = hal().disk().read(self.dev, indirect, ctx);

--- a/kernel-rs/src/fs/lfs/inode.rs
+++ b/kernel-rs/src/fs/lfs/inode.rs
@@ -249,10 +249,10 @@ impl InodeGuard<'_, Lfs> {
         // 2. Write the imap to segment.
         let mut imap = tx.fs.imap(ctx);
         assert!(imap.set(self.inum, disk_block_no, &mut segment, ctx));
-        imap.free(ctx);
         if segment.is_full() {
             segment.commit(ctx);
         }
+        imap.free(ctx);
         segment.free(ctx);
     }
 
@@ -292,7 +292,7 @@ impl InodeGuard<'_, Lfs> {
             let bn = bn - NDIRECT;
             assert!(bn < NINDIRECT, "bmap: out of range");
 
-            // We need two `Buf`. Hence, we flush the segment earily if we need to
+            // We need two `Buf`. Hence, we flush the segment early if we need to
             // and maintain the lock on the `Segment` until we're done.
             let mut segment = tx.fs.segment(ctx);
             if segment.remaining() < 2 {

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -447,13 +447,13 @@ impl FileSystem for Lfs {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let mut bp = guard.writable_data_block(off as usize / BSIZE, tx, &k);
+            let mut segment = tx.fs.segment(&k);
+            let mut bp = guard.writable_data_block(off as usize / BSIZE, &mut segment, tx, &k);
             let m = core::cmp::min(n - tot, BSIZE as u32 - off % BSIZE as u32);
             let begin = (off % BSIZE as u32) as usize;
             let end = begin + m as usize;
             let res = f(tot, &mut bp.deref_inner_mut().data[begin..end], &mut k);
             bp.free(&k);
-            let mut segment = tx.fs.segment(&k);
             if segment.is_full() {
                 segment.commit(&k);
             }

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -77,26 +77,6 @@ impl Tx<'_, Lfs> {
         // self.fs.log().lock().write(b, ctx);
     }
 
-    /// Zero a block.
-    // fn bzero(&self, dev: u32, bno: u32, ctx: &KernelCtx<'_, '_>) {
-    //     let mut buf = ctx.kernel().bcache().get_buf(dev, bno).lock(ctx);
-    //     buf.deref_inner_mut().data.fill(0);
-    //     buf.deref_inner_mut().valid = true;
-    //     self.write(buf, ctx);
-    // }
-
-    /// Blocks.
-    /// Allocate a zeroed disk block to be used by `inum` as the `block_no`th data block.
-    // TODO: Okay to remove dev: u32?
-    fn balloc(&self, inum: u32, block_no: u32, ctx: &KernelCtx<'_, '_>) -> (Buf, u32) {
-        let mut segment = self.fs.segment(ctx);
-        let (mut buf, bno) = segment.get_or_add_data_block(inum, block_no, ctx).unwrap();
-        buf.deref_inner_mut().data.fill(0);
-        buf.deref_inner_mut().valid = true;
-        segment.free(ctx);
-        (buf, bno)
-    }
-
     /// Free a disk block.
     fn bfree(&self, _dev: u32, _b: u32, _ctx: &KernelCtx<'_, '_>) {
         // TODO: We don't need this. The cleaner should handle this.

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -437,7 +437,7 @@ impl FileSystem for Lfs {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let bp = guard.read_data_block(off as usize / BSIZE, &k);
+            let bp = guard.readable_data_block(off as usize / BSIZE, &k);
             let m = core::cmp::min(n - tot, BSIZE as u32 - off % BSIZE as u32);
             let begin = (off % BSIZE as u32) as usize;
             let end = begin + m as usize;
@@ -472,7 +472,7 @@ impl FileSystem for Lfs {
         }
         let mut tot: u32 = 0;
         while tot < n {
-            let mut bp = guard.write_data_block(off as usize / BSIZE, tx, &k);
+            let mut bp = guard.writable_data_block(off as usize / BSIZE, tx, &k);
             let m = core::cmp::min(n - tot, BSIZE as u32 - off % BSIZE as u32);
             let begin = (off % BSIZE as u32) as usize;
             let end = begin + m as usize;

--- a/kernel-rs/src/fs/lfs/segment.rs
+++ b/kernel-rs/src/fs/lfs/segment.rs
@@ -96,14 +96,14 @@ impl SegSumEntry {
     fn get_buf(&self) -> Option<&BufUnlocked> {
         match self {
             SegSumEntry::Empty => None,
-            SegSumEntry::Inode { inum: _, buf } => Some(&buf),
+            SegSumEntry::Inode { inum: _, buf } => Some(buf),
             SegSumEntry::DataBlock {
                 inum: _,
                 block_no: _,
                 buf,
-            } => Some(&buf),
-            SegSumEntry::IndirectMap { inum: _, buf } => Some(&buf),
-            SegSumEntry::Imap { block_no: _, buf } => Some(&buf),
+            } => Some(buf),
+            SegSumEntry::IndirectMap { inum: _, buf } => Some(buf),
+            SegSumEntry::Imap { block_no: _, buf } => Some(buf),
         }
     }
 }
@@ -204,10 +204,9 @@ impl Segment {
             let mut buf = self.read_segment_block(self.offset + 1, ctx);
             buf.deref_inner_mut().data.fill(0);
             buf.deref_inner_mut().valid = true;
-            let buf = buf.unlock(ctx);
-            self.segment_summary[self.offset] = f(buf.clone());
+            self.segment_summary[self.offset] = f(buf.create_unlocked());
             self.offset += 1;
-            Some((buf.lock(ctx), self.get_disk_block_no(self.offset, ctx)))
+            Some((buf, self.get_disk_block_no(self.offset, ctx)))
         }
     }
 


### PR DESCRIPTION
* Added basic synchronization. [2c5ffeb](https://github.com/kaist-cp/rv6/pull/612/commits/2c5ffeb6bff5f1997682ef015aad35a6e56aeef5)
* Fixed bugs in `InodeGuard::bmap_internal`. [1acf937](https://github.com/kaist-cp/rv6/pull/612/commits/1acf9370c716aace27748da2c1d0a26711f4905c)
* Added `SegSumEntry::IndirectMap`. [de1c0d3](https://github.com/kaist-cp/rv6/pull/612/commits/de1c0d3e58ef2c498ea9268d27f010d1a997f0c5)
* and more
-----
Now, only the following usertests seem to **always** fail.
* manywrites
* bigwrite

We need to implement the segment cleaner to fix this.