### PR TITLE
Use `#[derive(Deref)]` for simple cases

### DIFF
--- a/kernel-rs/Cargo.lock
+++ b/kernel-rs/Cargo.lock
@@ -50,6 +50,12 @@ version = "0.1.0"
 source = "git+https://github.com/maxbla/const-zero.git#1bb768cca47420bcedafa4ec8eefa29c6f590a6f"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cortex-a"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +79,19 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
 
 [[package]]
 name = "either"
@@ -174,6 +193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rv6-kernel"
 version = "0.1.0"
 dependencies = [
@@ -185,6 +213,7 @@ dependencies = [
  "const-zero",
  "cortex-a",
  "cstr_core",
+ "derive_more",
  "itertools",
  "num-iter",
  "pin-project",
@@ -200,6 +229,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "spin"

--- a/kernel-rs/Cargo.toml
+++ b/kernel-rs/Cargo.toml
@@ -31,6 +31,7 @@ bitmaps = { version = "3.2.0", default-features = false }
 cfg-if = "1.0.0"
 const-zero = { git = "https://github.com/maxbla/const-zero.git" }
 cstr_core = { version = "0.2.6", default-features = false }
+derive_more = "0.99.17"
 itertools = { version = "0.10.3", default-features = false }
 num-iter = { version = "0.1.43", default-features = false }
 pin-project = "1.0.11"

--- a/kernel-rs/src/bio.rs
+++ b/kernel-rs/src/bio.rs
@@ -12,7 +12,9 @@
 //! * Only one process at a time can use a buffer, so do not keep them longer than necessary.
 
 use core::mem::{self, ManuallyDrop};
-use core::ops::{Deref, DerefMut};
+use core::ops::Deref;
+
+use derive_more::{Deref, DerefMut};
 
 use crate::arena::ArenaRc;
 use crate::util::strong_pin::StrongPin;
@@ -74,6 +76,7 @@ pub struct BufInner {
 // an alignment of 4 bytes. Due to the align(4) modifier, BufData has an
 // alignment of 4 bytes.
 #[repr(align(4))]
+#[derive(Deref, DerefMut)]
 pub struct BufData {
     pub inner: [u8; BSIZE],
 }
@@ -82,20 +85,6 @@ impl BufData {
     #[allow(dead_code)]
     pub fn copy_from(&mut self, buf: &BufData) {
         memmove(&mut self.inner, &buf.inner);
-    }
-}
-
-impl Deref for BufData {
-    type Target = [u8; BSIZE];
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl DerefMut for BufData {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
     }
 }
 

--- a/kernel-rs/src/proc/kernel_ctx.rs
+++ b/kernel-rs/src/proc/kernel_ctx.rs
@@ -1,4 +1,4 @@
-use core::ops::Deref;
+use derive_more::Deref;
 
 use super::*;
 use crate::{
@@ -37,6 +37,7 @@ pub struct KernelCtx<'id, 'p> {
 /// # Safety
 ///
 /// `inner` is the current Cpu's proc, whose state should be `RUNNING`.
+#[derive(Deref)]
 pub struct CurrentProc<'id, 'p> {
     inner: ProcRef<'id, 'p>,
 }
@@ -130,14 +131,6 @@ impl<'id, 'p> CurrentProc<'id, 'p> {
         // SAFETY: cwd has been initialized according to the invariants
         // of Proc and CurrentProc.
         unsafe { self.deref_mut_data().cwd.assume_init_mut() }
-    }
-}
-
-impl<'id, 's> Deref for CurrentProc<'id, 's> {
-    type Target = ProcRef<'id, 's>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
     }
 }
 

--- a/kernel-rs/src/proc/mod.rs
+++ b/kernel-rs/src/proc/mod.rs
@@ -7,6 +7,7 @@ use core::{
 };
 
 use array_macro::array;
+use derive_more::Deref;
 
 use crate::{
     arch::interface::{ContextManager, ProcManager, TrapManager},
@@ -122,6 +123,7 @@ pub struct ProcRef<'id, 's>(Branded<'id, &'s Proc>);
 /// # Safety
 ///
 /// * `proc.info` is locked.
+#[derive(Deref)]
 pub struct ProcGuard<'id, 's> {
     proc: ProcRef<'id, 's>,
 }
@@ -317,14 +319,6 @@ impl<'id> ProcGuard<'id, '_> {
         let result = f(**self);
         mem::forget(self.info.lock());
         result
-    }
-}
-
-impl<'id, 's> Deref for ProcGuard<'id, 's> {
-    type Target = ProcRef<'id, 's>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.proc
     }
 }
 


### PR DESCRIPTION
간단한 wrapper types들에 대해서는 `#[derive(Deref)]`를 이용하도록 수정했습니다.


참고 : 다른 wrapper type들의 경우  `#[derive(Deref)]`를 이용해도 compile error는 일어나지 않는 것을 확인했으나, deref Target이 저희가 원하는 것과 조금 달라지게 되어서
(ex: 우리가 원하는 `deref()` 결과 : `&T`, `#[derive(Deref)]`를 이용할 경우의 `deref()` 결과 : `&ManuallyDrop<T>`)
그냥 직접 구현하는 현재 방법을 유지했습니다.