### PR TITLE
Allow a segment to have more than one segment summary block.

### DIFF
--- a/kernel-rs/src/fs/lfs/cleaner.rs
+++ b/kernel-rs/src/fs/lfs/cleaner.rs
@@ -90,7 +90,7 @@ impl Lfs {
 
     /// Scans the entries of the segment summary block located at `seg_block_no` for live blocks.
     /// Returns `None` if the block located at `seg_block_no` is not a segment summary block.
-    /// Otherwise, returns a copy of the segment summary with dead blocks marked as empty, and the number of live blocks.
+    /// Otherwise, returns a copy of the segment summary, where dead blocks marked as empty, and the number of live blocks.
     /// Aborts the scan if the number of live blocks is larger than `thres`.
     fn scan_seg_sum(
         &self,
@@ -133,7 +133,7 @@ impl Lfs {
     }
 
     /// Scans the segment for live blocks.
-    /// Returns a copy of the segment summary with dead blocks marked as empty, and the number of live blocks.
+    /// Returns a segment summary, where everything except live blocks marked as empty, and the number of live blocks.
     /// Aborts the scan if the number of live blocks is larger than `thres`.
     fn scan_segment(
         &self,

--- a/kernel-rs/src/fs/lfs/cleaner.rs
+++ b/kernel-rs/src/fs/lfs/cleaner.rs
@@ -213,7 +213,7 @@ impl Lfs {
                     ip.writable_data_block(entry.block_no as usize, &mut seg, tx, ctx)
                         .free(ctx);
                     if seg.is_full() {
-                        seg.commit(ctx);
+                        seg.commit(true, ctx);
                     }
                     seg.free(ctx);
 
@@ -230,7 +230,7 @@ impl Lfs {
                     let mut seg = self.segmanager(ctx);
                     ip.writable_indirect_block(&mut seg, ctx).free(ctx);
                     if seg.is_full() {
-                        seg.commit(ctx);
+                        seg.commit(true, ctx);
                     }
                     seg.free(ctx);
 
@@ -246,7 +246,7 @@ impl Lfs {
                         .unwrap()
                         .free(ctx);
                     if seg.is_full() {
-                        seg.commit(ctx);
+                        seg.commit(true, ctx);
                     }
                     imap.free(ctx);
                     seg.free(ctx);

--- a/kernel-rs/src/fs/lfs/inode.rs
+++ b/kernel-rs/src/fs/lfs/inode.rs
@@ -240,14 +240,14 @@ impl InodeGuard<'_, Lfs> {
 
         bp.free(ctx);
         if seg.is_full() {
-            seg.commit(ctx);
+            seg.commit(true, ctx);
         }
 
         // 2. Write the imap to segment.
         let mut imap = tx.fs.imap(ctx);
         assert!(imap.set(self.inum, disk_block_no, &mut seg, ctx));
         if seg.is_full() {
-            seg.commit(ctx);
+            seg.commit(true, ctx);
         }
         imap.free(ctx);
         seg.free(ctx);
@@ -331,7 +331,7 @@ impl InodeGuard<'_, Lfs> {
             // We need two `Buf`. Hence, we flush the segment early if we need to
             // and maintain the lock on the `SegManager` until we're done.
             if seg.remaining() < 2 {
-                seg.commit(ctx);
+                seg.commit(true, ctx);
             }
 
             // Get the indirect block and the address of the indirect data block.
@@ -517,13 +517,13 @@ impl Itable<Lfs> {
         }
         bp.free(ctx);
         if seg.is_full() {
-            seg.commit(ctx);
+            seg.commit(true, ctx);
         }
 
         // 2. Now write the imap.
         assert!(imap.set(inum, disk_block_no, &mut seg, ctx));
         if seg.is_full() {
-            seg.commit(ctx);
+            seg.commit(true, ctx);
         }
         imap.free(ctx);
         seg.free(ctx);

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -470,7 +470,7 @@ impl FileSystem for Lfs {
             let res = f(tot, &mut bp.deref_inner_mut().data[begin..end], &mut k);
             bp.free(&k);
             if seg.is_full() {
-                seg.commit(&k);
+                seg.commit(true, &k);
             }
             seg.free(&k);
             if res.is_err() {
@@ -556,7 +556,7 @@ impl FileSystem for Lfs {
             let mut imap = tx.fs.imap(ctx);
             assert!(imap.set(ip.inum, 0, &mut seg, ctx));
             if seg.is_full() {
-                seg.commit(ctx);
+                seg.commit(true, ctx);
             }
             imap.free(ctx);
             seg.free(ctx);

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -97,17 +97,6 @@ impl Lfs {
         self.tx_manager.get().expect("tx_manager")
     }
 
-    /// Commits the segment without acquring the lock on the `SegManager`
-    /// and without flushing it.
-    ///
-    /// # Safety
-    ///
-    /// Use this only when no one is accessing the `SegManager`.
-    /// You should usually use `Lfs::segment().commit(ctx)` instead.
-    pub unsafe fn commit_segment_unchecked(&self, ctx: &KernelCtx<'_, '_>) {
-        unsafe { &mut *self.segmanager.get_unchecked().get_mut_raw() }.commit_no_alloc(ctx);
-    }
-
     /// Commits the checkpoint at the checkpoint region without acquiring any locks or checking the type is initialized.
     /// If `first` is `true`, writes it at the first checkpoint region. Otherwise, writes at the second region.
     ///

--- a/kernel-rs/src/fs/lfs/tx.rs
+++ b/kernel-rs/src/fs/lfs/tx.rs
@@ -110,11 +110,7 @@ impl SleepableLock<TxManager> {
                 }
 
                 let mut seg = fs.segmanager(ctx);
-                if seg.remaining() < 2 {
-                    seg.commit(ctx);
-                } else {
-                    seg.commit_no_alloc(ctx);
-                }
+                seg.commit(false, ctx);
                 seg.free(ctx);
                 // SAFETY: there is no another transaction, so `inner` cannot be read or written.
                 unsafe {

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -345,7 +345,7 @@ impl VirtioDisk {
     /// `VirtioDisk::rw` and may incur additional performance overhead.
     fn write_seq(
         guard: &mut SleepableLockGuard<'_, Self>,
-        barray: &mut ArrayVec<Buf, MAX_SEQ_WRITE>,
+        barray: &mut [Buf],
         ctx: &KernelCtx<'_, '_>,
     ) {
         // 3 * MAX_SEQ_WRITE descriptors are required to write every block of a full segment
@@ -385,11 +385,6 @@ impl VirtioDisk {
         // Finalize the last set of `Buf`s
         if !guard.darray.is_empty() {
             Self::finalize_write_seq(guard, &mut barray[num_block_written - 1], ctx);
-        }
-
-        // Free all the `Buf`s
-        for buf in barray.drain(..barray.len()) {
-            buf.free(ctx);
         }
     }
 

--- a/mklfs/lfs.h
+++ b/mklfs/lfs.h
@@ -47,6 +47,7 @@ struct dimap {
 };
 
 #define FSMAGIC 0x10203040
+#define SEGSUM_MAGIC 0x10305070
 
 #define NDIRECT 12
 #define NINDIRECT (BSIZE / sizeof(uint))

--- a/mklfs/mklfs.c
+++ b/mklfs/mklfs.c
@@ -41,6 +41,8 @@ struct checkpoint {
 // Note: The `struct dsegsum` is defined here, since the segment size
 // may differ depending on disk.
 struct dsegsum {
+  uint magic;
+  uint size;
   struct dsegsumentry entry[SEGSIZE - 1];
 };
 
@@ -223,6 +225,9 @@ balloc(uint block_type, uint inum, uint block_no)
   bn = NMETA + segnum * SEGSIZE;
   rsect(bn, buf);
   dss = (struct dsegsum*)buf;
+  if ((freeblock - NMETA) % SEGSIZE == 1)
+    dss->magic = xint(SEGSUM_MAGIC);
+  dss->size = xint((freeblock - NMETA) % SEGSIZE);
   dss->entry[freeblock - bn - 1].block_type = xint(block_type);
   dss->entry[freeblock - bn - 1].inum = xint(inum);
   dss->entry[freeblock - bn - 1].block_no = xint(block_no);


### PR DESCRIPTION
Sprite-lfs, NetBSD-lfs 와 동일하게 rv6-lfs 도 하나의 `Segment`가 여러개의 segment summary block을 가질 수 있도록 수정하였습니다.
* PR #630 이 merge되면, 이제 parital segment write를 할 때도 disk IO request를 하나만 하면 됩니다. (이전에는 이전의 segment summary block을 update해줘야 했으므로 2번이였음)
* `DSegSum` struct에 `magic`와 `size` field를 추가했습니다.

-----
Sprite-lfs 및 NetBSD-lfs와 동일하게, 어느 disk block이 valid한 summary block인지 아닌지는 magic을 이용하여 판별합니다. 다만, 추가적으로
* Sprite-lfs의 경우, 각각의 segment summary가 다음 segment summary를 가리키는 pointer를 저장하도록 하고
* NetBSD-lfs의 경우, magic뿐만 아니라 check sum도 이용하는 반면,
* rv6-lfs의 경우, magic만을 사용합니다.