### PR TITLE
Fix `TxManager`

### DIFF
--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -97,6 +97,10 @@ impl Lfs {
         self.imap.get().expect("imap").lock(ctx)
     }
 
+    pub fn imap_raw(&self) -> *mut Imap {
+        self.imap.get().expect("imap").get_mut_raw()
+    }
+
     fn tx_manager(&self) -> &SleepableLock<TxManager> {
         self.tx_manager.get().expect("tx_manager")
     }

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -89,6 +89,10 @@ impl Lfs {
         self.segmanager.get().expect("segmanager").lock(ctx)
     }
 
+    pub fn segmanager_raw(&self) -> *mut SegManager {
+        self.segmanager.get().expect("segmanager").get_mut_raw()
+    }
+
     pub fn imap(&self, ctx: &KernelCtx<'_, '_>) -> SleepLockGuard<'_, Imap> {
         self.imap.get().expect("imap").lock(ctx)
     }
@@ -97,18 +101,15 @@ impl Lfs {
         self.tx_manager.get().expect("tx_manager")
     }
 
-    /// Commits the checkpoint at the checkpoint region without acquiring any locks or checking the type is initialized.
+    /// Commits the checkpoint at the checkpoint region.
     /// If `first` is `true`, writes it at the first checkpoint region. Otherwise, writes at the second region.
-    ///
-    /// # Safety
-    ///
-    /// Call this function only when you can ensure the `SegTable` and `Imap` is not under mutation
-    /// and only after `self` is initialzed.
-    pub unsafe fn commit_checkpoint(
+    pub fn commit_checkpoint(
         &self,
-        dev: u32,
         first: bool,
         timestamp: u32,
+        seg: &SegManager,
+        imap: &Imap,
+        dev: u32,
         ctx: &KernelCtx<'_, '_>,
     ) {
         let (bno1, bno2) = self.superblock().get_chkpt_block_no();
@@ -116,8 +117,8 @@ impl Lfs {
 
         let mut buf = hal().disk().read(dev, block_no, ctx);
         let chkpt = unsafe { &mut *(buf.deref_inner_mut().data.as_ptr() as *mut Checkpoint) };
-        chkpt.segtable = unsafe { &*self.segmanager.get_unchecked().get_mut_raw() }.dsegtable();
-        chkpt.imap = unsafe { &*self.imap.get_unchecked().get_mut_raw() }.dimap();
+        chkpt.segtable = seg.dsegtable();
+        chkpt.imap = imap.dimap();
         chkpt.timestamp = timestamp;
         hal().disk().write(&mut buf, ctx);
         buf.free(ctx);

--- a/kernel-rs/src/fs/lfs/tx.rs
+++ b/kernel-rs/src/fs/lfs/tx.rs
@@ -18,6 +18,9 @@ use crate::{
 // making us allocate a new segment summary block in the same segment.
 pub const CLEANING_THRES: usize = NBUF + MIN_REQUIRED_BLOCKS + 1;
 
+/// Checkpointing is done only after at least this amount of blocks were written to the segment.
+const CHECKPOINTING_THRES: usize = 25;
+
 /// Manages the starts and wrap ups of FS transactions.
 /// * Blocks new FS sys calls when we may not have enough segments. (i.e. Wait for the segment cleaner to finish.)
 /// * After all FS sys calls are done, commits the checkpoint.
@@ -39,6 +42,10 @@ pub struct TxManager {
     /// Increments when commiting the checkpoint.
     timestamp: u32,
 
+    /// The `Segmanager`'s `blocks_written` value at the last checkpoint commit.
+    /// Starts from 0 at boot.
+    last_blocks_written: usize,
+
     /// The last segment that the cleaner scanned.
     last_seg_no: u32,
 }
@@ -55,6 +62,7 @@ impl TxManager {
             committing: false,
             stored_at_first,
             timestamp,
+            last_blocks_written: 0,
             last_seg_no: 0,
         }
     }
@@ -107,9 +115,11 @@ impl SleepableLock<TxManager> {
             let dev = guard.dev;
             let stored_at_first = guard.stored_at_first;
             let timestamp = guard.timestamp;
+            let mut last_blocks_written = guard.last_blocks_written;
             let mut last_seg_no = guard.last_seg_no;
 
             guard.reacquire_after(|| {
+                // Run the cleaner if necessary.
                 let seg = fs.segmanager(ctx);
                 let remaining = seg.remaining() as u32;
                 let nfree = seg.nfree();
@@ -118,16 +128,23 @@ impl SleepableLock<TxManager> {
                     last_seg_no = fs.clean(last_seg_no, dev, tx, ctx);
                 }
 
+                // Do checkpointing if necessary.
                 let mut seg = fs.segmanager(ctx);
-                seg.commit(false, ctx);
-                seg.free(ctx);
-                // SAFETY: there is no another transaction, so `inner` cannot be read or written.
-                unsafe {
-                    // TODO: Checkpointing doesn't need to be done this often.
-                    fs.commit_checkpoint(dev, stored_at_first, timestamp, ctx)
+                if seg.blocks_written() < last_blocks_written + CHECKPOINTING_THRES {
+                    seg.free(ctx);
+                } else {
+                    last_blocks_written = seg.blocks_written();
+                    seg.commit(false, ctx);
+                    seg.free(ctx);
+                    // SAFETY: there is no another transaction, so `inner` cannot be read or written.
+                    unsafe {
+                        // TODO: Checkpointing doesn't need to be done this often.
+                        fs.commit_checkpoint(dev, stored_at_first, timestamp, ctx)
+                    }
                 }
             });
 
+            guard.last_blocks_written = last_blocks_written;
             guard.last_seg_no = last_seg_no;
             guard.committing = false;
         }


### PR DESCRIPTION
*  Checkpointing을 덜 자주하도록 수정하였습니다.
   * 이전에는 거의 sys call이 끝날때마다 했던 반면, 이제는 최소 25개의 segment block을 write한 후에만 checkpointing을 합니다.
* `TxManager::end_op`가 `SegManager`의 lock을 잡지 않고 내부를 access하도록 수정했습니다.
  * 어차피 이 동안은 `SegManager`를 access하는 다른 thread가 존재하지 않습니다.

-----
참고로, 이제 여러 최적화를 해서인지 `Lfs`가 `Ufs`보다 성능면에서 좀 더 빠른 것 같습니다. `bigwrite`, `writebig`, `bigfile`와 같은 usertest만 실행했을때, 실행시간이 다음과 같이 나옵니다.
* ufs : Mean=11.037454444294175, Standard Deviation=0.20522410049808243
* lfs : Mean=7.416204286622815, Standard Deviation=0.10157998064059887

다만, 아직 `Lfs`가 완전히 완성된 건 아니긴 합니다.
