### PR TITLE
[Closes #597]Mark `ArenaRc::new` as unsafe.

### DIFF
--- a/kernel-rs/src/arena/mod.rs
+++ b/kernel-rs/src/arena/mod.rs
@@ -81,7 +81,12 @@ pub struct ArenaRc<A: Arena> {
 }
 
 impl<T, A: Arena<Data = T>> ArenaRc<A> {
-    pub fn new(arena: StrongPin<'_, A>, inner: Ref<A::Data>) -> Self {
+    /// Creates a new `Rc` that was allocated from the arena.
+    ///
+    /// # Safety
+    ///
+    /// `inner` must be allocated from `arena`
+    pub unsafe fn new(arena: StrongPin<'_, A>, inner: Ref<A::Data>) -> Self {
         Self {
             arena: arena.as_pin().get_ref(),
             inner: ManuallyDrop::new(inner),


### PR DESCRIPTION
Closes #597 
간단한 PR입니다. `ArenaRc::new`를 unsafe fn으로 변경했습니다.
이유는 [comment](https://github.com/kaist-cp/rv6/issues/597#issue-1131526745)에 적어놨습니다.

-----
추가적으로, 사실 `array_arena.rs`/`mru_arena.rs` 모듈에서 `ArenaRc::new`를 사용하지 않고 직접
```Rust
return ArenaRc {
    arena: self.as_pin().get_ref(),
    inner: ManuallyDrop::new(entry),
};
```
와 같은 방법을 사용하면 unsafe를 통하지 않고 `ArenaRc`를 만들 수 있습니다.

다만, 제 생각에는 `array_arena.rs`/`mru_arena.rs`에서는 `ArenaRc`의 내부가 visible하지 않도록 하는 게 자연스러울 것 같으므로, 추후 이런 식으로 변경하는 게 좋을 것 같습니다.