### PR TITLE
Fix to boot at newer qemu

### DIFF
--- a/kernel-rs/src/arch/riscv/asm.rs
+++ b/kernel-rs/src/arch/riscv/asm.rs
@@ -64,6 +64,43 @@ pub unsafe fn w_mepc(x: usize) {
 }
 
 bitflags! {
+    /// Physical memory protection CSRs
+    pub struct Pmp: u64 {
+        /// read permission
+        const PMP_R = (1) << 0;
+
+        /// write permission
+        const PMP_W = (1) << 1;
+
+        /// execute permission
+        const PMP_X = (1) << 2;
+
+        /// top of range
+        const PMP_A_TOR = (1) << 3;
+    }
+}
+
+impl Pmp {
+    /// Pmp configuration.
+    /// Writes the given address-matching mode to the first Pmp configuration register.
+    #[inline]
+    pub unsafe fn w_pmpcfg0(self) {
+        unsafe {
+            asm!("csrw pmpcfg0, {x}", x = in(reg) self.bits());
+        }
+    }
+
+    /// Pmp address register.
+    /// This address will be used by the first Pmp.
+    #[inline]
+    pub unsafe fn w_pmpaddr0(x: u64) {
+        unsafe {
+            asm!("csrw pmpaddr0, {x}", x = in(reg) x);
+        }
+    }
+}
+
+bitflags! {
     /// Supervisor Status Register, sstatus.
     pub struct Sstatus: usize {
         /// Previous mode, 1=Supervisor, 0=User


### PR DESCRIPTION
Previously, rv6 (riscv) failed to boot when using a newer qemu version.
This PR fixes this by trivially initializing the physical memory protection CSRs.
* Corresponding commit in xv6-riscv : https://github.com/mit-pdos/xv6-riscv/commit/9655f71758003f93294e82926783024a7e4bcdde
* Also see https://github.com/mit-pdos/xv6-riscv/pull/62
* [RISC-V Spec](https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf) (See Section 3.7.1)