### PR TITLE
Fix `Buf` related code

### DIFF
--- a/kernel-rs/src/fs/lfs/cleaner.rs
+++ b/kernel-rs/src/fs/lfs/cleaner.rs
@@ -7,7 +7,7 @@ use arrayvec::ArrayVec;
 use static_assertions::const_assert;
 
 use super::{
-    segment::{BlockType, DSegSum, DSegSumEntry, SEGSUM_MAGIC},
+    segment::{BlockType, DSegSum, DSegSumEntry},
     tx::CLEANING_THRES,
     Lfs, SegManager, Tx,
 };
@@ -130,11 +130,13 @@ impl Lfs {
             superblock.seg_to_disk_block_no(seg_no, seg_block_no),
             ctx,
         );
-        let mut seg_sum = unsafe { &*(buf.deref_inner().data.as_ptr() as *const DSegSum) }.clone();
-        buf.free(ctx);
-        if seg_sum.magic != SEGSUM_MAGIC {
+        let seg_sum = <&DSegSum>::try_from(&buf.deref_inner().data);
+        if seg_sum.is_err() {
+            buf.free(ctx);
             return None;
         }
+        let mut seg_sum = seg_sum.unwrap().clone();
+        buf.free(ctx);
 
         // 2. iterate the segment summary and count the number of live blocks
         // or mark dead blocks as empty

--- a/kernel-rs/src/fs/lfs/cleaner.rs
+++ b/kernel-rs/src/fs/lfs/cleaner.rs
@@ -130,7 +130,7 @@ impl Lfs {
             superblock.seg_to_disk_block_no(seg_no, seg_block_no),
             ctx,
         );
-        let seg_sum = <&DSegSum>::try_from(&buf.deref_inner().data);
+        let seg_sum = <&DSegSum>::try_from(buf.data());
         if seg_sum.is_err() {
             buf.free(ctx);
             return None;

--- a/kernel-rs/src/fs/lfs/imap.rs
+++ b/kernel-rs/src/fs/lfs/imap.rs
@@ -21,6 +21,22 @@ struct DImapBlock {
     entry: [u32; NENTRY],
 }
 
+impl<'s> From<&'s BufData> for &'s DImapBlock {
+    fn from(b: &'s BufData) -> Self {
+        const_assert!(mem::size_of::<DImapBlock>() <= BSIZE);
+        const_assert!(mem::align_of::<BufData>() % mem::align_of::<DImapBlock>() == 0);
+        unsafe { &*(b.as_ptr() as *const DImapBlock) }
+    }
+}
+
+impl<'s> From<&'s mut BufData> for &'s mut DImapBlock {
+    fn from(b: &'s mut BufData) -> Self {
+        const_assert!(mem::size_of::<DImapBlock>() <= BSIZE);
+        const_assert!(mem::align_of::<BufData>() % mem::align_of::<DImapBlock>() == 0);
+        unsafe { &mut *(b.as_mut_ptr() as *mut DImapBlock) }
+    }
+}
+
 /// Stores the address of each imap block.
 pub struct Imap {
     dev_no: u32,
@@ -73,7 +89,7 @@ impl Imap {
     pub fn get_empty_inum(&self, ctx: &KernelCtx<'_, '_>) -> Option<u32> {
         for i in 0..IMAPSIZE {
             let buf = self.get_imap_block(i, ctx);
-            let imap_block = unsafe { &*(buf.deref_inner().data.as_ptr() as *const DImapBlock) };
+            let imap_block: &DImapBlock = (&buf.deref_inner().data).into();
             for j in 0..NENTRY {
                 let inum = i * NENTRY + j;
                 // inum: (0, ninodes)
@@ -98,7 +114,7 @@ impl Imap {
 
         const_assert!(mem::size_of::<DImapBlock>() <= mem::size_of::<BufData>());
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<DImapBlock>() == 0);
-        let imap_block = unsafe { &*(buf.deref_inner().data.as_ptr() as *const DImapBlock) };
+        let imap_block: &DImapBlock = (&buf.deref_inner().data).into();
         let res = imap_block.entry[offset];
         buf.free(ctx);
         res
@@ -148,8 +164,7 @@ impl Imap {
             // Update entry.
             const_assert!(mem::size_of::<DImapBlock>() <= mem::size_of::<BufData>());
             const_assert!(mem::align_of::<BufData>() % mem::align_of::<DImapBlock>() == 0);
-            let imap_block =
-                unsafe { &mut *(buf.deref_inner_mut().data.as_mut_ptr() as *mut DImapBlock) };
+            let imap_block: &mut DImapBlock = (&mut buf.deref_inner_mut().data).into();
             imap_block.entry[offset] = disk_block_no;
             buf.free(ctx);
             true

--- a/kernel-rs/src/fs/lfs/imap.rs
+++ b/kernel-rs/src/fs/lfs/imap.rs
@@ -89,7 +89,7 @@ impl Imap {
     pub fn get_empty_inum(&self, ctx: &KernelCtx<'_, '_>) -> Option<u32> {
         for i in 0..IMAPSIZE {
             let buf = self.get_imap_block(i, ctx);
-            let imap_block: &DImapBlock = (&buf.deref_inner().data).into();
+            let imap_block: &DImapBlock = buf.data().into();
             for j in 0..NENTRY {
                 let inum = i * NENTRY + j;
                 // inum: (0, ninodes)
@@ -114,7 +114,7 @@ impl Imap {
 
         const_assert!(mem::size_of::<DImapBlock>() <= mem::size_of::<BufData>());
         const_assert!(mem::align_of::<BufData>() % mem::align_of::<DImapBlock>() == 0);
-        let imap_block: &DImapBlock = (&buf.deref_inner().data).into();
+        let imap_block: &DImapBlock = buf.data().into();
         let res = imap_block.entry[offset];
         buf.free(ctx);
         res
@@ -134,9 +134,7 @@ impl Imap {
                 if addr != self.addr[block_no] {
                     // Copy the imap block content from old imap block.
                     let old_buf = self.get_imap_block(block_no, ctx);
-                    buf.deref_inner_mut()
-                        .data
-                        .copy_from(&old_buf.deref_inner().data);
+                    buf.data_mut().copy_from(old_buf.data());
                     // Update imap mapping.
                     self.addr[block_no] = addr;
                     old_buf.free(ctx);
@@ -164,7 +162,7 @@ impl Imap {
             // Update entry.
             const_assert!(mem::size_of::<DImapBlock>() <= mem::size_of::<BufData>());
             const_assert!(mem::align_of::<BufData>() % mem::align_of::<DImapBlock>() == 0);
-            let imap_block: &mut DImapBlock = (&mut buf.deref_inner_mut().data).into();
+            let imap_block: &mut DImapBlock = buf.data_mut().into();
             imap_block.entry[offset] = disk_block_no;
             buf.free(ctx);
             true

--- a/kernel-rs/src/fs/lfs/inode.rs
+++ b/kernel-rs/src/fs/lfs/inode.rs
@@ -10,7 +10,7 @@ use crate::{
     fs::{DInodeType, Inode, InodeGuard, InodeType, Itable, RcInode, Tx},
     hal::hal,
     lock::SleepLock,
-    param::{NINODE, ROOTDEV},
+    param::{BSIZE, NINODE, ROOTDEV},
     proc::KernelCtx,
     util::{memset, strong_pin::StrongPin},
 };
@@ -64,6 +64,40 @@ pub struct Dinode {
 
     /// Indirect data block address
     pub addr_indirect: u32,
+}
+
+impl<'s> TryFrom<&'s mut BufData> for &'s mut Dinode {
+    type Error = &'static str;
+
+    fn try_from(b: &'s mut BufData) -> Result<&mut Dinode, &'static str> {
+        const_assert!(mem::size_of::<Dinode>() <= BSIZE);
+        const_assert!(mem::align_of::<BufData>() % mem::align_of::<Dinode>() == 0);
+
+        // Disk content uses intel byte order.
+        let t = i16::from_le_bytes(b[..mem::size_of::<i16>()].try_into().unwrap());
+        if t < mem::variant_count::<DInodeType>() as i16 {
+            // SAFETY: b is aligned properly and t < #(variants of DInodeType).
+            Ok(unsafe { &mut *(b.as_mut_ptr() as *mut Dinode) })
+        } else {
+            Err("wrong inode type")
+        }
+    }
+}
+
+impl<'s> From<&'s BufData> for &'s [u32; NINDIRECT] {
+    fn from(b: &'s BufData) -> Self {
+        const_assert!(mem::size_of::<[u32; NINDIRECT]>() <= BSIZE);
+        const_assert!(mem::align_of::<BufData>() % mem::align_of::<[u32; NINDIRECT]>() == 0);
+        unsafe { &*(b.as_ptr() as *const [u32; NINDIRECT]) }
+    }
+}
+
+impl<'s> From<&'s mut BufData> for &'s mut [u32; NINDIRECT] {
+    fn from(b: &'s mut BufData) -> Self {
+        const_assert!(mem::size_of::<[u32; NINDIRECT]>() <= BSIZE);
+        const_assert!(mem::align_of::<BufData>() % mem::align_of::<[u32; NINDIRECT]>() == 0);
+        unsafe { &mut *(b.as_mut_ptr() as *mut [u32; NINDIRECT]) }
+    }
 }
 
 // TODO: Dirent and following Iter codes are redundant to codes in ufs/inode.rs
@@ -263,14 +297,13 @@ impl InodeGuard<'_, Lfs> {
             } else {
                 None
             }
-        } else if inner.addr_indirect == 0 {
+        } else if inner.addr_indirect == 0 || bn - NDIRECT > NINDIRECT {
             None
         } else {
             // Read the indirect block.
             let bp = hal().disk().read(self.dev, inner.addr_indirect, ctx);
             // Get the address.
-            let (prefix, data, _) = unsafe { bp.deref_inner().data.align_to::<u32>() };
-            debug_assert_eq!(prefix.len(), 0, "bmap: Buf data unaligned");
+            let data: &[u32; NINDIRECT] = (&bp.deref_inner().data).into();
             let addr = data[bn - NDIRECT];
             bp.free(ctx);
             if addr != 0 {
@@ -336,8 +369,7 @@ impl InodeGuard<'_, Lfs> {
 
             // Get the indirect block and the address of the indirect data block.
             let mut bp = self.writable_indirect_block(seg, ctx);
-            let (prefix, data, _) = unsafe { bp.deref_inner_mut().data.align_to_mut::<u32>() };
-            debug_assert_eq!(prefix.len(), 0, "bmap: Buf data unaligned");
+            let data: &mut [u32; NINDIRECT] = (&mut bp.deref_inner_mut().data).into();
             // Get the indirect data block and update the indirect block.
             let (buf, new_addr) = self.writable_data_block_inner(bn + NDIRECT, data[bn], seg, ctx);
             data[bn] = new_addr;
@@ -492,17 +524,7 @@ impl Itable<Lfs> {
         let inum = imap.get_empty_inum(ctx).unwrap();
         let (mut bp, disk_block_no) = seg.add_new_inode_block(inum, ctx).unwrap();
 
-        const_assert!(mem::size_of::<Dinode>() <= mem::size_of::<BufData>());
-        const_assert!(mem::align_of::<BufData>() % mem::align_of::<Dinode>() == 0);
-        // SAFETY: dip is inside bp.data.
-        let dip = bp.deref_inner_mut().data.as_mut_ptr() as *mut Dinode;
-        // SAFETY: i16 does not have internal structure.
-        let t = unsafe { *(dip as *const i16) };
-        // If t >= #(variants of DInodeType), UB will happen when we read dip.typ.
-        assert!(t < core::mem::variant_count::<DInodeType>() as i16);
-        // SAFETY: dip is aligned properly and t < #(variants of DInodeType).
-        let dip = unsafe { &mut *dip };
-
+        let dip: &mut Dinode = (&mut bp.deref_inner_mut().data).try_into().unwrap();
         // SAFETY: DInode does not have any invariant.
         unsafe { memset(dip, 0u32) };
         match typ {

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -518,10 +518,10 @@ impl FileSystem for Lfs {
         if !guard.valid {
             let fs = ctx.kernel().fs();
             let imap = fs.imap(ctx);
-            let mut bp = hal().disk().read(inode.dev, imap.get(inode.inum, ctx), ctx);
+            let bp = hal().disk().read(inode.dev, imap.get(inode.inum, ctx), ctx);
             imap.free(ctx);
 
-            let dip: &mut Dinode = bp.data_mut().try_into().unwrap();
+            let dip: &Dinode = bp.data().try_into().unwrap();
             match dip.typ {
                 DInodeType::None => guard.typ = InodeType::None,
                 DInodeType::Dir => guard.typ = InodeType::Dir,

--- a/kernel-rs/src/fs/lfs/mod.rs
+++ b/kernel-rs/src/fs/lfs/mod.rs
@@ -119,7 +119,10 @@ impl Lfs {
         let (bno1, bno2) = self.superblock().get_chkpt_block_no();
         let block_no = if first { bno1 } else { bno2 };
 
-        let mut buf = hal().disk().read(dev, block_no, ctx);
+        let mut buf = ctx.kernel().bcache().get_buf(dev, block_no).lock(ctx);
+        buf.deref_inner_mut().data.fill(0);
+        buf.deref_inner_mut().valid = true;
+
         let chkpt = unsafe { &mut *(buf.deref_inner_mut().data.as_ptr() as *mut Checkpoint) };
         chkpt.segtable = seg.dsegtable();
         chkpt.imap = imap.dimap();

--- a/kernel-rs/src/fs/lfs/segment.rs
+++ b/kernel-rs/src/fs/lfs/segment.rs
@@ -222,12 +222,17 @@ impl SegManager {
             .seg_to_disk_block_no(self.segment_no, seg_block_no as u32)
     }
 
-    /// Reads the `seg_block_no`th block of this segment.
+    /// Returns a cleared `Buf` for the `seg_block_no`th block of this segment.
     /// `seg_block_no` starts from 0 to `SEGSIZE - 1`.
-    fn read_segment_block(&self, seg_block_no: usize, ctx: &KernelCtx<'_, '_>) -> Buf {
-        hal()
-            .disk()
-            .read(self.dev_no, self.get_disk_block_no(seg_block_no, ctx), ctx)
+    fn get_segment_block(&self, seg_block_no: usize, ctx: &KernelCtx<'_, '_>) -> Buf {
+        let mut buf = ctx
+            .kernel()
+            .bcache()
+            .get_buf(self.dev_no, self.get_disk_block_no(seg_block_no, ctx))
+            .lock(ctx);
+        buf.deref_inner_mut().data.fill(0);
+        buf.deref_inner_mut().valid = true;
+        buf
     }
 
     /// Returns true if the segment has no more remaining blocks.
@@ -319,9 +324,7 @@ impl SegManager {
         } else {
             // Append segment with a new zeroed block.
             let block_no = self.start + 1 + self.segment.len();
-            let mut buf = self.read_segment_block(block_no, ctx);
-            buf.deref_inner_mut().data.fill(0);
-            buf.deref_inner_mut().valid = true;
+            let buf = self.get_segment_block(block_no, ctx);
             self.segment.push((entry, buf.create_unlocked()));
             self.blocks_written += 1;
             Some((buf, self.get_disk_block_no(block_no, ctx)))
@@ -460,7 +463,7 @@ impl SegManager {
         let len = self.segment.len();
         if len > 0 {
             // Write the segment summary.
-            let mut bp = self.read_segment_block(self.start, ctx);
+            let mut bp = self.get_segment_block(self.start, ctx);
             let ssp = unsafe { &mut *(bp.deref_inner_mut().data.as_mut_ptr() as *mut DSegSum) };
             ssp.magic = SEGSUM_MAGIC;
             ssp.size = self.segment.len() as u32;

--- a/kernel-rs/src/fs/lfs/superblock.rs
+++ b/kernel-rs/src/fs/lfs/superblock.rs
@@ -67,7 +67,7 @@ impl<'s> TryFrom<&'s BufData> for &'s Superblock {
 impl Superblock {
     /// Read the super block.
     pub fn new(buf: &Buf) -> Self {
-        let sb: &Superblock = (&buf.deref_inner().data).try_into().unwrap();
+        let sb: &Superblock = buf.data().try_into().unwrap();
         sb.clone()
     }
 

--- a/kernel-rs/src/fs/lfs/superblock.rs
+++ b/kernel-rs/src/fs/lfs/superblock.rs
@@ -1,4 +1,4 @@
-use core::{mem, ptr};
+use core::mem;
 
 use static_assertions::const_assert;
 
@@ -16,6 +16,7 @@ const FSMAGIC: u32 = 0x10203040;
 // mklfs computes the super block and builds an initial file system. The
 // super block describes the disk layout:
 #[repr(C)]
+#[derive(Clone)]
 pub struct Superblock {
     /// Must be FSMAGIC
     magic: u32,
@@ -42,19 +43,32 @@ pub struct Superblock {
     segstart: u32,
 }
 
+impl<'s> TryFrom<&'s BufData> for &'s Superblock {
+    type Error = &'static str;
+
+    fn try_from(b: &'s BufData) -> Result<Self, Self::Error> {
+        const_assert!(mem::size_of::<Superblock>() <= BSIZE);
+        const_assert!(mem::align_of::<BufData>() % mem::align_of::<Superblock>() == 0);
+
+        // Disk content uses intel byte order.
+        let magic = u32::from_le_bytes(b[..mem::size_of::<u32>()].try_into().unwrap());
+        if magic == FSMAGIC {
+            // SAFETY:
+            // * buf.data is larger than Superblock
+            // * buf.data is aligned properly.
+            // * Superblock contains only u32's, so does not have any requirements.
+            Ok(unsafe { &*(b.as_ptr() as *const Superblock) })
+        } else {
+            Err("invalid file system")
+        }
+    }
+}
+
 impl Superblock {
     /// Read the super block.
     pub fn new(buf: &Buf) -> Self {
-        const_assert!(mem::size_of::<Superblock>() <= BSIZE);
-        const_assert!(mem::align_of::<BufData>() % mem::align_of::<Superblock>() == 0);
-        // SAFETY:
-        // * buf.data is larger than Superblock
-        // * buf.data is aligned properly.
-        // * Superblock contains only u32's, so does not have any requirements.
-        // * buf is locked, so we can access it exclusively.
-        let result = unsafe { ptr::read(buf.deref_inner().data.as_ptr() as *const Superblock) };
-        assert_eq!(result.magic, FSMAGIC, "invalid file system");
-        result
+        let sb: &Superblock = (&buf.deref_inner().data).try_into().unwrap();
+        sb.clone()
     }
 
     pub fn ninodes(&self) -> u32 {

--- a/kernel-rs/src/fs/ufs/log.rs
+++ b/kernel-rs/src/fs/ufs/log.rs
@@ -84,9 +84,7 @@ impl Log {
             let mut dbuf = dbuf.lock(ctx);
 
             // Copy block to dst.
-            dbuf.deref_inner_mut()
-                .data
-                .copy_from(&lbuf.deref_inner().data);
+            dbuf.data_mut().copy_from(lbuf.data());
 
             // Write dst to disk.
             hal().disk().write(&mut dbuf, ctx);
@@ -107,7 +105,7 @@ impl Log {
         // * buf.data is aligned properly.
         // * LogHeader contains only u32's, so does not have any requirements.
         // * buf is locked, so we can access it exclusively.
-        let lh = unsafe { &mut *(buf.deref_inner_mut().data.as_mut_ptr() as *mut LogHeader) };
+        let lh = unsafe { &mut *(buf.data_mut().as_mut_ptr() as *mut LogHeader) };
         buf.free(ctx);
 
         for b in &lh.block[0..lh.n as usize] {
@@ -129,7 +127,7 @@ impl Log {
         // * buf.data is aligned properly.
         // * LogHeader contains only u32's, so does not have any requirements.
         // * buf is locked, so we can access it exclusively.
-        let mut lh = unsafe { &mut *(buf.deref_inner_mut().data.as_mut_ptr() as *mut LogHeader) };
+        let mut lh = unsafe { &mut *(buf.data_mut().as_mut_ptr() as *mut LogHeader) };
 
         lh.n = self.bufs.len() as u32;
         for (db, b) in izip!(&mut lh.block, &self.bufs) {
@@ -160,9 +158,7 @@ impl Log {
             // Cache block.
             let from = hal().disk().read(self.dev, from.blockno, ctx);
 
-            to.deref_inner_mut()
-                .data
-                .copy_from(&from.deref_inner().data);
+            to.data_mut().copy_from(from.data());
 
             // Write the log.
             hal().disk().write(&mut to, ctx);

--- a/kernel-rs/src/fs/ufs/superblock.rs
+++ b/kernel-rs/src/fs/ufs/superblock.rs
@@ -60,7 +60,7 @@ impl Superblock {
         // * buf.data is aligned properly.
         // * Superblock contains only u32's, so does not have any requirements.
         // * buf is locked, so we can access it exclusively.
-        let result = unsafe { ptr::read(buf.deref_inner().data.as_ptr() as *const Superblock) };
+        let result = unsafe { ptr::read(buf.data().as_ptr() as *const Superblock) };
         assert_eq!(result.magic, FSMAGIC, "invalid file system");
         result
     }

--- a/kernel-rs/src/lib.rs
+++ b/kernel-rs/src/lib.rs
@@ -11,7 +11,6 @@
 #![deny(explicit_outlives_requirements)]
 #![deny(keyword_idents)]
 #![deny(macro_use_extern_crate)]
-#![deny(missing_debug_implementations)]
 #![deny(non_ascii_idents)]
 #![deny(pointer_structural_match)]
 #![deny(rust_2018_idioms)]

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -206,7 +206,7 @@ impl Drop for Descriptor {
 
 impl SleepableLock<VirtioDisk> {
     /// Return a locked Buf with the `latest` contents of the indicated block.
-    /// If buf.valid is true, we don't need to access Disk.
+    // If buf.valid is true, we don't need to access Disk.
     pub fn read(self: Pin<&Self>, dev: u32, blockno: u32, ctx: &KernelCtx<'_, '_>) -> Buf {
         let mut buf = ctx.kernel().bcache().get_buf(dev, blockno).lock(ctx);
         if !buf.deref_inner().valid {

--- a/kernel-rs/src/virtio/virtio_disk.rs
+++ b/kernel-rs/src/virtio/virtio_disk.rs
@@ -209,9 +209,9 @@ impl SleepableLock<VirtioDisk> {
     // If buf.valid is true, we don't need to access Disk.
     pub fn read(self: Pin<&Self>, dev: u32, blockno: u32, ctx: &KernelCtx<'_, '_>) -> Buf {
         let mut buf = ctx.kernel().bcache().get_buf(dev, blockno).lock(ctx);
-        if !buf.deref_inner().valid {
+        if !buf.is_initialized() {
             VirtioDisk::rw(&mut self.pinned_lock(), &mut buf, false, ctx);
-            buf.deref_inner_mut().valid = true;
+            buf.mark_initialized();
         }
         buf
     }
@@ -311,13 +311,9 @@ impl VirtioDisk {
         };
 
         // Properly set the allocated three descriptors.
-        guard.get_pin_mut().set_three_descriptors(
-            &desc,
-            b,
-            b.deref_inner().data.as_ptr() as _,
-            BSIZE,
-            write,
-        );
+        guard
+            .get_pin_mut()
+            .set_three_descriptors(&desc, b, b.data().as_ptr() as _, BSIZE, write);
 
         // Notify the device for a new request and sleep until its done.
         VirtioDisk::notify_and_sleep(guard, desc, b, ctx);
@@ -351,7 +347,7 @@ impl VirtioDisk {
         // Copy all the data of the `Buf`s to `write_buf`.
         let write_buf = &mut guard.get_pin_mut().project().write_buf[0..BSIZE * barray.len()];
         for (i, b) in barray.iter().enumerate() {
-            write_buf[(BSIZE * i)..(BSIZE * (i + 1))].copy_from_slice(&b.deref_inner().data.inner);
+            write_buf[(BSIZE * i)..(BSIZE * (i + 1))].copy_from_slice(&b.data().inner);
         }
 
         // Properly set the allocated three descriptors.
@@ -394,7 +390,7 @@ impl VirtioDisk {
             let buf = unsafe { &mut *info.inflight[id].b };
 
             // disk is done with buf
-            buf.deref_inner_mut().disk = false;
+            *buf.disk_mut() = false;
             buf.vdisk_request_waitchannel.wakeup(kernel);
 
             *info.used_idx = info.used_idx.wrapping_add(1);
@@ -491,7 +487,7 @@ impl VirtioDisk {
         };
 
         // Record struct Buf for virtio_disk_intr().
-        buf.deref_inner_mut().disk = true;
+        *buf.disk_mut() = true;
         // It does not break the invariant because buf is &mut Buf, which refers
         // to a valid Buf.
         info.inflight[descs[0].idx].b = buf;


### PR DESCRIPTION
* b80c9e4 : 불필요한 disk read를 줄였습니다.
* 954bd03 : `BufData`의 내용을 읽을 때 `From`, `TryFrom` 등의 conversion을 이용하도록 수정하였습니다. (`Lfs`에서만 수정)
  * 이전 : 
  ```Rust
  let imap_block = unsafe { &*(buf.deref_inner().data.as_ptr() as *const DImapBlock) };
  ```
  * 이후 : 
  ```Rust
  let imap_block: &DImapBlock = (&buf.deref_inner().data).into();
  ```
* b1b2cda : `BufInner`의 field들을 모두 private으로 변경한 후 `Buf`의 method들을 이용해 접근하도록 수정하였습니다.