### PR TITLE
[Closes #611] Implement checkpointing in `Lfs`

### DIFF
--- a/kernel-rs/src/fs/lfs/imap.rs
+++ b/kernel-rs/src/fs/lfs/imap.rs
@@ -28,18 +28,7 @@ pub struct Imap {
     addr: [u32; IMAPSIZE],
 }
 
-impl const Default for Imap {
-    fn default() -> Self {
-        Self {
-            dev_no: 0,
-            ninodes: 0,
-            addr: [0; IMAPSIZE],
-        }
-    }
-}
-
 impl Imap {
-    #[allow(dead_code)]
     pub fn new(dev_no: u32, ninodes: usize, addr: [u32; IMAPSIZE]) -> Self {
         Self {
             dev_no,

--- a/kernel-rs/src/fs/lfs/imap.rs
+++ b/kernel-rs/src/fs/lfs/imap.rs
@@ -133,4 +133,10 @@ impl Imap {
             false
         }
     }
+
+    /// Returns an immutable reference to the inner mapping,
+    /// which stores the disk block number of each imap block.
+    pub fn get_mapping(&self) -> &[u32; IMAPSIZE] {
+        &self.addr
+    }
 }

--- a/kernel-rs/src/fs/lfs/imap.rs
+++ b/kernel-rs/src/fs/lfs/imap.rs
@@ -48,6 +48,12 @@ impl Imap {
         hal().disk().read(self.dev_no, self.addr[block_no], ctx)
     }
 
+    /// Returns the imap in the on-disk format.
+    /// This should be written at the checkpoint of the disk.
+    pub fn dimap(&self) -> [u32; IMAPSIZE] {
+        self.addr
+    }
+
     /// Returns an unused inum.
     pub fn get_empty_inum(&self, ctx: &KernelCtx<'_, '_>) -> Option<u32> {
         for i in 0..IMAPSIZE {
@@ -121,11 +127,5 @@ impl Imap {
         } else {
             false
         }
-    }
-
-    /// Returns an immutable reference to the inner mapping,
-    /// which stores the disk block number of each imap block.
-    pub fn get_mapping(&self) -> &[u32; IMAPSIZE] {
-        &self.addr
     }
 }

--- a/kernel-rs/src/fs/lfs/inode.rs
+++ b/kernel-rs/src/fs/lfs/inode.rs
@@ -42,7 +42,6 @@ pub struct InodeInner {
 // It needs repr(C) because it's struct for in-disk representation
 // which should follow C(=machine) representation
 // https://github.com/kaist-cp/rv6/issues/52
-#[allow(dead_code)]
 #[repr(C)]
 pub struct Dinode {
     /// File type

--- a/kernel-rs/src/fs/lfs/inode.rs
+++ b/kernel-rs/src/fs/lfs/inode.rs
@@ -3,7 +3,7 @@ use core::{iter::StepBy, mem, ops::Range};
 use static_assertions::const_assert;
 use zerocopy::{AsBytes, FromBytes};
 
-use super::{FileName, Lfs, Path, Segment, NDIRECT, NINDIRECT, ROOTINO};
+use super::{FileName, Lfs, Path, SegManager, NDIRECT, NINDIRECT, ROOTINO};
 use crate::{
     arena::{Arena, ArrayArena},
     bio::{Buf, BufData},
@@ -194,10 +194,8 @@ impl InodeGuard<'_, Lfs> {
     /// Copy a modified in-memory inode to disk.
     pub fn update(&self, tx: &Tx<'_, Lfs>, ctx: &KernelCtx<'_, '_>) {
         // 1. Write the inode to segment.
-        let mut segment = tx.fs.segment(ctx);
-        let (mut bp, disk_block_no) = segment
-            .get_or_add_updated_inode_block(self.inum, ctx)
-            .unwrap();
+        let mut seg = tx.fs.segmanager(ctx);
+        let (mut bp, disk_block_no) = seg.get_or_add_updated_inode_block(self.inum, ctx).unwrap();
 
         const_assert!(mem::size_of::<Dinode>() <= mem::size_of::<BufData>());
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<Dinode>() == 0);
@@ -241,18 +239,18 @@ impl InodeGuard<'_, Lfs> {
         (*dip).addr_indirect = inner.addr_indirect;
 
         bp.free(ctx);
-        if segment.is_full() {
-            segment.commit(ctx);
+        if seg.is_full() {
+            seg.commit(ctx);
         }
 
         // 2. Write the imap to segment.
         let mut imap = tx.fs.imap(ctx);
-        assert!(imap.set(self.inum, disk_block_no, &mut segment, ctx));
-        if segment.is_full() {
-            segment.commit(ctx);
+        assert!(imap.set(self.inum, disk_block_no, &mut seg, ctx));
+        if seg.is_full() {
+            seg.commit(ctx);
         }
         imap.free(ctx);
-        segment.free(ctx);
+        seg.free(ctx);
     }
 
     /// Copies the inode's `bn`th data block content into an empty block on the segment,
@@ -278,13 +276,13 @@ impl InodeGuard<'_, Lfs> {
     pub fn writable_data_block(
         &mut self,
         bn: usize,
-        segment: &mut SleepLockGuard<'_, Segment>,
+        seg: &mut SleepLockGuard<'_, SegManager>,
         _tx: &Tx<'_, Lfs>,
         ctx: &KernelCtx<'_, '_>,
     ) -> Buf {
         if bn < NDIRECT {
             let addr = self.deref_inner().addr_direct[bn];
-            let (buf, new_addr) = self.writable_data_block_inner(bn, addr, segment, ctx);
+            let (buf, new_addr) = self.writable_data_block_inner(bn, addr, seg, ctx);
             self.deref_inner_mut().addr_direct[bn] = new_addr;
             buf
         } else {
@@ -292,18 +290,17 @@ impl InodeGuard<'_, Lfs> {
             assert!(bn < NINDIRECT, "bmap: out of range");
 
             // We need two `Buf`. Hence, we flush the segment early if we need to
-            // and maintain the lock on the `Segment` until we're done.
-            if segment.remaining() < 2 {
-                segment.commit(ctx);
+            // and maintain the lock on the `SegManager` until we're done.
+            if seg.remaining() < 2 {
+                seg.commit(ctx);
             }
 
             // Get the indirect block and the address of the indirect data block.
-            let mut bp = self.writable_indirect_block(segment, ctx);
+            let mut bp = self.writable_indirect_block(seg, ctx);
             let (prefix, data, _) = unsafe { bp.deref_inner_mut().data.align_to_mut::<u32>() };
             debug_assert_eq!(prefix.len(), 0, "bmap: Buf data unaligned");
             // Get the indirect data block and update the indirect block.
-            let (buf, new_addr) =
-                self.writable_data_block_inner(bn + NDIRECT, data[bn], segment, ctx);
+            let (buf, new_addr) = self.writable_data_block_inner(bn + NDIRECT, data[bn], seg, ctx);
             data[bn] = new_addr;
             bp.free(ctx);
             buf
@@ -352,16 +349,14 @@ impl InodeGuard<'_, Lfs> {
         &self,
         bn: usize,
         addr: u32,
-        segment: &mut SleepLockGuard<'_, Segment>,
+        seg: &mut SleepLockGuard<'_, SegManager>,
         ctx: &KernelCtx<'_, '_>,
     ) -> (Buf, u32) {
         if addr == 0 {
             // Allocate an empty block.
-            segment
-                .add_new_data_block(self.inum, bn as u32, ctx)
-                .unwrap()
+            seg.add_new_data_block(self.inum, bn as u32, ctx).unwrap()
         } else {
-            let (mut buf, new_addr) = segment
+            let (mut buf, new_addr) = seg
                 .get_or_add_updated_data_block(self.inum, bn as u32, ctx)
                 .unwrap();
             if new_addr != addr {
@@ -385,16 +380,16 @@ impl InodeGuard<'_, Lfs> {
     /// You should make sure the segment has an empty block before calling this.
     fn writable_indirect_block(
         &mut self,
-        segment: &mut SleepLockGuard<'_, Segment>,
+        seg: &mut SleepLockGuard<'_, SegManager>,
         ctx: &KernelCtx<'_, '_>,
     ) -> Buf {
         let indirect = self.deref_inner().addr_indirect;
         if indirect == 0 {
-            let (bp, new_indirect) = segment.add_new_indirect_block(self.inum, ctx).unwrap();
+            let (bp, new_indirect) = seg.add_new_indirect_block(self.inum, ctx).unwrap();
             self.deref_inner_mut().addr_indirect = new_indirect;
             bp
         } else {
-            let (mut bp, new_indirect) = segment
+            let (mut bp, new_indirect) = seg
                 .get_or_add_updated_indirect_block(self.inum, ctx)
                 .unwrap();
             if indirect != new_indirect {
@@ -480,12 +475,12 @@ impl Itable<Lfs> {
         tx: &Tx<'_, Lfs>,
         ctx: &KernelCtx<'_, '_>,
     ) -> RcInode<Lfs> {
-        let mut segment = tx.fs.segment(ctx);
+        let mut seg = tx.fs.segmanager(ctx);
         let mut imap = tx.fs.imap(ctx);
 
         // 1. Write the inode.
         let inum = imap.get_empty_inum(ctx).unwrap();
-        let (mut bp, disk_block_no) = segment.add_new_inode_block(inum, ctx).unwrap();
+        let (mut bp, disk_block_no) = seg.add_new_inode_block(inum, ctx).unwrap();
 
         const_assert!(mem::size_of::<Dinode>() <= mem::size_of::<BufData>());
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<Dinode>() == 0);
@@ -511,17 +506,17 @@ impl Itable<Lfs> {
             }
         }
         bp.free(ctx);
-        if segment.is_full() {
-            segment.commit(ctx);
+        if seg.is_full() {
+            seg.commit(ctx);
         }
 
         // 2. Now write the imap.
-        assert!(imap.set(inum, disk_block_no, &mut segment, ctx));
-        if segment.is_full() {
-            segment.commit(ctx);
+        assert!(imap.set(inum, disk_block_no, &mut seg, ctx));
+        if seg.is_full() {
+            seg.commit(ctx);
         }
         imap.free(ctx);
-        segment.free(ctx);
+        seg.free(ctx);
 
         self.get_inode(dev, inum)
     }

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -144,14 +144,15 @@ impl Lfs {
         // (Actually, the cleaner should have already runned earlier.)
     }
 
-    /// Commits the segment without acquring the lock on the `Segment`.
+    /// Commits the segment without acquring the lock on the `Segment`
+    /// and without flushing it.
     ///
     /// # Safety
     ///
     /// Use this only when no one is accessing the `Segment`.
     /// You should usually use `Lfs::segment().commit(ctx)` instead.
     pub unsafe fn commit_segment_unchecked(&self, ctx: &KernelCtx<'_, '_>) {
-        unsafe { &mut *self.segment.get_unchecked().get_mut_raw() }.commit(ctx);
+        unsafe { &mut *self.segment.get_unchecked().get_mut_raw() }.commit_no_alloc(ctx);
     }
 
     /// Commits the checkpoint at the checkpoint region without acquiring any locks or checking the type is initialized.

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -11,7 +11,6 @@ use super::{
 };
 use crate::util::strong_pin::StrongPin;
 use crate::{
-    bio::Buf,
     file::{FileType, InodeFileType},
     hal::hal,
     lock::{SleepLock, SleepLockGuard, SleepableLock},
@@ -70,22 +69,6 @@ pub struct Checkpoint {
     imap: [u32; IMAPSIZE],
     segtable: SegTable,
     timestamp: u32,
-}
-
-impl Tx<'_, Lfs> {
-    /// Caller has modified b->data and is done with the buffer.
-    /// Record the block number and pin in the cache by increasing refcnt.
-    /// commit()/write_log() will do the disk write.
-    ///
-    /// write() replaces write(); a typical use is:
-    ///   bp = kernel.fs().disk.read(...)
-    ///   modify bp->data[]
-    ///   write(bp)
-    #[allow(dead_code)]
-    fn write(&self, _b: Buf, _ctx: &KernelCtx<'_, '_>) {
-        // TODO: We should update the checkpoint here, and actually write to the disk when the segment is flushed.
-        // self.fs.log().lock().write(b, ctx);
-    }
 }
 
 impl Lfs {

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -566,6 +566,9 @@ impl FileSystem for Lfs {
             let mut seg = tx.fs.segmanager(ctx);
             let mut imap = tx.fs.imap(ctx);
             assert!(imap.set(ip.inum, 0, &mut seg, ctx));
+            if seg.is_full() {
+                seg.commit(ctx);
+            }
             imap.free(ctx);
             seg.free(ctx);
             ip.deref_inner_mut().valid = false;

--- a/kernel-rs/src/fs/lfs/segment.rs
+++ b/kernel-rs/src/fs/lfs/segment.rs
@@ -52,7 +52,6 @@ use crate::{
 };
 
 /// Entries for the in-memory segment summary.
-#[allow(dead_code)]
 pub enum SegSumEntry {
     Empty,
     /// Inode.
@@ -143,7 +142,6 @@ pub struct Segment {
 }
 
 impl Segment {
-    #[allow(dead_code)]
     // TODO: Load from a non-empty segment instead?
     pub const fn new(dev_no: u32, segment_no: u32) -> Self {
         Self {

--- a/kernel-rs/src/fs/lfs/tx.rs
+++ b/kernel-rs/src/fs/lfs/tx.rs
@@ -1,0 +1,101 @@
+//! The `TxManager` type manages the starts and wrap ups of FS transactions
+//! to maintain consistency and an enough number of segments.
+//!
+//! * Blocks new FS sys calls when we may not have enough segments. (i.e. Wait for the segment cleaner to finish.)
+//! * After all FS sys calls are done, commits the checkpoint.
+//! * After all FS sys calls are done, runs the segment cleaner if the number of remaining segments
+//!   are lower than threshold.
+
+use super::Lfs;
+use crate::{lock::SleepableLock, proc::KernelCtx};
+
+/// Manages the starts and wrap ups of FS transactions.
+/// * Blocks new FS sys calls when we may not have enough segments. (i.e. Wait for the segment cleaner to finish.)
+/// * After all FS sys calls are done, commits the checkpoint.
+/// * After all FS sys calls are done, runs the segment cleaner if the number of remaining segments
+///   are lower than threshold.
+pub struct TxManager {
+    dev: u32,
+
+    /// How many FS sys calls are executing?
+    outstanding: i32,
+
+    /// In commit(), please wait.
+    committing: bool,
+
+    /// Stores whether the latest checkpoint is stored at the first checkpoint region or the second.
+    stored_at_first: bool,
+
+    /// The timestamp of the latest checkpoint.
+    /// Increments when commiting the checkpoint.
+    timestamp: u32,
+}
+
+impl TxManager {
+    /// Returns a new `TxManager`.
+    /// * `stored_at_first` should be `true` if the latest checkpoint is stored at the first checkpoint region.
+    ///   Otherwise, it should be `false`.
+    /// * `timestamp` should be the timestamp of the latest checkpoint.
+    pub fn new(dev: u32, stored_at_first: bool, timestamp: u32) -> Self {
+        Self {
+            dev,
+            outstanding: 0,
+            committing: false,
+            stored_at_first,
+            timestamp,
+        }
+    }
+}
+
+impl SleepableLock<TxManager> {
+    /// Called at the start of each FS system call.
+    pub fn begin_op(&self, ctx: &KernelCtx<'_, '_>) {
+        let mut guard = self.lock();
+        loop {
+            // TODO: Block if we don't have enough segments left.
+            if guard.committing {
+                guard.sleep(ctx);
+            } else {
+                guard.outstanding += 1;
+                break;
+            }
+        }
+    }
+
+    /// Called at the end of each FS system call.
+    /// Commits the checkpoint if this was the last outstanding operation.
+    pub fn end_op(&self, fs: &Lfs, ctx: &KernelCtx<'_, '_>) {
+        let mut guard = self.lock();
+        guard.outstanding -= 1;
+        assert!(!guard.committing, "guard.committing");
+
+        if guard.outstanding == 0 {
+            // Since outstanding is 0, no ongoing transaction exists.
+            // The lock is still held, so new transactions cannot start.
+            guard.committing = true;
+            // Committing is true, so new transactions cannot start even after releasing the lock.
+
+            // Update info about the latest checkpoint.
+            let dev = guard.dev;
+            guard.stored_at_first = !guard.stored_at_first;
+            let stored_at_first = guard.stored_at_first;
+            guard.timestamp += 1;
+            let timestamp = guard.timestamp;
+
+            // Commit w/o holding locks, since not allowed to sleep with locks.
+            guard.reacquire_after(||
+                // SAFETY: there is no another transaction, so `inner` cannot be read or written.
+                // TODO: This actually shouldn't be done this often.
+                unsafe {
+                    fs.commit_segment_unchecked(ctx);
+                    fs.commit_checkpoint(dev, stored_at_first, timestamp, ctx)
+                });
+
+            guard.committing = false;
+        }
+
+        // begin_op() may be waiting for LOG space, and decrementing log.outstanding has decreased
+        // the amount of reserved space.
+        guard.wakeup(ctx.kernel());
+    }
+}

--- a/kernel-rs/src/fs/mod.rs
+++ b/kernel-rs/src/fs/mod.rs
@@ -52,7 +52,6 @@ pub enum InodeType {
     Device { major: u16, minor: u16 },
 }
 
-#[allow(dead_code)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(i16)]
 pub enum DInodeType {


### PR DESCRIPTION
Closes #611 
* Implemented checkpointing in `Lfs`
* All usertests except `manywrites` and `bigdir` work. (These fail since we run out of segments)
  * usertests that work when we run it individually may not work if we run it in a sequence. (Again, we run out of segments)